### PR TITLE
docs(backlog): align the backlog with the web UI mockup

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -5,6 +5,11 @@ Features and technical work, grouped by area. Rough priority: **P0** = next,
 
 Legend: `[ ]` todo · `[~]` in progress · `[x]` done
 
+The UI items below track the **workbench mockup** (Claude Design → *Strata Web
+UI*): a left rail with a project switcher and five analysis screens, plus a
+two-scope settings area (**Project settings** and app-wide **Settings**).
+Anything marked *(mockup)* exists as a design and needs an implementation.
+
 ---
 
 ## Core & platform
@@ -13,63 +18,183 @@ Legend: `[ ]` todo · `[~]` in progress · `[x]` done
 - [x] Orchestrator + git ingest + plugin registry
 - [x] HTTP API (`/health`, `/plugins`, `/analyze`)
 - [x] Incremental cache — SQLite, keyed on `(pluginId, blob)`; skip unchanged files
-- [ ] **P0** Third-party plugin discovery — load a user plugins directory, not just built-ins
-- [ ] **P1** Worker queue for heavy analyses (BullMQ / worker_threads); progress events
+- [ ] **P0** Analysis run metadata in the `/analyze` result — branch, resolved rev,
+      file count, duration, finished-at. The mockup header (`main · @ 4c1249e ·
+      analyzed 2 min ago · 1.82s`) and the overview stat cards read this directly.
+- [ ] **P0** Third-party plugin discovery — load a user plugins directory, not just
+      built-ins. Surfaced as *Settings → Plugins & engine → Plugins directory*.
+- [ ] **P0** Path allow-listing / sandbox for the `root` a request may analyse —
+      a prerequisite now that the UI lets a user register arbitrary project roots.
+- [ ] **P1** Worker queue for heavy analyses (BullMQ / worker_threads); progress
+      events so *Re-analyze* can show a running state instead of blocking.
 - [ ] **P1** Analyse a bare/remote repo (clone-on-demand) and a specific `rev` range
-- [ ] **P1** Path allow-listing / sandbox for the `root` a request may analyse
 - [ ] **P2** Snapshot & compare two revisions (trend deltas)
 - [ ] **P2** Plugin config schema + per-plugin settings surfaced to the UI
+
+## Configuration & persistence
+
+New area — the mockup's settings screens need somewhere to write to. Nothing
+here exists yet.
+
+- [ ] **P0** Project registry — persist the list of registered projects
+      (id, display name, root path, last-analysis summary). Backs the sidebar
+      switcher, *Add project*, and *Danger zone → Remove project* (drops the
+      entry only; never touches the repo on disk).
+- [ ] **P0** Project-scoped config store + `GET`/`PATCH` endpoints, covering the
+      *Project settings* sections: display name, root, revision (default `HEAD`),
+      history limit, ignore globs, analyze paths, enabled language plugins,
+      enabled git metrics, commit convention, architecture rules.
+- [ ] **P0** App-scoped config store + endpoints: appearance (theme, density),
+      plugins directory, third-party plugin loading, cache on/off + clear,
+      CI gate thresholds, AI provider instances.
+- [ ] **P1** Secret storage for provider env values — write-only from the API's
+      perspective; the mockup states *"sensitive values are stored separately and
+      are not returned to the app after saving"*, so redact on read.
+- [ ] **P1** Config precedence + a checked-in `strata.config.*` file so a project's
+      scope, rules, and gates travel with the repo and drive headless CI mode.
+- [ ] **P2** Import/export a project config; per-project overrides of app defaults.
 
 ## Git / history intelligence
 
 - [x] Hotspots (churn × complexity)
-- [ ] **P0** Change coupling — files that change together (temporal coupling)
+- [ ] **P0** Commit analytics aggregates behind the *Commit analytics* screen —
+      per-type and per-scope counts, convention-validity rate (`96% valid ·
+      6 non-conforming`), breaking-change count, and a weekly activity series.
+- [ ] **P0** Change coupling — files that change together (temporal coupling).
+      Appears as a *planned* toggle under *Project settings → Metrics*.
 - [ ] **P1** Knowledge map / bus factor — contribution concentration per file/dir
 - [ ] **P1** Code age — stable vs. actively-churning regions
