### PR TITLE
feat(core): add blob-keyed incremental cache

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,13 @@ PORT=4000
 # Directory of repositories to analyse (mounted read-only into the container)
 STRATA_REPOS_DIR=./repos
 
+# --- Incremental cache ------------------------------------------------------
+# Where cache.db lives. Never inside an analysed repo (they're read-only).
+# Default: <cwd>/.strata — in the container, /app/.strata (a persisted volume).
+STRATA_CACHE_DIR=.strata
+# Set to 0/off/false to analyse everything from scratch every time.
+STRATA_CACHE=1
+
 # --- AI provider (optional) -------------------------------------------------
 # Works with any OpenAI-compatible endpoint. Examples:
 #   OpenAI:     AI_BASE_URL=https://api.openai.com/v1

--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,9 @@ PORT=4000
 STRATA_REPOS_DIR=./repos
 
 # --- Incremental cache ------------------------------------------------------
-# Where cache.db lives. Never inside an analysed repo (they're read-only).
+# Where cache.db lives. Relative paths resolve against the *working directory*,
+# so set this explicitly if you run Strata from inside the repo you analyse —
+# otherwise cache.db lands in that repo (the core warns when it does).
 # Default: <cwd>/.strata — in the container, /app/.strata (a persisted volume).
 STRATA_CACHE_DIR=.strata
 # Set to 0/off/false to analyse everything from scratch every time.

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -12,7 +12,7 @@ Legend: `[ ]` todo · `[~]` in progress · `[x]` done
 - [x] Plugin SDK contracts (language / commit-convention / git-metric / ai-provider)
 - [x] Orchestrator + git ingest + plugin registry
 - [x] HTTP API (`/health`, `/plugins`, `/analyze`)
-- [ ] **P0** Incremental cache — SQLite, keyed on `(pluginId, blob)`; skip unchanged files
+- [x] Incremental cache — SQLite, keyed on `(pluginId, blob)`; skip unchanged files
 - [ ] **P0** Third-party plugin discovery — load a user plugins directory, not just built-ins
 - [ ] **P1** Worker queue for heavy analyses (BullMQ / worker_threads); progress events
 - [ ] **P1** Analyse a bare/remote repo (clone-on-demand) and a specific `rev` range

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends git \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /out ./
+
+# The incremental cache is written at runtime as `node` — mount a volume here
+# (see compose.yml) to keep it across restarts.
+ENV STRATA_CACHE_DIR=/app/.strata
+RUN mkdir -p /app/.strata && chown node:node /app/.strata
+
 EXPOSE 4000
 USER node
 CMD ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ place and build. The web UI and richer analyzers are next — see
 - Angular module: component/DI graph, lazy boundaries ⏳
 - PHP module ⏳
 
+**Core**
+- Incremental cache — SQLite, keyed on the git blob sha, so a rerun only
+  re-analyses what changed ✅
+
 **Architecture & AI**
 - Architecture fitness rules ("`ui` may not import `db`") ⏳
 - AI: explain a hotspot, NL query over the repo, auto architecture docs ⏳
@@ -59,7 +63,15 @@ Or hit the API directly:
 curl -X POST localhost:4000/analyze \
   -H 'content-type: application/json' \
   -d '{"root":"/absolute/path/to/a/repo","historyLimit":500}'
+
+# analyses are cached per git blob; force a cold run, or empty the cache
+curl -X POST localhost:4000/analyze -H 'content-type: application/json' \
+  -d '{"root":"/absolute/path/to/a/repo","cache":false}'
+curl -X DELETE localhost:4000/cache
 ```
+
+The cache lives in `$STRATA_CACHE_DIR` (default `.strata/cache.db`, never inside
+the analysed repo); `STRATA_CACHE=0` disables it globally.
 
 ## Run with Docker
 

--- a/README.md
+++ b/README.md
@@ -70,8 +70,9 @@ curl -X POST localhost:4000/analyze -H 'content-type: application/json' \
 curl -X DELETE localhost:4000/cache
 ```
 
-The cache lives in `$STRATA_CACHE_DIR` (default `.strata/cache.db`, never inside
-the analysed repo); `STRATA_CACHE=0` disables it globally.
+The cache lives in `$STRATA_CACHE_DIR` (default `<cwd>/.strata/cache.db`) —
+keep it out of the repo you analyse, which the server and container defaults
+already do; `STRATA_CACHE=0` disables it globally.
 
 ## Run with Docker
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -132,9 +132,11 @@ builds a `RepoContext` and fans work out.
 4. The active `commit-convention` plugin parses each commit.
 5. Results merge into an `AnalysisReport`, returned by the API.
 
-Steps 2 and 3 go through the cache: a plugin whose inputs digest to a stored
-result is skipped, and one that does run only recomputes the blobs that changed.
-The report carries the run's cache counters.
+Steps 2 and 3 go through the cache. The core skips any plugin whose inputs
+digest to a stored result — that part needs no cooperation. Per-file reuse
+inside a plugin that does run is opt-in: only plugins that route their per-file
+work through `ctx.cache.file()` skip unchanged blobs; one that ignores the
+helper recomputes everything. The report carries the run's cache counters.
 
 ### Grant merge trust (governance runtime)
 
@@ -163,19 +165,25 @@ publish. The Linux desktop job is still a stub — it produces no bundle until
 - **Plugin model** — `define*` helpers stamp the `kind` discriminant; the
   registry refuses a plugin whose manifest `sdk` major mismatches.
 - **RepoContext** — the single immutable surface plugins are allowed to touch
-  (`root`, `rev`, `files`, `git()`, `log`).
+  (`root`, `rev`, `files`, `git()`, `log`, `cache`).
 - **Incremental cache** — two levels in one SQLite file (`node:sqlite`, no
-  dependency): per-file results keyed on `(pluginId, blob)` and handed to
-  plugins as `RepoContext.cache`, plus whole-plugin-run results keyed on a
-  digest of every input. A git blob sha is a content hash, so an entry survives
-  across revisions, branches and repositories. Lives outside the analysed repo
-  (`$STRATA_CACHE_DIR`, else `<cwd>/.strata/cache.db`) because repos are mounted
-  read-only; `STRATA_CACHE=0`, `analyze({cache: false})` or `DELETE /cache` turn
-  it off or empty it. An unopenable cache degrades to a pass-through, never an
-  error.
+  dependency): per-file results keyed on `(pluginId, pluginVersion, blob)` and
+  offered to plugins as `RepoContext.cache`, plus whole-plugin-run results keyed
+  on a digest of every input. A git blob sha is a content hash, so an entry
+  survives across revisions, branches and repositories; the plugin version in
+  the key means a new plugin build invalidates its own entries. Stored in
+  `$STRATA_CACHE_DIR`, else `<cwd>/.strata/cache.db` — the server and image put
+  that outside the analysed repo, and the core warns if the resolved path lands
+  inside it. `STRATA_CACHE=0`, `analyze({cache: false})` or `DELETE /cache` turn
+  it off or empty it. A cache that cannot be opened, read or written degrades to
+  a pass-through with one warning — it never fails an analysis.
 - **Configuration** — `.env` (see `.env.example`); AI creds never committed.
 - **Logging** — structured logger injected via `RepoContext.log`.
-- **Security** — analysed repos mounted read-only; AI is opt-in.
+- **Security** — analysed repos mounted read-only; AI is opt-in. The HTTP API
+  is unauthenticated and assumes a trusted network: `/analyze` takes any `root`
+  on disk and `DELETE /cache` discards cached results (cost: a recomputation).
+  Path allow-listing and an auth story are on the backlog; until then, do not
+  expose the port beyond a trusted network.
 
 ## 9. Architecture Decisions
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -71,7 +71,7 @@ the analysed repo.
 |-----------|----------|
 | Extensibility | Four small plugin contracts in `@strata/sdk`; a registry loads them by manifest. |
 | One tool, many languages | Parsing standardised on **tree-sitter** grammars (roadmap); analyzers return a common shape. |
-| Big-repo performance | Blob-sha-keyed incremental cache (SQLite, roadmap) in the core. |
+| Big-repo performance | Blob-sha-keyed incremental cache (SQLite) in the core. |
 | Portability | Web frontend + thin API, packaged as a Docker image now and Tauri desktop later. |
 | Governance | Conventional Commits + release-please automate versioning/releases. |
 
@@ -132,6 +132,10 @@ builds a `RepoContext` and fans work out.
 4. The active `commit-convention` plugin parses each commit.
 5. Results merge into an `AnalysisReport`, returned by the API.
 
+Steps 2 and 3 go through the cache: a plugin whose inputs digest to a stored
+result is skipped, and one that does run only recomputes the blobs that changed.
+The report carries the run's cache counters.
+
 ### Grant merge trust (governance runtime)
 
 `/vouch @user` (issue comment) → `vouch-command` workflow validates the actor is
@@ -160,7 +164,15 @@ publish. The Linux desktop job is still a stub — it produces no bundle until
   registry refuses a plugin whose manifest `sdk` major mismatches.
 - **RepoContext** — the single immutable surface plugins are allowed to touch
   (`root`, `rev`, `files`, `git()`, `log`).
-- **Incremental cache (roadmap)** — analysis keyed on `(pluginId, blob)`.
+- **Incremental cache** — two levels in one SQLite file (`node:sqlite`, no
+  dependency): per-file results keyed on `(pluginId, blob)` and handed to
+  plugins as `RepoContext.cache`, plus whole-plugin-run results keyed on a
+  digest of every input. A git blob sha is a content hash, so an entry survives
+  across revisions, branches and repositories. Lives outside the analysed repo
+  (`$STRATA_CACHE_DIR`, else `<cwd>/.strata/cache.db`) because repos are mounted
+  read-only; `STRATA_CACHE=0`, `analyze({cache: false})` or `DELETE /cache` turn
+  it off or empty it. An unopenable cache degrades to a pass-through, never an
+  error.
 - **Configuration** — `.env` (see `.env.example`); AI creds never committed.
 - **Logging** — structured logger injected via `RepoContext.log`.
 - **Security** — analysed repos mounted read-only; AI is opt-in.
