### PR TITLE
ci: let packageManager pin the pnpm version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Version comes from "packageManager" in package.json — don't set it here
+      # too, or action-setup errors out on the mismatch.
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -18,9 +18,8 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Version comes from "packageManager" in package.json.
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,9 +69,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # Version comes from "packageManager" in package.json.
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
## What

Drops `version: 9` from the `pnpm/action-setup@v4` steps in `ci.yml`, `commitlint.yml` and `release.yml`, leaving `packageManager: pnpm@9.12.0` in `package.json` as the single source of truth.

## Why

`pnpm/action-setup@v4` hard-errors when the version is specified in both places:

```
Error: Multiple versions of pnpm specified:
  - version 9 in the GitHub Action config with the key "version"
  - version pnpm@9.12.0 in the package.json with the key "packageManager"
```

Every job that sets up pnpm was failing at that step — `build`, `commitlint`, and the release jobs — on main and on every PR. Found while preparing branch protection: `build` and `commitlint` cannot be required checks while they fail 100% of the time.

## Type of change

- [ ] feat / fix / perf / refactor
- [x] docs / test / build / ci / chore

## Checklist

- [ ] `pnpm build && pnpm test && pnpm lint` pass locally — unchanged by this PR; the real verification is CI on this PR going green
- [ ] Added/updated tests where it made sense — n/a, CI config only
- [ ] Docs updated (README / docs/) if behaviour changed — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)