-- [ ] **P1** Commit analytics dashboard — type/scope breakdown, breaking-change timeline
+- [ ] **P1** Ignore-globs for metrics (exclude lockfiles/generated) — shares the
+      project-scoped glob list with the language scan rather than a second setting.
 - [ ] **P2** Author/ownership graph; main contributor per module
-- [ ] **P2** Ignore-globs for metrics (exclude lockfiles/generated)
+- [ ] **P2** Breaking-change timeline (the mockup shows a count; a timeline is the
+      natural follow-up)
 
 ## Language modules
 
 - [x] TypeScript/JavaScript starter (import graph + cycles)
 - [ ] **P0** Replace regex scan with **tree-sitter** (accurate resolution, aliases, dynamic imports)
-- [ ] **P0** Real dead code — unreferenced exports, unreachable files, unused deps
+- [ ] **P0** Real dead code — unreferenced exports, unreachable files, unused deps.
+      The mockup's *Dead code* table is the target shape: path, symbol, reason
+      (`unreferenced-export` / `unreachable-file` / `unused-dependency`), line.
 - [ ] **P0** Real metrics — cyclomatic complexity, nesting, duplication
+- [ ] **P0** Graph summary in the language result — node/edge counts, cycle count,
+      and fan-in/fan-out ranking (the mockup's *Max fan-in · sdk · 7* panel).
+- [ ] **P1** Emit each SCC as an ordered path so the UI can print the cycle as
+      `a → b → a` instead of an unordered node set.
 - [ ] **P1** **Angular** module — component/module/service graph, DI graph, standalone vs NgModule, lazy boundaries, unused components
 - [ ] **P1** **PHP** module — dependency graph + dead code
 - [ ] **P2** Cross-language project graph (e.g. TS frontend ↔ PHP backend boundaries)
 
 ## Architecture fitness
 
-- [ ] **P1** Rule engine — declare allowed/forbidden dependencies ("`ui` may not import `db`")
+- [ ] **P1** Rule engine — declare allowed/forbidden dependencies ("`ui` may not import `db`"),
+      persisted per project and edited in *Project settings → Architecture rules*
 - [ ] **P1** Boundary/layer violation report + CI gate
+- [ ] **P2** Violations surfaced on the dependency graph (highlight the offending edge)
 - [ ] **P2** Fitness-function trends over time
 
 ## AI
 
+The mockup reframes this area: providers are **local CLI coding agents**
+(Codex, Claude, Cursor) that Strata launches as subprocesses, not
+OpenAI-compatible HTTP endpoints. The existing `AIProvider` contract in
+`packages/sdk/src/ai.ts` (`listModels` / `chat` / `embed`) still fits as the
+call surface, but everything about *configuring* an instance is new. Analysis
+itself stays fully offline.
+
 - [x] AI-provider contract + template (OpenAI-compatible / Ollama)
+- [ ] **P1** CLI-agent provider kind — spawn and talk to a coding-agent binary;
+      per-instance binary path, agent home path, shadow home (account-specific
+      home that keeps `auth.json` separate while sharing state), launch args,
+      env vars, and a model id list.
+- [ ] **P1** Provider health checks — resolve the binary, read its version and
+      auth state, list models; run on an interval (*Health check interval*,
+      `0` = manual only) and expose the three states the mockup renders:
+      *Ready*, *Not found*, *Disabled*.
+- [ ] **P1** Provider registry UI — enable/disable, display name, accent colour,
+      env vars, models, plus *Add custom provider*. See the Web UI section.
 - [ ] **P1** "Explain this hotspot / module" action
 - [ ] **P1** Natural-language query over the repo (RAG on the analysis DB + embeddings)
-- [ ] **P1** Provider registry + settings UI (add provider, key, model)
 - [ ] **P2** PR/commit risk assessment
 - [ ] **P2** Auto-generate/refresh architecture docs from the graphs
 
 ## Web UI (`apps/web`)
 
-- [ ] **P0** Scaffold the frontend (Vite + SvelteKit/Next + Tailwind)
-- [ ] **P0** Hotspot treemap view
-- [ ] **P0** Dependency graph view (Cytoscape/d3) with cycle highlighting
-- [ ] **P1** Commit analytics view
-- [ ] **P1** AI provider settings screen
+Design reference: *Strata Web UI* mockup. Design tokens are defined there for
+both themes — dark and light palettes, `--h1…--h5` heat ramp, IBM Plex
+Sans/Mono.
+
+### Shell
+
+- [ ] **P0** Scaffold the frontend (Vite + SvelteKit/Next + Tailwind) and port the
+      mockup's token set as the theme layer (light + dark, both specified)
+- [ ] **P0** App shell — left rail (logo, project switcher, analysis nav, plugin
+      count, settings entries), sticky header (breadcrumb, branch + rev chips,
+      last-run summary, *Re-analyze*), scrollable main pane
+- [ ] **P0** Project switcher — dropdown listing registered projects with file
+      count and last-analysis age, select / remove / *Add project* (which lands on
+      *Project settings → Analyze / run* for the first analysis)
+- [ ] **P1** Cycle count badge on the *Dependencies* nav item, driven by the last run
+- [ ] **P1** Empty and error states — no projects registered, never analysed,
+      analysis failed, plugin threw
+
+### Analysis screens
+
+- [ ] **P0** Overview — six stat cards (files, top hotspot, import cycles, commits,
+      dead code, plugins), top-hotspot bar list, import-cycle alert card with the
+      cycle path, loaded-plugins list, commit-type strip
+- [ ] **P0** Hotspot treemap — heat legend, tiles sized by score and coloured by
+      complexity, plus the ranked table (churn / complexity / LOC / score)
+- [ ] **P0** Dependency graph view (Cytoscape/d3) — local vs. package vs. cycle edge
+      styles, cycle nodes highlighted, side panel with the SCC path and graph
+      summary (nodes, edges, cycles, max fan-in)
+- [ ] **P1** Commit analytics view — by-type bars, breaking + validity stat cards,
+      8-week activity chart, recent-commits table with `BREAKING` markers
+- [ ] **P1** Dead code view — three summary cards and the findings table. Ships
+      behind the mockup's *preview* banner until tree-sitter dead code lands.
+- [ ] **P2** Drill-down: click a treemap tile or graph node → file detail
+      (churn history, complexity, importers/imports, dead symbols)
+
+### Project settings
+
+- [ ] **P0** Settings shell — sidebar swaps to a settings nav with *Back to
+      workbench*, scoped title, and section list
+- [ ] **P0** General — display name, root path (read-only mount), revision, history limit
+- [ ] **P0** Analyze / run — root, revision, history limit, the plugin chips that
+      will run, *Run analysis* (`POST /analyze`), and a recents list
+- [ ] **P1** Scope & ignore — ignore globs and analyze paths as editable chip lists
+- [ ] **P1** Language plugins — per-project toggles with the extensions each one
+      claims; *planned* modules (Angular, PHP) shown disabled
+- [ ] **P1** Metrics & convention — metric toggles plus a
+      `conventional` / `gitmoji` / `custom` convention selector
+- [ ] **P1** Architecture rules — list and edit `X may not import Y` rules with an
+      *enforced* marker
+- [ ] **P1** Danger zone — remove the project from Strata (repo on disk untouched)
+
+### Application settings
+
+- [ ] **P1** Appearance — theme (dark / light / system) and density
+      (dense / balanced / airy)
+- [ ] **P1** Plugins & engine — plugins directory, third-party loading toggle,
+      incremental cache toggle and *Clear cache*
+- [ ] **P1** CI gates — fail on new import cycles, hotspot regression threshold
+- [ ] **P1** AI providers — provider cards with enable toggle, expandable detail
+      (display name, accent colour, env vars, binary path, home path, shadow home,
+      launch args, models), health-check interval stepper, *Add custom provider*
+- [ ] **P2** About — version, licence, links to docs / architecture / backlog
 - [ ] **P2** Multi-repo workspace; saved views
 
 ## CI / delivery
 
 - [x] CI (build/typecheck/lint/test), Conventional Commits enforcement (hook + CI)
 - [x] release-please + multi-arch GHCR image + Linux desktop stub
-- [ ] **P1** Headless CI mode — emit JSON/Markdown report, **fail on thresholds** (hotspot regression, new cycles)
+- [ ] **P1** Headless CI mode — emit JSON/Markdown report, **fail on thresholds**
+      (hotspot regression, new cycles, rule violations), reading the same gate
+      config the *CI gates* screen edits
 - [ ] **P1** Commit the pnpm lockfile and switch CI to `--frozen-lockfile`
+- [ ] **P1** Serve the built web UI from `@strata/server` so the Docker image is a
+      single deployable workbench
 - [ ] **P2** Tauri desktop app under `apps/desktop` (enable the Linux release job)
 - [ ] **P2** Add macOS/Windows to the desktop release matrix (+ signing)
 
@@ -77,4 +202,6 @@ Legend: `[ ]` todo · `[~]` in progress · `[x]` done
 
 - [x] arc42 architecture + per-module docs + Makefile + `analyze`/`new-plugin` scripts
 - [ ] **P1** ADR folder (`docs/adr/`) — promote ADR-1…6 into standalone records
+- [ ] **P1** ADR for the CLI-agent provider model (subprocess + shadow home +
+      secret storage), since it supersedes the HTTP-provider assumption
 - [ ] **P2** Example gallery / screenshots once the UI exists


### PR DESCRIPTION
Reworks `BACKLOG.md` around the **Strata Web UI** design (Claude Design project): a workbench shell with a project switcher, five analysis screens, and a two-scope settings area (project vs. application).

## What changed

**New section — Configuration & persistence.** The mockup's settings screens have nowhere to write to today. Adds the project registry (backs the sidebar switcher, *Add project*, *Remove project*), project- and app-scoped config stores with endpoints, and write-only secret storage for provider env values.

**Promoted to P0**, because the mockup depends on them directly:
- Analysis run metadata on `/analyze` — branch, resolved rev, file count, duration, finished-at. The header chips (`main · @ 4c1249e · 1.82s`) and the overview stat cards read this, and it isn't emitted yet.
- Path allow-listing for the analysed `root` — the UI now lets users register arbitrary project roots.
- Change coupling, commit-analytics aggregates (validity rate, breaking count, weekly activity series), and graph summary stats (node/edge counts, fan-in ranking).

**Web UI section restructured** into Shell / Analysis screens / Project settings / Application settings, one item per mockup screen, with the mockup's design tokens (light + dark, heat ramp) called out as part of the scaffold.

## Note for review

The mockup's *AI providers* screen assumes a different provider model than the SDK does. [`packages/sdk/src/ai.ts`](packages/sdk/src/ai.ts) describes HTTP providers (`"openai"`, `"ollama"`), while the mockup configures **local CLI coding agents** — binary path, `CODEX_HOME`/`CLAUDE_HOME`, a shadow home that keeps `auth.json` separate, launch args, and health checks against a resolved binary version.

This PR treats that as an extension rather than a replacement: the `chat`/`listModels` contract stays as the call surface, with the CLI-agent provider kind, health checks, and registry UI added as new items, plus an ADR item under Docs since it supersedes the HTTP-provider assumption. If CLI agents are meant to *replace* the HTTP contract, that's a larger change to `ai.ts` and the `ai-provider-template` plugin and should be decided before those items are picked up.

Docs-only — no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)