@@ -172,7 +184,7 @@ publish. The Linux desktop job is still a stub — it produces no bundle until
 | ADR-1 | TypeScript core (not Rust) | One language end-to-end; easy plugin authoring. Revisit if profiling demands. |
 | ADR-2 | tree-sitter for parsing | One framework, many grammars, uniform AST. |
 | ADR-3 | Shell out to `git` | Fastest and most complete; avoids reimplementing git. |
-| ADR-4 | SQLite blob-keyed cache | Cheap incremental analysis for large repos. |
+| ADR-4 | SQLite blob-keyed cache (`node:sqlite`) | Cheap incremental analysis for large repos, with no runtime dependency. |
 | ADR-5 | Docker image is the primary deliverable | Matches "self-host over the browser". |
 | ADR-6 | Vouch file over GitHub team | Works on a personal repo; auditable in git history. |
 
@@ -183,7 +195,7 @@ publish. The Linux desktop job is still a stub — it produces no bundle until
 | Quality | Scenario | Target |
 |---------|----------|--------|
 | Extensibility | Add a Python language plugin | No core change; only a new `plugins/*` package. |
-| Performance | Re-analyse a 50k-file repo after a 1-file change | Only that file re-parsed (with cache). |
+| Performance | Re-analyse a 50k-file repo after a 1-file change | Only that file re-parsed; an unchanged repo skips the plugins entirely. |
 | Correctness | Import cycles in TS | All SCCs > 1 node reported. |
 | Portability | Fresh machine with Docker | `docker run` yields a working API. |
 
@@ -192,7 +204,7 @@ publish. The Linux desktop job is still a stub — it produces no bundle until
 | Risk / debt | Impact | Mitigation |
 |-------------|--------|-----------|
 | Regex-based TS import scan (starter) | Misses/false edges | Replace with tree-sitter / TS compiler API. |
-| No cache yet | Slow on large repos | Implement the blob-keyed SQLite cache (ADR-4). |
+| Cache is only as pure as its plugins | A `cache.file()` value that depends on more than the file's contents goes stale | Contract documented in the SDK; plugin version is part of the key, `DELETE /cache` is the escape hatch. |
 | Complexity proxy is indentation-based | Rough hotspot scores | Feed real cyclomatic complexity from language plugins. |
 | Web UI not scaffolded | No visual output yet | Build `apps/web` (see backlog). |
 | Vouch-bot needs push to `main` | May hit branch protection | Bypass entry or PR-mode fallback (documented). |

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -77,8 +77,11 @@ at any OpenAI-compatible endpoint, or a native SDK for other providers.
 ## Incremental analysis
 
 Every `RepoContext` carries a `cache` scoped to your plugin and keyed on
-`(pluginId, blob)` — a git blob sha is a content hash, so an entry stays valid
-until the file itself changes. Wrap the expensive per-file work in it:
+`(pluginId, pluginVersion, blob)` — a git blob sha is a content hash, so an
+entry stays valid until the file itself changes, and bumping your version
+invalidates your own entries. Using it is **opt-in**: a plugin that never calls
+`cache.file()` recomputes every file on every run. Wrap the expensive per-file
+work in it:
 
 ```ts
 const scanned = await ctx.cache.file(file, async (f) => {

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -74,6 +74,35 @@ Copy `plugins/ai-provider-template`. Implement `listModels()` and `chat()`
 (and optionally `embed()`), reading credentials from the environment. Point it
 at any OpenAI-compatible endpoint, or a native SDK for other providers.
 
+## Incremental analysis
+
+Every `RepoContext` carries a `cache` scoped to your plugin and keyed on
+`(pluginId, blob)` — a git blob sha is a content hash, so an entry stays valid
+until the file itself changes. Wrap the expensive per-file work in it:
+
+```ts
+const scanned = await ctx.cache.file(file, async (f) => {
+  const text = await f.read();
+  return { loc: text.split('\n').length, imports: scan(text) };
+});
+```
+
+Rules of the road:
+
+- `compute` must depend on **that file's contents only**. Anything else — other
+  files, git history, the clock, env vars — will be served stale on the next
+  run. Keep whole-set work (resolving an import to a path, cycle detection)
+  outside the cached value.
+- The value is stored as JSON, so it must be JSON-serialisable.
+- Bump your plugin's `version` when its analysis changes: the version is part of
+  the key, so a bump invalidates exactly your entries. (`DELETE /cache` or
+  `STRATA_CACHE=0` are the manual escape hatches during development.)
+- Don't branch on availability — when caching is off, `ctx.cache.file()` is a
+  pass-through that just calls `compute`.
+
+The core also caches whole plugin results, so if nothing in your input changed
+you won't be called at all.
+
 ## Local development
 
 ```bash

--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -26,16 +26,18 @@ to plugins. This is the only module that knows about all four plugin kinds.
 | File | Responsibility |
 |------|----------------|
 | `git.ts` | `resolveRev`, `listFiles` (with blob shas), `history`, `churn`. |
-| `registry.ts` | `PluginRegistry` — load manifests, SDK-major check, `byKind()`. |
+| `registry.ts` | `PluginRegistry` — load manifests, SDK-major check, `byKind()` / `loadedByKind()`. |
+| `cache.ts` | `openAnalysisCache()` — the SQLite incremental cache + key digests. |
 | `index.ts` | `Strata` orchestrator + `AnalyzeOptions` / `AnalysisReport`. |
 
 ## 5. Runtime
 
 `analyze()`:
 1. `resolveRev` → sha; `listFiles` → `RepoFile[]` (blob-keyed).
-2. Build `RepoContext`.
-3. Route files to `language` plugins by extension.
-4. Stream `history`; run `git-metric` plugins.
+2. Build `RepoContext`, one `cache` scope per plugin.
+3. Route files to `language` plugins by extension — skipping any plugin whose
+   input digest already has a stored result.
+4. Stream `history`; run `git-metric` plugins (same skip).
 5. Parse commits with the first `commit-convention` plugin.
 6. Merge into `AnalysisReport`.
 
@@ -43,12 +45,27 @@ to plugins. This is the only module that knows about all four plugin kinds.
 
 - **Extension-based routing** for language plugins (simple, fast).
 - **First-registered commit convention wins** (single active convention).
-- **Blob sha on every file** now, so the planned `(pluginId, blob)` cache is a
-  drop-in — no plugin changes required.
+- **Blob sha on every file**, so the cache keys on content, not on paths or
+  timestamps.
+- **Two cache levels** — a plugin whose entire input digest is unchanged is
+  skipped outright; otherwise it re-reads only the blobs that changed, through
+  `RepoContext.cache`. Graph-shaped results are not per-file, so the per-file
+  level alone would not make a rerun free.
+- **The plugin version is part of every key**, so shipping a new plugin build
+  invalidates exactly that plugin's entries.
+- **`node:sqlite`** over `better-sqlite3` — Node ≥ 24 is already a constraint,
+  and the cache stays dependency- and native-build-free.
+- **The cache never fails an analysis** — an unwritable database degrades to a
+  pass-through with a warning.
 
 ## 7. Quality & Risks
 
 - **Risk:** unbounded history/churn on huge repos. **Mitigation:** `historyLimit`
-  option today; SQLite cache + worker queue on the roadmap.
+  option and the incremental cache; worker queue on the roadmap.
+- **Risk:** a plugin caches a value that depends on more than one file's
+  contents, and serves it stale. **Mitigation:** the purity contract is in the
+  SDK docs; `analyze({cache: false})` and `DELETE /cache` recover.
+- **Risk:** the cache file grows without bound. **Mitigation:** entries carry a
+  last-used stamp and are pruned after 30 days on open.
 - **Risk:** `git` output parsing edge cases (root commit, renames). **Mitigation:**
   record-separator parsing; covered by analysis smoke runs.

--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -55,8 +55,9 @@ to plugins. This is the only module that knows about all four plugin kinds.
   invalidates exactly that plugin's entries.
 - **`node:sqlite`** over `better-sqlite3` — Node ≥ 24 is already a constraint,
   and the cache stays dependency- and native-build-free.
-- **The cache never fails an analysis** — an unwritable database degrades to a
-  pass-through with a warning.
+- **The cache never fails an analysis** — a database that cannot be opened,
+  read or written degrades to a pass-through with one warning per run. A failed
+  write costs a recomputation on the next run, nothing more.
 
 ## 7. Quality & Risks
 

--- a/packages/core/src/cache.test.ts
+++ b/packages/core/src/cache.test.ts
@@ -1,0 +1,167 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { RepoFile } from '@strata/sdk';
+import { digest, filesDigest, nullCache, openAnalysisCache } from './cache.js';
+
+function file(path: string, blob: string, body = ''): RepoFile {
+  return { path, blob, read: async () => body };
+}
+
+describe('analysis cache', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'strata-cache-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('computes once per blob and reuses the value afterwards', async () => {
+    const cache = openAnalysisCache({ dir });
+    const scope = cache.scope('plugin-a', '1.0.0');
+    let calls = 0;
+    const compute = async (f: RepoFile) => {
+      calls++;
+      return { loc: f.path.length };
+    };
+
+    expect(await scope.file(file('a.ts', 'blob1'), compute)).toEqual({ loc: 4 });
+    // Same blob at a different path: still the same content, still one compute.
+    expect(await scope.file(file('copy.ts', 'blob1'), compute)).toEqual({
+      loc: 4,
+    });
+    expect(calls).toBe(1);
+
+    cache.close();
+
+    // A fresh process sees the persisted entry.
+    const reopened = openAnalysisCache({ dir });
+    expect(
+      await reopened.scope('plugin-a', '1.0.0').file(file('a.ts', 'blob1'), compute),
+    ).toEqual({ loc: 4 });
+    expect(calls).toBe(1);
+    expect(reopened.stats()).toMatchObject({ hits: 1, misses: 0 });
+    reopened.close();
+  });
+
+  it('recomputes when the blob, the plugin or its version changes', async () => {
+    const cache = openAnalysisCache({ dir });
+    let calls = 0;
+    const compute = async () => ++calls;
+
+    await cache.scope('plugin-a', '1.0.0').file(file('a.ts', 'blob1'), compute);
+    await cache.scope('plugin-a', '1.0.0').file(file('a.ts', 'blob2'), compute);
+    await cache.scope('plugin-a', '2.0.0').file(file('a.ts', 'blob1'), compute);
+    await cache.scope('plugin-b', '1.0.0').file(file('a.ts', 'blob1'), compute);
+
+    expect(calls).toBe(4);
+    expect(cache.stats()).toMatchObject({ hits: 0, misses: 4, writes: 4 });
+    cache.close();
+  });
+
+  it('stores and returns whole-run results', async () => {
+    const cache = openAnalysisCache({ dir });
+    expect(cache.getRun('plugin-a', '1.0.0', 'key')).toBeUndefined();
+
+    cache.setRun('plugin-a', '1.0.0', 'key', { cycles: [['a', 'b']] });
+    cache.flush();
+    cache.close();
+
+    const reopened = openAnalysisCache({ dir });
+    expect(reopened.getRun('plugin-a', '1.0.0', 'key')).toEqual({
+      cycles: [['a', 'b']],
+    });
+    // A different plugin version must not read the old result.
+    expect(reopened.getRun('plugin-a', '1.1.0', 'key')).toBeUndefined();
+    reopened.close();
+  });
+
+  it('clears everything on demand', async () => {
+    const cache = openAnalysisCache({ dir });
+    let calls = 0;
+    const compute = async () => ++calls;
+
+    await cache.scope('plugin-a', '1.0.0').file(file('a.ts', 'blob1'), compute);
+    cache.setRun('plugin-a', '1.0.0', 'key', 1);
+    cache.flush();
+    cache.clear();
+
+    expect(cache.getRun('plugin-a', '1.0.0', 'key')).toBeUndefined();
+    await cache.scope('plugin-a', '1.0.0').file(file('a.ts', 'blob1'), compute);
+    expect(calls).toBe(2);
+    cache.close();
+  });
+
+  it('prunes entries that have gone cold', async () => {
+    const cache = openAnalysisCache({ dir });
+    let calls = 0;
+    const compute = async () => ++calls;
+    await cache.scope('plugin-a', '1.0.0').file(file('a.ts', 'blob1'), compute);
+    cache.setRun('plugin-a', '1.0.0', 'key', 1);
+    cache.flush();
+
+    cache.prune(0); // everything is now older than the cutoff
+    expect(cache.getRun('plugin-a', '1.0.0', 'key')).toBeUndefined();
+    await cache.scope('plugin-a', '1.0.0').file(file('a.ts', 'blob1'), compute);
+    expect(calls).toBe(2);
+    cache.close();
+  });
+
+  it('honours the explicit and env-var off switches', async () => {
+    const off = openAnalysisCache({ dir, enabled: false });
+    expect(off.path).toBeNull();
+
+    process.env.STRATA_CACHE = 'off';
+    try {
+      const envOff = openAnalysisCache({ dir });
+      expect(envOff.path).toBeNull();
+    } finally {
+      delete process.env.STRATA_CACHE;
+    }
+
+    let calls = 0;
+    const compute = async () => ++calls;
+    await off.scope('plugin-a', '1.0.0').file(file('a.ts', 'blob1'), compute);
+    await off.scope('plugin-a', '1.0.0').file(file('a.ts', 'blob1'), compute);
+    expect(calls).toBe(2); // a disabled cache is a pass-through
+    off.close();
+  });
+
+  it('degrades to a pass-through when the database cannot be opened', () => {
+    const warnings: string[] = [];
+    const log = {
+      debug: () => {},
+      info: () => {},
+      warn: (m: string) => warnings.push(m),
+      error: () => {},
+    };
+    // A path under a *file* can never be created.
+    const cache = openAnalysisCache({
+      path: resolve(import.meta.filename, 'nope/cache.db'),
+      log,
+    });
+
+    expect(cache.path).toBeNull();
+    expect(warnings).toHaveLength(1);
+    expect(nullCache().path).toBeNull();
+  });
+
+  it('digests file sets by content, independent of order', () => {
+    const a = [file('a.ts', 'blob1'), file('b.ts', 'blob2')];
+    const b = [file('b.ts', 'blob2'), file('a.ts', 'blob1')];
+    expect(filesDigest(a)).toBe(filesDigest(b));
+    expect(filesDigest(a)).not.toBe(
+      filesDigest([file('a.ts', 'blob1'), file('b.ts', 'changed')]),
+    );
+    // Paths matter too — the same blob moved is a different graph.
+    expect(filesDigest(a)).not.toBe(
+      filesDigest([file('a.ts', 'blob1'), file('moved.ts', 'blob2')]),
+    );
+    expect(digest(['x', 1, undefined])).toBe(digest(['x', 1, undefined]));
+    expect(digest(['x', 1])).not.toBe(digest(['x', 2]));
+  });
+});

--- a/packages/core/src/cache.test.ts
+++ b/packages/core/src/cache.test.ts
@@ -131,6 +131,32 @@ describe('analysis cache', () => {
     off.close();
   });
 
+  it('keeps working when the database fails mid-run', async () => {
+    const warnings: string[] = [];
+    const log = {
+      debug: () => {},
+      info: () => {},
+      warn: (m: string) => warnings.push(m),
+      error: () => {},
+    };
+    const cache = openAnalysisCache({ dir, log });
+    // Closing the database makes every later statement throw — the same shape
+    // as a full disk or a write lock we never win.
+    cache.close();
+
+    let calls = 0;
+    const value = await cache
+      .scope('plugin-a', '1.0.0')
+      .file(file('a.ts', 'blob1'), async () => ++calls);
+
+    expect(value).toBe(1); // the read failure was a miss, not an error
+    expect(() => cache.flush()).not.toThrow();
+    expect(() => cache.close()).not.toThrow();
+    expect(cache.getRun('plugin-a', '1.0.0', 'key')).toBeUndefined();
+    // One warning for the whole degraded run, not one per statement.
+    expect(warnings).toHaveLength(1);
+  });
+
   it('degrades to a pass-through when the database cannot be opened', () => {
     const warnings: string[] = [];
     const log = {

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -1,0 +1,453 @@
+import { createHash } from 'node:crypto';
+import { mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { DatabaseSync, type StatementSync } from 'node:sqlite';
+import type { Logger, PluginCache, RepoFile } from '@strata/sdk';
+
+/**
+ * The incremental cache (ADR-4).
+ *
+ * Two levels, both in one SQLite file:
+ *
+ *   - **file** — `(pluginId, blob) → JSON`. The unit the whole design is built
+ *     around: a git blob sha *is* the content hash, so an entry stays valid for
+ *     as long as the file does, across revisions, branches and repositories.
+ *     Plugins reach this through `RepoContext.cache`.
+ *   - **run** — `(pluginId, runKey) → JSON`. A whole plugin result, keyed on a
+ *     digest of everything that went into it. When nothing changed at all, the
+ *     plugin is skipped entirely rather than re-assembling a graph from cached
+ *     per-file parts.
+ *
+ * The plugin's version is part of both keys, so publishing a new plugin build
+ * invalidates exactly that plugin's entries; stale rows age out via `prune()`.
+ *
+ * SQLite is via `node:sqlite`, so the cache adds no dependency to the runtime.
+ */
+
+/** Bump when the table layout changes; a mismatch wipes and rebuilds the file. */
+const SCHEMA_VERSION = '1';
+
+const SCHEMA = `
+CREATE TABLE IF NOT EXISTS file_cache (
+  plugin_id TEXT    NOT NULL,
+  version   TEXT    NOT NULL,
+  blob      TEXT    NOT NULL,
+  value     TEXT    NOT NULL,
+  used_at   INTEGER NOT NULL,
+  PRIMARY KEY (plugin_id, version, blob)
+) WITHOUT ROWID;
+CREATE INDEX IF NOT EXISTS file_cache_used_at ON file_cache (used_at);
+
+CREATE TABLE IF NOT EXISTS run_cache (
+  plugin_id TEXT    NOT NULL,
+  version   TEXT    NOT NULL,
+  run_key   TEXT    NOT NULL,
+  value     TEXT    NOT NULL,
+  used_at   INTEGER NOT NULL,
+  PRIMARY KEY (plugin_id, version, run_key)
+) WITHOUT ROWID;
+CREATE INDEX IF NOT EXISTS run_cache_used_at ON run_cache (used_at);
+`;
+
+export interface CacheStats {
+  /** Per-file lookups that were served from the cache. */
+  hits: number;
+  /** Per-file lookups that had to be computed. */
+  misses: number;
+  /** Whole plugin runs served from the cache (plugin never ran). */
+  runHits: number;
+  runMisses: number;
+  /** Entries written back on this run. */
+  writes: number;
+}
+
+export interface CacheOptions {
+  /**
+   * Off switch. Defaults to the `STRATA_CACHE` env var (`0`/`off`/`false`/`no`
+   * disable it), otherwise on.
+   */
+  enabled?: boolean;
+  /** Database file. Overrides `dir`. */
+  path?: string;
+  /**
+   * Directory to hold `cache.db`. Defaults to `$STRATA_CACHE_DIR`, else
+   * `<cwd>/.strata`. Never the analysed repo — those are mounted read-only.
+   */
+  dir?: string;
+  /** Drop entries untouched for this long, on open. 0 disables pruning. */
+  maxAgeDays?: number;
+  /** Where to report a cache that could not be opened. */
+  log?: Logger;
+}
+
+export interface AnalysisCache {
+  /** The database file backing this cache, or `null` when disabled. */
+  readonly path: string | null;
+  /** A `PluginCache` bound to one plugin — what `RepoContext.cache` gets. */
+  scope(pluginId: string, version: string): PluginCache;
+  /** Whole-run result lookup; `undefined` on a miss. */
+  getRun<T>(pluginId: string, version: string, runKey: string): T | undefined;
+  setRun(
+    pluginId: string,
+    version: string,
+    runKey: string,
+    value: unknown,
+  ): void;
+  /** Commit everything buffered since the last flush. */
+  flush(): void;
+  /** Drop entries that have not been used for `maxAgeMs`. */
+  prune(maxAgeMs: number): void;
+  stats(): CacheStats;
+  /** Forget everything (keeps the file). */
+  clear(): void;
+  close(): void;
+}
+
+const DISABLED_VALUES = new Set(['0', 'off', 'false', 'no']);
+
+const consoleLog: Logger = {
+  debug: (m, meta) => console.debug(`[strata:cache] ${m}`, meta ?? ''),
+  info: (m, meta) => console.info(`[strata:cache] ${m}`, meta ?? ''),
+  warn: (m, meta) => console.warn(`[strata:cache] ${m}`, meta ?? ''),
+  error: (m, meta) => console.error(`[strata:cache] ${m}`, meta ?? ''),
+};
+
+/**
+ * Open the cache. Never throws: an unwritable location (read-only container,
+ * missing permissions) degrades to a pass-through cache and a warning, because
+ * a broken cache must not fail an analysis.
+ */
+export function openAnalysisCache(opts: CacheOptions = {}): AnalysisCache {
+  const log = opts.log ?? consoleLog;
+  if (!cacheEnabled(opts.enabled)) return nullCache();
+
+  const file =
+    opts.path ??
+    resolve(opts.dir ?? process.env.STRATA_CACHE_DIR ?? '.strata', 'cache.db');
+  try {
+    return new SqliteAnalysisCache(file, opts.maxAgeDays ?? 30);
+  } catch (err) {
+    log.warn(
+      `disabled — could not open ${file}: ${(err as Error).message}`,
+    );
+    return nullCache();
+  }
+}
+
+function cacheEnabled(explicit?: boolean): boolean {
+  if (explicit !== undefined) return explicit;
+  const env = process.env.STRATA_CACHE?.trim().toLowerCase();
+  return !(env && DISABLED_VALUES.has(env));
+}
+
+/** A cache that caches nothing — used when disabled or unavailable. */
+export function nullCache(): AnalysisCache {
+  const stats: CacheStats = {
+    hits: 0,
+    misses: 0,
+    runHits: 0,
+    runMisses: 0,
+    writes: 0,
+  };
+  return {
+    path: null,
+    scope: () => ({
+      file: (file, compute) => {
+        stats.misses++;
+        return compute(file);
+      },
+    }),
+    getRun: () => {
+      stats.runMisses++;
+      return undefined;
+    },
+    setRun: () => {},
+    flush: () => {},
+    prune: () => {},
+    stats: () => ({ ...stats }),
+    clear: () => {},
+    close: () => {},
+  };
+}
+
+interface PendingWrite {
+  pluginId: string;
+  version: string;
+  key: string;
+  value: string;
+}
+
+class SqliteAnalysisCache implements AnalysisCache {
+  readonly path: string;
+
+  private readonly db: DatabaseSync;
+  private readonly selectFile: StatementSync;
+  private readonly insertFile: StatementSync;
+  private readonly touchFile: StatementSync;
+  private readonly selectRun: StatementSync;
+  private readonly insertRun: StatementSync;
+  private readonly touchRun: StatementSync;
+
+  /** Writes and hits are buffered, then committed in one transaction. */
+  private readonly pendingFiles = new Map<string, PendingWrite>();
+  private readonly pendingRuns = new Map<string, PendingWrite>();
+  private readonly touched = { files: new Set<string>(), runs: new Set<string>() };
+
+  private readonly counters: CacheStats = {
+    hits: 0,
+    misses: 0,
+    runHits: 0,
+    runMisses: 0,
+    writes: 0,
+  };
+
+  constructor(path: string, maxAgeDays: number) {
+    this.path = resolve(path);
+    mkdirSync(dirname(this.path), { recursive: true });
+    this.db = new DatabaseSync(this.path);
+
+    this.db.exec('PRAGMA journal_mode = WAL');
+    this.db.exec('PRAGMA synchronous = NORMAL');
+    // Several analyses (or several server workers) may share the file.
+    this.db.exec('PRAGMA busy_timeout = 5000');
+    this.migrate();
+
+    this.selectFile = this.db.prepare(
+      'SELECT value FROM file_cache WHERE plugin_id = ? AND version = ? AND blob = ?',
+    );
+    this.insertFile = this.db.prepare(
+      `INSERT INTO file_cache (plugin_id, version, blob, value, used_at)
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT (plugin_id, version, blob)
+       DO UPDATE SET value = excluded.value, used_at = excluded.used_at`,
+    );
+    this.touchFile = this.db.prepare(
+      'UPDATE file_cache SET used_at = ? WHERE plugin_id = ? AND version = ? AND blob = ?',
+    );
+    this.selectRun = this.db.prepare(
+      'SELECT value FROM run_cache WHERE plugin_id = ? AND version = ? AND run_key = ?',
+    );
+    this.insertRun = this.db.prepare(
+      `INSERT INTO run_cache (plugin_id, version, run_key, value, used_at)
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT (plugin_id, version, run_key)
+       DO UPDATE SET value = excluded.value, used_at = excluded.used_at`,
+    );
+    this.touchRun = this.db.prepare(
+      'UPDATE run_cache SET used_at = ? WHERE plugin_id = ? AND version = ? AND run_key = ?',
+    );
+
+    if (maxAgeDays > 0) this.prune(maxAgeDays * 86_400_000);
+  }
+
+  /** Create the tables, wiping first if the file predates this schema. */
+  private migrate(): void {
+    this.db.exec(
+      'CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)',
+    );
+    const row = this.db
+      .prepare("SELECT value FROM meta WHERE key = 'schema_version'")
+      .get() as { value?: string } | undefined;
+
+    if (row?.value !== undefined && row.value !== SCHEMA_VERSION) {
+      this.db.exec('DROP TABLE IF EXISTS file_cache');
+      this.db.exec('DROP TABLE IF EXISTS run_cache');
+    }
+    this.db.exec(SCHEMA);
+    this.db
+      .prepare(
+        `INSERT INTO meta (key, value) VALUES ('schema_version', ?)
+         ON CONFLICT (key) DO UPDATE SET value = excluded.value`,
+      )
+      .run(SCHEMA_VERSION);
+  }
+
+  scope(pluginId: string, version: string): PluginCache {
+    return {
+      file: async <T>(
+        file: RepoFile,
+        compute: (file: RepoFile) => Promise<T>,
+      ): Promise<T> => {
+        const key = entryKey(pluginId, version, file.blob);
+        const cached = this.readFile(pluginId, version, file.blob, key);
+        if (cached !== undefined) {
+          this.counters.hits++;
+          return cached as T;
+        }
+        this.counters.misses++;
+        const value = await compute(file);
+        this.pendingFiles.set(key, {
+          pluginId,
+          version,
+          key: file.blob,
+          value: JSON.stringify(value) ?? 'null',
+        });
+        this.counters.writes++;
+        return value;
+      },
+    };
+  }
+
+  private readFile(
+    pluginId: string,
+    version: string,
+    blob: string,
+    key: string,
+  ): unknown {
+    // Written earlier in this same run (two paths can share one blob).
+    const pending = this.pendingFiles.get(key);
+    if (pending) return parse(pending.value);
+
+    const row = this.selectFile.get(pluginId, version, blob) as
+      | { value: string }
+      | undefined;
+    if (row === undefined) return undefined;
+    this.touched.files.add(key);
+    return parse(row.value);
+  }
+
+  getRun<T>(pluginId: string, version: string, runKey: string): T | undefined {
+    const key = entryKey(pluginId, version, runKey);
+    const pending = this.pendingRuns.get(key);
+    const value =
+      pending !== undefined
+        ? parse(pending.value)
+        : parse(
+            (
+              this.selectRun.get(pluginId, version, runKey) as
+                | { value: string }
+                | undefined
+            )?.value,
+          );
+
+    if (value === undefined) {
+      this.counters.runMisses++;
+      return undefined;
+    }
+    this.counters.runHits++;
+    if (pending === undefined) this.touched.runs.add(key);
+    return value as T;
+  }
+
+  setRun(
+    pluginId: string,
+    version: string,
+    runKey: string,
+    value: unknown,
+  ): void {
+    this.pendingRuns.set(entryKey(pluginId, version, runKey), {
+      pluginId,
+      version,
+      key: runKey,
+      value: JSON.stringify(value) ?? 'null',
+    });
+    this.counters.writes++;
+  }
+
+  flush(): void {
+    const pending =
+      this.pendingFiles.size +
+      this.pendingRuns.size +
+      this.touched.files.size +
+      this.touched.runs.size;
+    if (pending === 0) return;
+
+    const now = Date.now();
+    this.db.exec('BEGIN IMMEDIATE');
+    try {
+      for (const w of this.pendingFiles.values()) {
+        this.insertFile.run(w.pluginId, w.version, w.key, w.value, now);
+      }
+      for (const w of this.pendingRuns.values()) {
+        this.insertRun.run(w.pluginId, w.version, w.key, w.value, now);
+      }
+      // Keep entries this run used alive, so `prune` only drops cold ones.
+      for (const key of this.touched.files) {
+        const [pluginId, version, blob] = splitKey(key);
+        this.touchFile.run(now, pluginId, version, blob);
+      }
+      for (const key of this.touched.runs) {
+        const [pluginId, version, runKey] = splitKey(key);
+        this.touchRun.run(now, pluginId, version, runKey);
+      }
+      this.db.exec('COMMIT');
+    } catch (err) {
+      this.db.exec('ROLLBACK');
+      throw err;
+    }
+    this.pendingFiles.clear();
+    this.pendingRuns.clear();
+    this.touched.files.clear();
+    this.touched.runs.clear();
+  }
+
+  /** Drop entries untouched for `maxAgeMs`; `prune(0)` empties the cache. */
+  prune(maxAgeMs: number): void {
+    const cutoff = Date.now() - maxAgeMs;
+    this.db.prepare('DELETE FROM file_cache WHERE used_at <= ?').run(cutoff);
+    this.db.prepare('DELETE FROM run_cache WHERE used_at <= ?').run(cutoff);
+  }
+
+  stats(): CacheStats {
+    return { ...this.counters };
+  }
+
+  clear(): void {
+    this.pendingFiles.clear();
+    this.pendingRuns.clear();
+    this.touched.files.clear();
+    this.touched.runs.clear();
+    this.db.exec('DELETE FROM file_cache');
+    this.db.exec('DELETE FROM run_cache');
+  }
+
+  close(): void {
+    try {
+      this.flush();
+    } finally {
+      this.db.close();
+    }
+  }
+}
+
+/** `\x1f` cannot occur in a plugin id, a version or a sha. */
+const KEY_SEP = '\x1f';
+
+function entryKey(pluginId: string, version: string, key: string): string {
+  return `${pluginId}${KEY_SEP}${version}${KEY_SEP}${key}`;
+}
+
+function splitKey(key: string): [string, string, string] {
+  const [pluginId, version, rest] = key.split(KEY_SEP);
+  return [pluginId!, version!, rest!];
+}
+
+/** A row we cannot read is a miss, not a crash. */
+function parse(value: string | undefined): unknown {
+  if (value === undefined) return undefined;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Content digest of a file set — `(path, blob)` for every file, order-independent.
+ * Two runs with the same digest see byte-identical inputs, which is what makes
+ * a whole-run cache entry safe to reuse.
+ */
+export function filesDigest(files: readonly RepoFile[]): string {
+  const hash = createHash('sha256');
+  for (const f of [...files].sort((a, b) => (a.path < b.path ? -1 : 1))) {
+    hash.update(`${f.path}\0${f.blob}\n`);
+  }
+  return hash.digest('hex');
+}
+
+/** Digest of arbitrary key parts, for run keys that mix in more than files. */
+export function digest(parts: readonly (string | number | undefined)[]): string {
+  const hash = createHash('sha256');
+  for (const p of parts) hash.update(`${p ?? ''}\0`);
+  return hash.digest('hex');
+}

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -125,7 +125,7 @@ export function openAnalysisCache(opts: CacheOptions = {}): AnalysisCache {
     opts.path ??
     resolve(opts.dir ?? process.env.STRATA_CACHE_DIR ?? '.strata', 'cache.db');
   try {
-    return new SqliteAnalysisCache(file, opts.maxAgeDays ?? 30);
+    return new SqliteAnalysisCache(file, opts.maxAgeDays ?? 30, log);
   } catch (err) {
     log.warn(
       `disabled — could not open ${file}: ${(err as Error).message}`,
@@ -201,7 +201,14 @@ class SqliteAnalysisCache implements AnalysisCache {
     writes: 0,
   };
 
-  constructor(path: string, maxAgeDays: number) {
+  /** Set once the database has failed; keeps the warning to one per run. */
+  private degraded = false;
+
+  constructor(
+    path: string,
+    maxAgeDays: number,
+    private readonly log: Logger,
+  ) {
     this.path = resolve(path);
     mkdirSync(dirname(this.path), { recursive: true });
     this.db = new DatabaseSync(this.path);
@@ -298,12 +305,31 @@ class SqliteAnalysisCache implements AnalysisCache {
     const pending = this.pendingFiles.get(key);
     if (pending) return parse(pending.value);
 
-    const row = this.selectFile.get(pluginId, version, blob) as
+    const row = this.read(() => this.selectFile.get(pluginId, version, blob)) as
       | { value: string }
       | undefined;
     if (row === undefined) return undefined;
     this.touched.files.add(key);
     return parse(row.value);
+  }
+
+  /** A read that fails is a miss — never an error the analysis has to handle. */
+  private read(query: () => unknown): unknown {
+    try {
+      return query();
+    } catch (err) {
+      this.degrade('read', err);
+      return undefined;
+    }
+  }
+
+  private degrade(op: string, err: unknown): void {
+    if (this.degraded) return;
+    this.degraded = true;
+    this.log.warn(
+      `${op} failed on ${this.path}; continuing without the cache: ` +
+        (err as Error).message,
+    );
   }
 
   getRun<T>(pluginId: string, version: string, runKey: string): T | undefined {
@@ -314,9 +340,9 @@ class SqliteAnalysisCache implements AnalysisCache {
         ? parse(pending.value)
         : parse(
             (
-              this.selectRun.get(pluginId, version, runKey) as
-                | { value: string }
-                | undefined
+              this.read(() =>
+                this.selectRun.get(pluginId, version, runKey),
+              ) as { value: string } | undefined
             )?.value,
           );
 
@@ -353,8 +379,8 @@ class SqliteAnalysisCache implements AnalysisCache {
     if (pending === 0) return;
 
     const now = Date.now();
-    this.db.exec('BEGIN IMMEDIATE');
     try {
+      this.db.exec('BEGIN IMMEDIATE');
       for (const w of this.pendingFiles.values()) {
         this.insertFile.run(w.pluginId, w.version, w.key, w.value, now);
       }
@@ -372,13 +398,20 @@ class SqliteAnalysisCache implements AnalysisCache {
       }
       this.db.exec('COMMIT');
     } catch (err) {
-      this.db.exec('ROLLBACK');
-      throw err;
+      // A write that fails (SQLITE_BUSY past the timeout, a full or read-only
+      // disk) costs a recomputation next run — it must not fail this analysis.
+      try {
+        this.db.exec('ROLLBACK');
+      } catch {
+        // Already rolled back; the original error is the interesting one.
+      }
+      this.degrade(`write of ${pending} entries`, err);
+    } finally {
+      this.pendingFiles.clear();
+      this.pendingRuns.clear();
+      this.touched.files.clear();
+      this.touched.runs.clear();
     }
-    this.pendingFiles.clear();
-    this.pendingRuns.clear();
-    this.touched.files.clear();
-    this.touched.runs.clear();
   }
 
   /** Drop entries untouched for `maxAgeMs`; `prune(0)` empties the cache. */
@@ -405,7 +438,11 @@ class SqliteAnalysisCache implements AnalysisCache {
     try {
       this.flush();
     } finally {
-      this.db.close();
+      try {
+        this.db.close();
+      } catch (err) {
+        this.degrade('close', err);
+      }
     }
   }
 }

--- a/packages/core/src/incremental.test.ts
+++ b/packages/core/src/incremental.test.ts
@@ -1,0 +1,161 @@
+import { execFile } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { Strata } from './index.js';
+import { PluginRegistry } from './registry.js';
+
+const exec = promisify(execFile);
+
+/**
+ * End-to-end proof of the incremental path: analyse a real git repo twice and
+ * assert the second run recomputes nothing, then change one file and assert
+ * only that file is recomputed.
+ */
+
+/** The stub plugin counts its per-file work here, in the shared realm. */
+declare global {
+  var __strataScans: string[] | undefined;
+}
+
+const PLUGIN_SOURCE = `export default {
+  kind: 'language',
+  extensions: ['ts'],
+  async analyze(ctx) {
+    const nodes = [];
+    for (const file of ctx.files) {
+      const loc = await ctx.cache.file(file, async (f) => {
+        (globalThis.__strataScans ??= []).push(f.path);
+        return (await f.read()).split('\\n').length;
+      });
+      nodes.push({ id: file.path, label: file.path, kind: 'file', meta: { loc } });
+    }
+    return { graph: { nodes, edges: [], cycles: [] }, deadCode: [], metrics: [] };
+  },
+};
+`;
+
+let repo: string;
+let cacheDir: string;
+let pluginDir: string;
+let strata: Strata;
+
+async function git(args: string[]): Promise<void> {
+  await exec('git', args, {
+    cwd: repo,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'Strata Test',
+      GIT_AUTHOR_EMAIL: 'test@example.com',
+      GIT_COMMITTER_NAME: 'Strata Test',
+      GIT_COMMITTER_EMAIL: 'test@example.com',
+    },
+  });
+}
+
+async function commit(files: Record<string, string>, message: string) {
+  for (const [name, body] of Object.entries(files)) {
+    writeFileSync(join(repo, name), body);
+  }
+  await git(['add', '-A']);
+  await git(['commit', '-m', message]);
+}
+
+/** Files scanned since the last call. */
+function scans(): string[] {
+  const seen = globalThis.__strataScans ?? [];
+  globalThis.__strataScans = [];
+  return seen;
+}
+
+beforeAll(async () => {
+  repo = mkdtempSync(join(tmpdir(), 'strata-repo-'));
+  cacheDir = mkdtempSync(join(tmpdir(), 'strata-cache-'));
+  pluginDir = mkdtempSync(join(tmpdir(), 'strata-plugin-'));
+
+  mkdirSync(join(pluginDir, 'dist'), { recursive: true });
+  writeFileSync(join(pluginDir, 'dist/index.mjs'), PLUGIN_SOURCE);
+  writeFileSync(
+    join(pluginDir, 'strata.plugin.json'),
+    JSON.stringify({
+      id: 'test-language',
+      name: 'test-language',
+      kind: 'language',
+      version: '1.0.0',
+      sdk: '0.1.0',
+      main: './dist/index.mjs',
+    }),
+  );
+
+  await exec('git', ['init', '-q', '-b', 'main'], { cwd: repo });
+  await commit(
+    { 'a.ts': 'export const a = 1;\n', 'b.ts': 'export const b = 2;\n' },
+    'feat: initial',
+  );
+
+  const registry = new PluginRegistry();
+  await registry.loadFrom(join(pluginDir, 'strata.plugin.json'));
+  strata = new Strata(registry, { cache: { dir: cacheDir } });
+}, 30_000);
+
+afterAll(() => {
+  strata.close();
+  for (const dir of [repo, cacheDir, pluginDir]) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('incremental analysis', () => {
+  it('computes every file on a cold cache', async () => {
+    const report = await strata.analyze({ root: repo });
+
+    expect(scans().sort()).toEqual(['a.ts', 'b.ts']);
+    expect(report.cache).toMatchObject({
+      enabled: true,
+      hits: 0,
+      misses: 2,
+      runHits: 0,
+    });
+  });
+
+  it('skips the plugin entirely when nothing changed', async () => {
+    const first = await strata.analyze({ root: repo });
+    const second = await strata.analyze({ root: repo });
+
+    expect(scans()).toEqual([]);
+    expect(second.cache).toMatchObject({ runHits: 1, misses: 0 });
+    expect(second.languages).toEqual(first.languages);
+  });
+
+  it('recomputes only the file that changed', async () => {
+    await commit({ 'b.ts': 'export const b = 2;\nexport const c = 3;\n' }, 'fix: b');
+
+    const report = await strata.analyze({ root: repo });
+
+    expect(scans()).toEqual(['b.ts']); // a.ts came from the cache
+    expect(report.cache).toMatchObject({ hits: 1, misses: 1, runHits: 0 });
+    expect(report.languages.ts?.graph.nodes).toContainEqual({
+      id: 'b.ts',
+      label: 'b.ts',
+      kind: 'file',
+      meta: { loc: 3 },
+    });
+  });
+
+  it('recomputes everything when the caller opts out', async () => {
+    const report = await strata.analyze({ root: repo, cache: false });
+
+    expect(scans().sort()).toEqual(['a.ts', 'b.ts']);
+    expect(report.cache.enabled).toBe(false);
+  });
+
+  it('recomputes everything after the cache is cleared', async () => {
+    strata.clearCache();
+    const report = await strata.analyze({ root: repo });
+
+    expect(scans().sort()).toEqual(['a.ts', 'b.ts']);
+    expect(report.cache).toMatchObject({ hits: 0, misses: 2, runHits: 0 });
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,10 +7,26 @@ import type {
   RepoContext,
 } from '@strata/sdk';
 import { PluginRegistry } from './registry.js';
-import { churn, git, history, listFiles, resolveRev } from './git.js';
+import { git, history, listFiles, resolveRev } from './git.js';
+import {
+  digest,
+  filesDigest,
+  nullCache,
+  openAnalysisCache,
+  type AnalysisCache,
+  type CacheOptions,
+  type CacheStats,
+} from './cache.js';
 
 export { PluginRegistry } from './registry.js';
 export * as gitUtil from './git.js';
+export {
+  openAnalysisCache,
+  nullCache,
+  type AnalysisCache,
+  type CacheOptions,
+  type CacheStats,
+} from './cache.js';
 
 const consoleLogger: Logger = {
   debug: (m, meta) => console.debug(`[strata] ${m}`, meta ?? ''),
@@ -26,6 +42,20 @@ export interface AnalyzeOptions {
   rev?: string;
   /** Cap the history window (number of commits). */
   historyLimit?: number;
+  /** Set false to recompute everything for this run (nothing is read or written). */
+  cache?: boolean;
+}
+
+export interface StrataOptions {
+  /** Incremental cache configuration; `false` turns it off entirely. */
+  cache?: CacheOptions | false;
+}
+
+/** What the cache did during one analysis. */
+export interface CacheReport extends CacheStats {
+  enabled: boolean;
+  /** Database file backing the cache, if any. */
+  path?: string;
 }
 
 export interface AnalysisReport {
@@ -33,20 +63,30 @@ export interface AnalysisReport {
   languages: Record<string, LanguageAnalysis>;
   metrics: MetricSeries[];
   commits: ParsedCommit[];
+  cache: CacheReport;
 }
 
 /**
  * The orchestrator. Builds a RepoContext, then fans the work out to whichever
- * plugins are registered. Everything a plugin sees flows through here, so this
- * is also where caching / incremental analysis will hook in.
+ * plugins are registered. Everything a plugin sees flows through here, which is
+ * also where the incremental cache hooks in: each plugin gets a `cache` scoped
+ * to its own id, and a plugin whose entire input is unchanged is skipped.
  */
 export class Strata {
-  constructor(private readonly registry: PluginRegistry) {}
+  private cache?: AnalysisCache;
+
+  constructor(
+    private readonly registry: PluginRegistry,
+    private readonly options: StrataOptions = {},
+  ) {}
 
   async analyze(opts: AnalyzeOptions): Promise<AnalysisReport> {
+    const cache = opts.cache === false ? nullCache() : this.openCache();
+    // Counters live as long as the cache does; report this run's delta.
+    const before = cache.stats();
     const rev = await resolveRev(opts.root, opts.rev);
     const files = await listFiles(opts.root, rev);
-    const ctx: RepoContext = {
+    const ctx: Omit<RepoContext, 'cache'> = {
       root: opts.root,
       rev,
       files,
@@ -56,14 +96,33 @@ export class Strata {
 
     // 1. Per-language static analysis, routed by file extension.
     const languages: Record<string, LanguageAnalysis> = {};
-    for (const lang of this.registry.byKind('language')) {
-      const exts = new Set(lang.extensions.map((e) => `.${e}`));
+    for (const { manifest, plugin } of this.registry.loadedByKind('language')) {
+      const exts = new Set(plugin.extensions.map((e) => `.${e}`));
       const matched = files.filter((f) => exts.has(extname(f.path)));
       if (matched.length === 0) continue;
-      languages[lang.extensions.join(',')] = await lang.analyze({
+
+      // The result depends on nothing but the matched files' contents, so their
+      // digest is the whole cache key.
+      const runKey = digest(['language', filesDigest(matched)]);
+      const key = plugin.extensions.join(',');
+      const hit = cache.getRun<LanguageAnalysis>(
+        manifest.id,
+        manifest.version,
+        runKey,
+      );
+      if (hit) {
+        languages[key] = hit;
+        continue;
+      }
+
+      const analysis = await plugin.analyze({
         ...ctx,
         files: matched,
+        cache: cache.scope(manifest.id, manifest.version),
       });
+      cache.setRun(manifest.id, manifest.version, runKey, analysis);
+      languages[key] = analysis;
+      cache.flush();
     }
 
     // 2. Git-history metrics (hotspots, coupling, …).
@@ -71,11 +130,37 @@ export class Strata {
       rev,
       maxCount: opts.historyLimit,
     });
-    // Warm the churn cache once; metric plugins can re-derive as needed.
-    void churn(opts.root, { rev, maxCount: opts.historyLimit });
     const metrics: MetricSeries[] = [];
-    for (const metric of this.registry.byKind('git-metric')) {
-      metrics.push(await metric.compute(ctx, commitLog));
+    for (const { manifest, plugin } of this.registry.loadedByKind(
+      'git-metric',
+    )) {
+      // Metrics read history as well as files, and a shallow clone can hold a
+      // different history for the same sha — so the repo goes into the key too.
+      const runKey = digest([
+        'git-metric',
+        opts.root,
+        rev,
+        opts.historyLimit,
+        commitLog.length,
+        filesDigest(files),
+      ]);
+      const hit = cache.getRun<MetricSeries>(
+        manifest.id,
+        manifest.version,
+        runKey,
+      );
+      if (hit) {
+        metrics.push(hit);
+        continue;
+      }
+
+      const series = await plugin.compute(
+        { ...ctx, cache: cache.scope(manifest.id, manifest.version) },
+        commitLog,
+      );
+      cache.setRun(manifest.id, manifest.version, runKey, series);
+      metrics.push(series);
+      cache.flush();
     }
 
     // 3. Commit-convention parsing (first registered convention wins).
@@ -84,6 +169,44 @@ export class Strata {
       ? commitLog.map((c) => convention.parse(c))
       : [];
 
-    return { rev, languages, metrics, commits };
+    cache.flush();
+    return {
+      rev,
+      languages,
+      metrics,
+      commits,
+      cache: {
+        enabled: cache.path !== null,
+        ...(cache.path ? { path: cache.path } : {}),
+        ...sinceStats(before, cache.stats()),
+      },
+    };
   }
+
+  /** Forget every cached result. */
+  clearCache(): void {
+    this.openCache().clear();
+  }
+
+  /** Flush and close the cache. Call on shutdown. */
+  close(): void {
+    this.cache?.close();
+    this.cache = undefined;
+  }
+
+  private openCache(): AnalysisCache {
+    if (this.options.cache === false) return (this.cache ??= nullCache());
+    return (this.cache ??= openAnalysisCache(this.options.cache));
+  }
+}
+
+/** What one analysis did, derived from the cache's cumulative counters. */
+function sinceStats(before: CacheStats, after: CacheStats): CacheStats {
+  return {
+    hits: after.hits - before.hits,
+    misses: after.misses - before.misses,
+    runHits: after.runHits - before.runHits,
+    runMisses: after.runMisses - before.runMisses,
+    writes: after.writes - before.writes,
+  };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-import { extname } from 'node:path';
+import { extname, relative, resolve, isAbsolute } from 'node:path';
 import type {
   LanguageAnalysis,
   Logger,
@@ -82,6 +82,7 @@ export class Strata {
 
   async analyze(opts: AnalyzeOptions): Promise<AnalysisReport> {
     const cache = opts.cache === false ? nullCache() : this.openCache();
+    warnIfCacheInsideRepo(cache.path, opts.root);
     // Counters live as long as the cache does; report this run's delta.
     const before = cache.stats();
     const rev = await resolveRev(opts.root, opts.rev);
@@ -198,6 +199,26 @@ export class Strata {
     if (this.options.cache === false) return (this.cache ??= nullCache());
     return (this.cache ??= openAnalysisCache(this.options.cache));
   }
+}
+
+/** Repos we have already warned about, so a server warns once per repo. */
+const warnedRoots = new Set<string>();
+
+/**
+ * The default cache directory is relative to the working directory, so running
+ * an analysis from inside the repo being analysed would write `cache.db` into
+ * it. Harmless for results (analysis reads from git, not the worktree) but it
+ * litters someone else's repository, so say so once.
+ */
+function warnIfCacheInsideRepo(cachePath: string | null, root: string): void {
+  if (!cachePath) return;
+  const rel = relative(resolve(root), cachePath);
+  if (rel.startsWith('..') || isAbsolute(rel) || warnedRoots.has(root)) return;
+  warnedRoots.add(root);
+  consoleLogger.warn(
+    `cache database lives inside the analysed repo (${cachePath}). ` +
+      'Set STRATA_CACHE_DIR to keep it elsewhere.',
+  );
 }
 
 /** What one analysis did, derived from the cache's cumulative counters. */

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -43,9 +43,20 @@ export class PluginRegistry {
   byKind<K extends StrataPlugin['kind']>(
     kind: K,
   ): Extract<StrataPlugin, { kind: K }>[] {
-    return this.plugins
-      .map((l) => l.plugin)
-      .filter((p): p is Extract<StrataPlugin, { kind: K }> => p.kind === kind);
+    return this.loadedByKind(kind).map((l) => l.plugin);
+  }
+
+  /**
+   * Like `byKind`, but keeps each plugin's manifest attached — the orchestrator
+   * needs the id and version to key cache entries.
+   */
+  loadedByKind<K extends StrataPlugin['kind']>(
+    kind: K,
+  ): (LoadedPlugin & { plugin: Extract<StrataPlugin, { kind: K }> })[] {
+    return this.plugins.filter(
+      (l): l is LoadedPlugin & { plugin: Extract<StrataPlugin, { kind: K }> } =>
+        l.plugin.kind === kind,
+    );
   }
 
   all(): readonly LoadedPlugin[] {

--- a/packages/sdk/ARCHITECTURE.md
+++ b/packages/sdk/ARCHITECTURE.md
@@ -29,7 +29,7 @@ Goals: a minimal, strongly-typed, SemVer-stable surface.
 
 | Area | Contents |
 |------|----------|
-| Shared types | `PluginManifest`, `RepoFile`, `RepoContext`, `Logger`, graph types |
+| Shared types | `PluginManifest`, `RepoFile`, `RepoContext`, `PluginCache`, `Logger`, graph types |
 | Language | `LanguagePlugin`, `LanguageAnalysis`, `DeadCodeFinding`, `CodeMetric` |
 | Commit | `CommitConventionPlugin`, `RawCommit`, `ParsedCommit` |
 | Git metric | `GitMetricPlugin`, `MetricSeries`, `MetricPoint` |
@@ -46,6 +46,8 @@ discriminant so the core can route a plugin without reflection.
   inference and set `kind` centrally.
 - **Discriminated union (`StrataPlugin`)** — lets the registry switch on `kind`
   type-safely.
+- **`RepoContext.cache` is always present** — the core injects a pass-through
+  when caching is off, so plugins never branch on cache availability.
 
 ## 7. Quality & Risks
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -50,6 +50,27 @@ export interface RepoFile {
   read(): Promise<string>;
 }
 
+/**
+ * Per-file memoisation, keyed on `(pluginId, blob)` — the incremental cache.
+ *
+ * The core scopes an instance to the plugin it hands the `RepoContext` to, so
+ * a plugin never sees another plugin's entries and never passes its own id.
+ * Wrap the expensive per-file part of an analysis in `file()`: on a rerun,
+ * every file whose blob is unchanged returns from the cache and `compute`
+ * never runs.
+ */
+export interface PluginCache {
+  /**
+   * Return the cached value for `file`, or run `compute` and store its result.
+   *
+   * `compute` must be pure in the file's contents — anything else (other files,
+   * history, the clock) makes the entry wrong on the next hit. The value is
+   * persisted as JSON, so it must be JSON-serialisable; `undefined` round-trips
+   * as `null`.
+   */
+  file<T>(file: RepoFile, compute: (file: RepoFile) => Promise<T>): Promise<T>;
+}
+
 /** Immutable view of the repository handed to plugins. */
 export interface RepoContext {
   /** Absolute path to the working tree root. */
@@ -62,6 +83,11 @@ export interface RepoContext {
   git(args: string[]): Promise<string>;
   /** Structured logger scoped to the current plugin. */
   log: Logger;
+  /**
+   * Blob-keyed cache scoped to this plugin. Always present — when caching is
+   * switched off the core injects a pass-through that just calls `compute`.
+   */
+  cache: PluginCache;
 }
 
 export interface Logger {

--- a/packages/server/ARCHITECTURE.md
+++ b/packages/server/ARCHITECTURE.md
@@ -50,7 +50,13 @@ happens once at startup.
 
 ## 7. Quality & Risks
 
-- **Risk:** `root` points anywhere on disk. **Mitigation:** deployments mount
-  repos read-only under a fixed prefix; add path allow-listing (backlog).
+- **Risk:** `root` points anywhere on disk, and the API is unauthenticated —
+  `DELETE /cache` is reachable by anyone who can reach the port (cost: a
+  recomputation). **Mitigation:** the API assumes a trusted network and
+  deployments mount repos read-only under a fixed prefix; path allow-listing and
+  auth are on the backlog. Do not expose the port publicly.
+- **Risk:** malformed request bodies. **Mitigation:** `/analyze` carries a JSON
+  schema, so a wrong-typed field (`"cache": "false"`) is a 400 rather than a
+  silently ignored option.
 - **Risk:** long analyses block the event loop. **Mitigation:** move heavy runs
   to a worker queue (backlog).

--- a/packages/server/ARCHITECTURE.md
+++ b/packages/server/ARCHITECTURE.md
@@ -24,7 +24,8 @@ UI and CI. Keeps transport concerns out of the core.
 |--------|------|---------|
 | GET | `/health` | Liveness. |
 | GET | `/plugins` | List loaded plugin manifests. |
-| POST | `/analyze` | Body `{ root, rev?, historyLimit? }` → `AnalysisReport`. |
+| POST | `/analyze` | Body `{ root, rev?, historyLimit?, cache? }` → `AnalysisReport` (incl. cache stats). |
+| DELETE | `/cache` | Empty the incremental cache. |
 
 ## 4. Building Blocks
 
@@ -44,6 +45,8 @@ happens once at startup.
 - **Fastify** for schema-friendly, fast HTTP with low overhead.
 - **Built-ins discovered from manifests** (not hard-wired imports), so adding a
   first-party plugin is a one-line list change; third-party dir loading is next.
+- **One long-lived `Strata`**, so the cache is opened once and closed with the
+  server (`onClose`), not per request.
 
 ## 7. Quality & Risks
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -38,14 +38,23 @@ export async function createServer() {
     registry.all().map((l) => l.manifest),
   );
 
-  app.post<{ Body: { root: string; rev?: string; historyLimit?: number } }>(
-    '/analyze',
-    async (req, reply) => {
-      const { root, rev, historyLimit } = req.body ?? {};
-      if (!root) return reply.status(400).send({ error: 'root is required' });
-      return strata.analyze({ root, rev, historyLimit });
-    },
-  );
+  app.post<{
+    Body: { root: string; rev?: string; historyLimit?: number; cache?: boolean };
+  }>('/analyze', async (req, reply) => {
+    const { root, rev, historyLimit, cache } = req.body ?? {};
+    if (!root) return reply.status(400).send({ error: 'root is required' });
+    return strata.analyze({ root, rev, historyLimit, cache });
+  });
+
+  // Escape hatch: drop every cached result (e.g. after upgrading a plugin
+  // in place without bumping its version).
+  app.delete('/cache', async () => {
+    strata.clearCache();
+    return { cleared: true };
+  });
+
+  // Flush and close the cache with the server.
+  app.addHook('onClose', async () => strata.close());
 
   return app;
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -38,11 +38,26 @@ export async function createServer() {
     registry.all().map((l) => l.manifest),
   );
 
+  // The schema rejects wrong types outright — `"cache": "false"` is a string,
+  // and silently caching anyway would be worse than a 400.
+  const analyzeSchema = {
+    body: {
+      type: 'object',
+      required: ['root'],
+      additionalProperties: false,
+      properties: {
+        root: { type: 'string', minLength: 1 },
+        rev: { type: 'string' },
+        historyLimit: { type: 'integer', minimum: 1 },
+        cache: { type: 'boolean' },
+      },
+    },
+  };
+
   app.post<{
     Body: { root: string; rev?: string; historyLimit?: number; cache?: boolean };
-  }>('/analyze', async (req, reply) => {
-    const { root, rev, historyLimit, cache } = req.body ?? {};
-    if (!root) return reply.status(400).send({ error: 'root is required' });
+  }>('/analyze', { schema: analyzeSchema }, async (req) => {
+    const { root, rev, historyLimit, cache } = req.body;
     return strata.analyze({ root, rev, historyLimit, cache });
   });
 

--- a/plugins/git-hotspots/ARCHITECTURE.md
+++ b/plugins/git-hotspots/ARCHITECTURE.md
@@ -24,7 +24,8 @@ git metric.
 
 - **Churn** — walk back exactly the analysed commits from the newest sha
   (`git log -n <N> <sha>`), counting touches per path. Root-commit safe.
-- **Complexity proxy** — indentation-weighted non-blank line count.
+- **Complexity proxy** — indentation-weighted non-blank line count, memoised
+  per blob via `ctx.cache`, so a rerun reads only changed files.
 - **Score** — `churn × complexity`, sorted descending, with `meta`.
 
 ## 5. Runtime

--- a/plugins/git-hotspots/src/index.ts
+++ b/plugins/git-hotspots/src/index.ts
@@ -4,6 +4,7 @@ import {
   type MetricSeries,
   type RawCommit,
   type RepoContext,
+  type RepoFile,
 } from '@strata/sdk';
 
 /**
@@ -42,7 +43,9 @@ export default defineGitMetricPlugin({
     for (const file of ctx.files) {
       const changes = churn.get(file.path);
       if (!changes) continue; // only score files that actually churn
-      const complexity = await indentComplexity(file);
+      // Complexity depends on the file's contents only — cache it per blob so a
+      // rerun re-reads nothing but the files that actually changed.
+      const complexity = await ctx.cache.file(file, indentComplexity);
       points.push({
         subject: file.path,
         value: changes * complexity,
@@ -60,9 +63,7 @@ export default defineGitMetricPlugin({
 });
 
 /** Sum of leading-whitespace depth per non-blank line — a fast complexity proxy. */
-async function indentComplexity(file: {
-  read(): Promise<string>;
-}): Promise<number> {
+async function indentComplexity(file: RepoFile): Promise<number> {
   const text = await file.read();
   let score = 0;
   for (const line of text.split('\n')) {

--- a/plugins/language-typescript/ARCHITECTURE.md
+++ b/plugins/language-typescript/ARCHITECTURE.md
@@ -23,7 +23,8 @@ language plugin — Angular and other TS-based analyzers build on its shape.
 
 ## 4. Building Blocks
 
-- **Import scan** — regex over `import/export … from` and `require()`.
+- **Import scan** — regex over `import/export … from` and `require()`; the
+  per-file result (`{ loc, specs }`) is cached per blob via `ctx.cache`.
 - **Local resolver** — maps relative specifiers to known files (`.ts`, `.tsx`,
   `/index.ts`, …); bare/package imports are ignored.
 - **Cycle detection** — Tarjan's SCC; components with > 1 node are cycles.
@@ -38,6 +39,8 @@ returns `{ graph, deadCode, metrics }`.
 - **Regex now, tree-sitter next** — accurate module resolution, dead-code via
   real export-usage, and per-symbol edges come with the parser upgrade; the
   returned shape won't change.
+- **Cache the scan, not the resolution** — specifier resolution depends on the
+  whole file set, so only the contents-derived half is cacheable per blob.
 
 ## 7. Quality & Risks
 

--- a/plugins/language-typescript/src/index.ts
+++ b/plugins/language-typescript/src/index.ts
@@ -21,6 +21,13 @@ import {
 const IMPORT_RE =
   /(?:import|export)[^'"]*?from\s*['"]([^'"]+)['"]|require\(\s*['"]([^'"]+)['"]\s*\)/g;
 
+/** What we extract from one file — cached per blob, so unchanged files are free. */
+interface FileScan {
+  loc: number;
+  /** Relative import specifiers, unresolved (resolution needs the whole set). */
+  specs: string[];
+}
+
 export default defineLanguagePlugin({
   extensions: ['ts', 'tsx', 'js', 'jsx', 'mjs', 'cjs'],
   async analyze(ctx: RepoContext): Promise<LanguageAnalysis> {
@@ -29,17 +36,18 @@ export default defineLanguagePlugin({
     const edges: GraphEdge[] = [];
 
     for (const file of ctx.files) {
-      const text = await file.read();
+      // Reading and scanning is the expensive half and depends only on the
+      // file's contents; resolving specifiers depends on the whole file set,
+      // so it stays out of the cached value.
+      const { loc, specs } = await ctx.cache.file(file, scan);
       nodes.push({
         id: file.path,
         label: file.path,
         kind: 'file',
-        meta: { loc: text.split('\n').length },
+        meta: { loc },
       });
 
-      for (const match of text.matchAll(IMPORT_RE)) {
-        const spec = match[1] ?? match[2];
-        if (!spec || !spec.startsWith('.')) continue; // skip bare/pkg imports
+      for (const spec of specs) {
         const target = resolveLocal(file, spec, byPath);
         if (target) edges.push({ from: file.path, to: target, kind: 'import' });
       }
@@ -56,6 +64,17 @@ export default defineLanguagePlugin({
     };
   },
 });
+
+/** Read a file once and pull out everything that depends on its contents alone. */
+async function scan(file: RepoFile): Promise<FileScan> {
+  const text = await file.read();
+  const specs: string[] = [];
+  for (const match of text.matchAll(IMPORT_RE)) {
+    const spec = match[1] ?? match[2];
+    if (spec?.startsWith('.')) specs.push(spec); // skip bare/pkg imports
+  }
+  return { loc: text.split('\n').length, specs };
+}
 
 /** Resolve a relative import specifier to a known file path. */
 function resolveLocal(

--- a/scripts/analyze.mjs
+++ b/scripts/analyze.mjs
@@ -33,11 +33,13 @@ for (const rel of [
 }
 
 const strata = new Strata(registry);
-const report = await strata.analyze({
-  root: resolve(target),
-  historyLimit,
-});
-strata.close();
+let report;
+try {
+  report = await strata.analyze({ root: resolve(target), historyLimit });
+} finally {
+  // Flushes pending cache writes even when the analysis threw.
+  strata.close();
+}
 
 const hot = report.metrics.find((m) => m.id === 'hotspots');
 console.log(`\nStrata — ${resolve(target)} @ ${report.rev.slice(0, 8)}\n`);

--- a/scripts/analyze.mjs
+++ b/scripts/analyze.mjs
@@ -32,10 +32,12 @@ for (const rel of [
   await registry.loadFrom(resolve(repoRoot, rel));
 }
 
-const report = await new Strata(registry).analyze({
+const strata = new Strata(registry);
+const report = await strata.analyze({
   root: resolve(target),
   historyLimit,
 });
+strata.close();
 
 const hot = report.metrics.find((m) => m.id === 'hotspots');
 console.log(`\nStrata — ${resolve(target)} @ ${report.rev.slice(0, 8)}\n`);
@@ -52,6 +54,14 @@ const valid = report.commits.filter((c) => c.valid).length;
 console.log(
   `\nCommits: ${report.commits.length} analysed, ${valid} conventional, ` +
     `${report.commits.filter((c) => c.breaking).length} breaking`,
+);
+
+const c = report.cache;
+console.log(
+  c.enabled
+    ? `\nCache: ${c.hits} file hits / ${c.misses} computed, ` +
+        `${c.runHits} plugin runs skipped (${c.path})`
+    : '\nCache: disabled',
 );
 
 for (const [langs, a] of Object.entries(report.languages)) {


### PR DESCRIPTION
Closes #1.

Analysis results are cached in SQLite — via `node:sqlite`, so the runtime gains no dependency and no native build.

## Two levels

| Level | Key | Why |
|-------|-----|-----|
| per file | `(pluginId, blob)` | The key the issue asks for. A git blob sha *is* a content hash, so an entry stays valid across revisions, branches and repositories. Plugins reach it through `RepoContext.cache`. |
| per plugin run | `(pluginId, runKey)` where `runKey` digests every input | Graph and cycle output is not per-file, so the per-file level alone would not make an unchanged rerun free. With it, the plugin is not called at all. |

The plugin's `version` is part of both keys, so shipping a new plugin build invalidates exactly that plugin's entries.

## Contract change

`RepoContext` gains a `cache: PluginCache`. It is always present — when caching is off the core injects a pass-through — so plugins never branch on availability. `compute` must depend on the file's contents alone; that rule is documented in the SDK and in `docs/PLUGINS.md`.

## Operational notes

- The cache lives in `$STRATA_CACHE_DIR` (default `<cwd>/.strata/cache.db`), never inside the analysed repo — those are mounted read-only.
- The Dockerfile now creates `/app/.strata` owned by `node`. Without it the container would silently fall back to no caching, since the existing compose volume targets a path the non-root user could not write.
- Off switches: `STRATA_CACHE=0`, `analyze({cache: false})`, `POST /analyze {"cache": false}`, `DELETE /cache`.
- An unopenable database warns and degrades to a pass-through. A broken cache must not fail an analysis.
- Entries carry a last-used stamp; cold ones are pruned after 30 days on open.

## Tests

- `packages/core/src/cache.test.ts` — persistence across reopen, isolation by blob / plugin / version, run-level entries, prune, clear, both off switches, and the degraded-open path.
- `packages/core/src/incremental.test.ts` — drives a real temp git repo end to end: cold run scans every file, an unchanged rerun skips the plugin entirely, and after committing a change to one file *only that file* is recomputed.

Measured on this repo: 207 ms cold → 46 ms warm, byte-identical report.

## Also

Drops the `void churn(...)` warm-up in the orchestrator — it memoised nothing and risked an unhandled rejection. The real cache replaces its intent.

A follow-up PR stacked on this branch splits the repo's multi-responsibility files, including the ones added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added persistent incremental caching to speed up repeated analyses by reusing unchanged results.
  - Added cache controls to enable, disable, bypass, clear, and configure storage.
  - Analysis reports and command-line output now show cache status and usage statistics.
  - Added an endpoint to clear cached results.
  - Plugin analysis now supports safe per-file result reuse.

- **Documentation**
  - Updated setup, API, architecture, and plugin documentation with cache behavior and configuration details.

- **Bug Fixes**
  - Analysis continues normally when caching is unavailable or disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->