### PR TITLE
feat(core): discover third-party plugins from a user plugins directory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,13 @@ PORT=4000
 # Directory of repositories to analyse (mounted read-only into the container)
 STRATA_REPOS_DIR=./repos
 
+# --- Plugins ----------------------------------------------------------------
+# Drop-in directory for third-party plugins: one subdirectory per plugin, each
+# with a strata.plugin.json (see docs/PLUGINS.md). Built-ins always load first.
+# A directory that does not exist simply means no third-party plugins.
+# Default: <cwd>/.strata/plugins — in the container, /app/.strata/plugins.
+STRATA_PLUGINS_DIR=.strata/plugins
+
 # --- Incremental cache ------------------------------------------------------
 # Where cache.db lives. Relative paths resolve against the *working directory*,
 # so set this explicitly if you run Strata from inside the repo you analyse —

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -21,10 +21,11 @@ Anything marked *(mockup)* exists as a design and needs an implementation.
 - [ ] **P0** Analysis run metadata in the `/analyze` result — branch, resolved rev,
       file count, duration, finished-at. The mockup header (`main · @ 4c1249e ·
       analyzed 2 min ago · 1.82s`) and the overview stat cards read this directly.
-- [x] Third-party plugin discovery — `STRATA_PLUGINS_DIR` is scanned for drop-in
-      plugins alongside the built-ins; `/plugins` reports the directory, each
-      plugin's source, and anything skipped. Surfaced as *Settings → Plugins &
-      engine → Plugins directory*.
+- [x] Third-party plugin discovery (API) — `STRATA_PLUGINS_DIR` is scanned for
+      drop-in plugins alongside the built-ins; `/plugins` reports the directory,
+      each plugin's source, and anything skipped. The *Settings → Plugins &
+      engine → Plugins directory* screen that renders it is still to build
+      (*mockup*), with the UI work below.
 - [ ] **P0** Path allow-listing / sandbox for the `root` a request may analyse —
       a prerequisite now that the UI lets a user register arbitrary project roots.
 - [ ] **P1** Worker queue for heavy analyses (BullMQ / worker_threads); progress

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -21,8 +21,10 @@ Anything marked *(mockup)* exists as a design and needs an implementation.
 - [ ] **P0** Analysis run metadata in the `/analyze` result — branch, resolved rev,
       file count, duration, finished-at. The mockup header (`main · @ 4c1249e ·
       analyzed 2 min ago · 1.82s`) and the overview stat cards read this directly.
-- [ ] **P0** Third-party plugin discovery — load a user plugins directory, not just
-      built-ins. Surfaced as *Settings → Plugins & engine → Plugins directory*.
+- [x] Third-party plugin discovery — `STRATA_PLUGINS_DIR` is scanned for drop-in
+      plugins alongside the built-ins; `/plugins` reports the directory, each
+      plugin's source, and anything skipped. Surfaced as *Settings → Plugins &
+      engine → Plugins directory*.
 - [ ] **P0** Path allow-listing / sandbox for the `root` a request may analyse —
       a prerequisite now that the UI lets a user register arbitrary project roots.
 - [ ] **P1** Worker queue for heavy analyses (BullMQ / worker_threads); progress

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,10 @@ COPY --from=build /out ./
 
 # The incremental cache is written at runtime as `node` — mount a volume here
 # (see compose.yml) to keep it across restarts.
-ENV STRATA_CACHE_DIR=/app/.strata
-RUN mkdir -p /app/.strata && chown node:node /app/.strata
+# Third-party plugins are read from the same volume: drop one directory per
+# plugin into /app/.strata/plugins (see docs/PLUGINS.md).
+ENV STRATA_CACHE_DIR=/app/.strata STRATA_PLUGINS_DIR=/app/.strata/plugins
+RUN mkdir -p /app/.strata/plugins && chown -R node:node /app/.strata
 
 EXPOSE 4000
 USER node

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ place and build. The web UI and richer analyzers are next — see
 **Core**
 - Incremental cache — SQLite, keyed on the git blob sha, so a rerun only
   re-analyses what changed ✅
+- Drop-in third-party plugins from a user plugins directory ✅
 
 **Architecture & AI**
 - Architecture fitness rules ("`ui` may not import `db`") ⏳
@@ -69,6 +70,16 @@ curl -X POST localhost:4000/analyze -H 'content-type: application/json' \
   -d '{"root":"/absolute/path/to/a/repo","cache":false}'
 curl -X DELETE localhost:4000/cache
 ```
+
+```bash
+# what loaded, from where, and anything that was skipped
+curl -s localhost:4000/plugins
+```
+
+Third-party plugins are drop-in: one directory per plugin (with its
+`strata.plugin.json`) under `$STRATA_PLUGINS_DIR`, default
+`<cwd>/.strata/plugins`. Built-ins load first, a plugin that fails to load is
+reported rather than fatal — see [`docs/PLUGINS.md`](docs/PLUGINS.md).
 
 The cache lives in `$STRATA_CACHE_DIR` (default `<cwd>/.strata/cache.db`) —
 keep it out of the repo you analyse, which the server and container defaults

--- a/compose.yml
+++ b/compose.yml
@@ -14,7 +14,9 @@ services:
     volumes:
       # Mount a repo you want to analyse (read-only) at /repos.
       - ${STRATA_REPOS_DIR:-./repos}:/repos:ro
-      # Persist the analysis cache across restarts.
+      # Persist the analysis cache across restarts. Third-party plugins are
+      # read from /app/.strata/plugins, so they live in this volume too — or
+      # mount a host directory there instead (see docs/PLUGINS.md).
       - strata-data:/app/.strata
     restart: unless-stopped
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -69,7 +69,7 @@ the analysed repo.
 
 | Challenge | Decision |
 |-----------|----------|
-| Extensibility | Four small plugin contracts in `@strata/sdk`; a registry loads them by manifest. |
+| Extensibility | Four small plugin contracts in `@strata/sdk`; a registry loads them by manifest — the built-ins, plus drop-in third-party plugins from `STRATA_PLUGINS_DIR`. |
 | One tool, many languages | Parsing standardised on **tree-sitter** grammars (roadmap); analyzers return a common shape. |
 | Big-repo performance | Blob-sha-keyed incremental cache (SQLite) in the core. |
 | Portability | Web frontend + thin API, packaged as a Docker image now and Tauri desktop later. |
@@ -87,6 +87,7 @@ strata/
 │   │              language, commit, metric, ai, cache, manifest, logger)
 │   ├── core/     @strata/core    Orchestrator: git ingest, registry, pipeline
 │   │              strata.ts · types.ts · logger.ts · registry.ts ·
+│   │              manifest.ts · discover.ts · plugins-dir.ts ·
 │   │              git/ (exec, rev, files, history, churn) ·
 │   │              cache/ (types, schema, sqlite, null, open, keys, digest, …)
 │   └── server/   @strata/server  Fastify HTTP API over the core
@@ -212,7 +213,7 @@ publish. The Linux desktop job is still a stub — it produces no bundle until
 
 | Quality | Scenario | Target |
 |---------|----------|--------|
-| Extensibility | Add a Python language plugin | No core change; only a new `plugins/*` package. |
+| Extensibility | Add a Python language plugin | No core change; only a new `plugins/*` package — or, from outside this repo, a directory dropped into `STRATA_PLUGINS_DIR`. |
 | Performance | Re-analyse a 50k-file repo after a 1-file change | Only that file re-parsed; an unchanged repo skips the plugins entirely. |
 | Correctness | Import cycles in TS | All SCCs > 1 node reported. |
 | Portability | Fresh machine with Docker | `docker run` yields a working API. |
@@ -225,6 +226,7 @@ publish. The Linux desktop job is still a stub — it produces no bundle until
 | Cache is only as pure as its plugins | A `cache.file()` value that depends on more than the file's contents goes stale | Contract documented in the SDK; plugin version is part of the key, `DELETE /cache` is the escape hatch. |
 | Complexity proxy is indentation-based | Rough hotspot scores | Feed real cyclomatic complexity from language plugins. |
 | Web UI not scaffolded | No visual output yet | Build `apps/web` (see backlog). |
+| Third-party plugins run in-process | A plugin has the server's privileges | Manifest/entry validation and id protection on load; installing one is a trust decision, and the plugins directory is operator-controlled. Isolation is a later step. |
 | Vouch-bot needs push to `main` | May hit branch protection | Bypass entry or PR-mode fallback (documented). |
 
 ## 12. Glossary

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -1,13 +1,14 @@
 # Writing a plugin
 
-A plugin is a workspace package with:
+A plugin is a package with:
 
 1. a `strata.plugin.json` manifest, and
 2. a module whose **default export** is built with one of the `define*` helpers
    from `@strata/sdk`.
 
 The core loads the manifest, checks the `sdk` major matches, imports `main`,
-and registers the default export by its `kind`.
+and registers the default export by its `kind`. It does not have to live in
+this repo — see [Installing a plugin](#installing-a-plugin).
 
 ## Manifest
 
@@ -106,15 +107,58 @@ Rules of the road:
 The core also caches whole plugin results, so if nothing in your input changed
 you won't be called at all.
 
+## Installing a plugin
+
+Third-party plugins are **drop-in**: one directory per plugin under the user
+plugins directory, each holding its `strata.plugin.json`.
+
+```
+~/.strata/plugins/            # $STRATA_PLUGINS_DIR
+├── strata-language-python/
+│   ├── strata.plugin.json
+│   └── dist/index.js
+└── strata-metric-coupling/   # a symlink to a checkout works too
+```
+
+```bash
+STRATA_PLUGINS_DIR=~/.strata/plugins pnpm --filter @strata/server start
+curl -s localhost:4000/plugins   # → { directory, plugins[], failures[] }
+```
+
+The directory defaults to `<cwd>/.strata/plugins` (in the container,
+`/app/.strata/plugins` — mount a volume there). A directory that does not exist
+means "nothing installed", not an error. Only the immediate subdirectories are
+scanned; nesting is not searched.
+
+What the loader enforces, because a drop-in plugin is not first-party code:
+
+- Every manifest field is validated, and the `kind` must be one of the four.
+- `main` is resolved **inside the plugin's own directory** — it may not point
+  anywhere else on the host.
+- The exported `kind` must match the manifest's.
+- Ids are unique and **first one wins**; built-ins load first, so a drop-in can
+  never take over an id Strata ships with.
+- A plugin that trips any of these is skipped, not fatal. It shows up in
+  `failures[]` on `GET /plugins` (and as a warning on startup) with the reason.
+
+Imports are resolved from the plugin's own directory, so ship it built, with
+its runtime dependencies bundled or vendored next to it. `@strata/sdk`'s
+`define*` helpers are compile-time only — nothing in a built plugin needs to
+import the SDK at runtime.
+
+`GET /plugins` also tags each entry with `source: "builtin" | "user"`, which is
+what *Settings → Plugins & engine* renders.
+
 ## Local development
 
 ```bash
 pnpm --filter @strata/plugin-<name> build
 ```
 
-First-party plugins are auto-discovered by `@strata/server`. A user plugins
-directory (drop-in third-party plugins) is on the roadmap — the loader
-(`PluginRegistry.loadFrom`) already takes an arbitrary manifest path.
+First-party plugins in this repo are auto-discovered by `@strata/server`. To
+test a plugin developed elsewhere, symlink its directory into the plugins
+directory and restart — discovery follows symlinks, so a rebuild is all that is
+needed between runs. Discovery happens once at startup.
 
 ## Versioning
 

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -135,16 +135,19 @@ What the loader enforces, because a drop-in plugin is not first-party code:
 - Every manifest field is validated, and the `kind` must be one of the four.
 - `main` is resolved **inside the plugin's own directory** — it may not point
   anywhere else on the host.
-- The exported `kind` must match the manifest's.
+- The exported `kind` must match the manifest's, and the export must actually
+  implement that kind (a `language` plugin without `analyze()` is refused at
+  load rather than throwing mid-analysis).
 - Ids are unique and **first one wins**; built-ins load first, so a drop-in can
   never take over an id Strata ships with.
 - A plugin that trips any of these is skipped, not fatal. It shows up in
   `failures[]` on `GET /plugins` (and as a warning on startup) with the reason.
 
-Imports are resolved from the plugin's own directory, so ship it built, with
-its runtime dependencies bundled or vendored next to it. `@strata/sdk`'s
-`define*` helpers are compile-time only — nothing in a built plugin needs to
-import the SDK at runtime.
+Imports are resolved from the plugin's own directory, so ship the plugin built,
+with its dependencies resolvable from there — its own `node_modules`, or bundled
+into the entry. That includes **`@strata/sdk`**: the `define*` helpers are
+ordinary functions that survive compilation, so a plugin built with `tsc` still
+imports the SDK at runtime.
 
 `GET /plugins` also tags each entry with `source: "builtin" | "user"`, which is
 what *Settings → Plugins & engine* renders.
@@ -155,8 +158,9 @@ what *Settings → Plugins & engine* renders.
 pnpm --filter @strata/plugin-<name> build
 ```
 
-First-party plugins in this repo are auto-discovered by `@strata/server`. To
-test a plugin developed elsewhere, symlink its directory into the plugins
+First-party plugins are loaded from the `BUILTINS` manifest list in
+`packages/server/src/registry.ts` — a new one in this repo needs a line there.
+To test a plugin developed elsewhere, symlink its directory into the plugins
 directory and restart — discovery follows symlinks, so a rebuild is all that is
 needed between runs. Discovery happens once at startup.
 

--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -11,7 +11,9 @@ to plugins. This is the only module that knows about all four plugin kinds.
 ## 2. Constraints
 
 - Reads git by shelling out to the `git` binary (must be on PATH).
-- Hands plugins nothing but a `RepoContext` — no direct fs/network leakage.
+- Hands plugins nothing but a `RepoContext` — the core injects no fs or network
+  APIs. That is an interface contract, **not a sandbox**: a plugin runs
+  in-process and can import `node:fs` itself (see §7).
 - Pure in → out per file, so results stay cacheable/incremental.
 
 ## 3. Interfaces (Context)
@@ -31,6 +33,7 @@ to plugins. This is the only module that knows about all four plugin kinds.
 | `logger.ts` | `createConsoleLogger(scope)` — what `RepoContext.log` gets. |
 | `registry.ts` | `PluginRegistry` — load plugins, contain load failures, `byKind()` / `loadedByKind()`. |
 | `manifest.ts` | `readManifest()` / `resolveEntry()` — validate a `strata.plugin.json` and its entry path. |
+| `plugin-shape.ts` | `pluginShapeError()` — does the module implement the kind it claims? |
 | `discover.ts` | `discoverPlugins(dir)` — the manifests installed in a plugins directory. |
 | `plugins-dir.ts` | `userPluginsDir()` — where drop-in plugins live (`STRATA_PLUGINS_DIR`). |
 | `git/exec.ts` | Run a read-only git command. |
@@ -61,9 +64,11 @@ to plugins. This is the only module that knows about all four plugin kinds.
 - **Extension-based routing** for language plugins (simple, fast).
 - **Third-party plugins are drop-in, and nothing about them is trusted** — one
   directory per plugin under `userPluginsDir()`, every manifest field validated,
-  `main` confined to the plugin's own directory, the exported kind checked
-  against the manifest. Built-ins load first and ids are first-one-wins, so a
-  drop-in cannot shadow one. A plugin that fails any check is recorded in
+  `main` confined to the plugin's own directory, the export checked both for the
+  kind it claims and for the members that kind must implement — a plugin that
+  would throw mid-analysis never registers. Built-ins load first and ids are
+  first-one-wins, so a drop-in cannot shadow one. A plugin that fails any check
+  is recorded in
   `registry.failures()` rather than thrown: a broken third-party plugin must
   cost only itself, not the process.
 - **First-registered commit convention wins** (single active convention).

--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -19,7 +19,7 @@ to plugins. This is the only module that knows about all four plugin kinds.
 - **Depends on:** `@strata/sdk` (contracts), `git` CLI.
 - **Consumed by:** `@strata/server` (and `scripts/analyze.mjs`).
 - **Public API:** `Strata.analyze(opts) → AnalysisReport`, `PluginRegistry`,
-  `gitUtil` helpers.
+  `discoverPlugins()` / `userPluginsDir()`, `gitUtil` helpers.
 
 ## 4. Building Blocks
 
@@ -29,7 +29,10 @@ to plugins. This is the only module that knows about all four plugin kinds.
 | `strata.ts` | The `Strata` orchestrator. |
 | `types.ts` | `AnalyzeOptions`, `StrataOptions`, `AnalysisReport`, `CacheReport`. |
 | `logger.ts` | `createConsoleLogger(scope)` — what `RepoContext.log` gets. |
-| `registry.ts` | `PluginRegistry` — load manifests, SDK-major check, `byKind()` / `loadedByKind()`. |
+| `registry.ts` | `PluginRegistry` — load plugins, contain load failures, `byKind()` / `loadedByKind()`. |
+| `manifest.ts` | `readManifest()` / `resolveEntry()` — validate a `strata.plugin.json` and its entry path. |
+| `discover.ts` | `discoverPlugins(dir)` — the manifests installed in a plugins directory. |
+| `plugins-dir.ts` | `userPluginsDir()` — where drop-in plugins live (`STRATA_PLUGINS_DIR`). |
 | `git/exec.ts` | Run a read-only git command. |
 | `git/rev.ts` | `resolveRev` — revision → sha. |
 | `git/files.ts` | `listFiles` — tracked files with blob shas. |
@@ -56,6 +59,13 @@ to plugins. This is the only module that knows about all four plugin kinds.
 ## 6. Decisions
 
 - **Extension-based routing** for language plugins (simple, fast).
+- **Third-party plugins are drop-in, and nothing about them is trusted** — one
+  directory per plugin under `userPluginsDir()`, every manifest field validated,
+  `main` confined to the plugin's own directory, the exported kind checked
+  against the manifest. Built-ins load first and ids are first-one-wins, so a
+  drop-in cannot shadow one. A plugin that fails any check is recorded in
+  `registry.failures()` rather than thrown: a broken third-party plugin must
+  cost only itself, not the process.
 - **First-registered commit convention wins** (single active convention).
 - **Blob sha on every file**, so the cache keys on content, not on paths or
   timestamps.
@@ -82,3 +92,9 @@ to plugins. This is the only module that knows about all four plugin kinds.
   last-used stamp and are pruned after 30 days on open.
 - **Risk:** `git` output parsing edge cases (root commit, renames). **Mitigation:**
   record-separator parsing; covered by analysis smoke runs.
+- **Risk:** a plugin runs **in-process, with the server's privileges** — the
+  validation above stops a malformed or misdeclared plugin, not a malicious
+  one, and installing a plugin is as much a trust decision as installing a
+  dependency. **Mitigation:** the plugins directory is operator-controlled and
+  local-only (nothing installs plugins over the network); isolation (worker
+  threads / permissions) is a later step.

--- a/packages/core/src/discover.ts
+++ b/packages/core/src/discover.ts
@@ -1,0 +1,44 @@
+import { readdir, stat } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { MANIFEST_FILENAME } from './manifest.js';
+
+/**
+ * List the manifests of every plugin installed in a plugins directory: one
+ * plugin per immediate subdirectory, holding a `strata.plugin.json`.
+ *
+ * A directory that does not exist yields nothing rather than throwing — most
+ * installs never drop a third-party plugin in, and that is not an error. Paths
+ * come back sorted so load order (and therefore which plugin wins an id clash)
+ * does not depend on the filesystem.
+ */
+export async function discoverPlugins(dir: string): Promise<string[]> {
+  const root = resolve(dir);
+  let entries: string[];
+  try {
+    entries = await readdir(root);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw new Error(
+      `plugins directory ${root} is not readable: ${(err as Error).message}`,
+      { cause: err },
+    );
+  }
+
+  const manifests: string[] = [];
+  for (const name of entries.sort()) {
+    // Testing for the manifest is the whole check: it filters stray files and
+    // follows a symlinked plugin directory, which is how you develop against a
+    // checkout without copying it in.
+    const manifestPath = join(root, name, MANIFEST_FILENAME);
+    if (await isFile(manifestPath)) manifests.push(manifestPath);
+  }
+  return manifests;
+}
+
+async function isFile(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isFile();
+  } catch {
+    return false;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,7 +6,19 @@
  * package's public surface.
  */
 export { Strata } from './strata.js';
-export { PluginRegistry, type LoadedPlugin } from './registry.js';
+export {
+  PluginRegistry,
+  type LoadedPlugin,
+  type PluginLoadFailure,
+  type PluginSource,
+} from './registry.js';
+export { discoverPlugins } from './discover.js';
+export { userPluginsDir } from './plugins-dir.js';
+export {
+  readManifest,
+  resolveEntry,
+  MANIFEST_FILENAME,
+} from './manifest.js';
 export { createConsoleLogger, consoleLogger } from './logger.js';
 export type {
   AnalysisReport,

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises';
-import { dirname, isAbsolute, relative, resolve } from 'node:path';
+import { dirname, isAbsolute, relative, resolve, sep } from 'node:path';
 import { PLUGIN_KINDS, SDK_VERSION, type PluginManifest } from '@strata/sdk';
 
 /** The file that marks a directory as a plugin. */
@@ -69,8 +69,9 @@ export function resolveEntry(
 ): string {
   const dir = dirname(resolve(manifestPath));
   const entry = resolve(dir, manifest.main);
+  // Only a leading `..` *segment* escapes; a child named `..lib` does not.
   const rel = relative(dir, entry);
-  if (rel === '' || rel.startsWith('..') || isAbsolute(rel)) {
+  if (rel === '' || rel === '..' || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
     throw new Error(
       `Plugin "${manifest.id}" has a "main" (${manifest.main}) outside its own directory.`,
     );

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -1,0 +1,87 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, isAbsolute, relative, resolve } from 'node:path';
+import { PLUGIN_KINDS, SDK_VERSION, type PluginManifest } from '@strata/sdk';
+
+/** The file that marks a directory as a plugin. */
+export const MANIFEST_FILENAME = 'strata.plugin.json';
+
+const REQUIRED_FIELDS = [
+  'id',
+  'name',
+  'kind',
+  'version',
+  'sdk',
+  'main',
+] as const satisfies readonly (keyof PluginManifest)[];
+
+/**
+ * Read and validate a `strata.plugin.json`. Built-ins are ours, but a manifest
+ * in the user plugins directory is hand-written by a third party, so every
+ * field is checked here rather than trusted and cast.
+ */
+export async function readManifest(
+  manifestPath: string,
+): Promise<PluginManifest> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await readFile(manifestPath, 'utf8'));
+  } catch (err) {
+    throw new Error(`${manifestPath} is not readable JSON: ${message(err)}`, {
+      cause: err,
+    });
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`${manifestPath} must contain a JSON object.`);
+  }
+
+  const fields = parsed as Record<string, unknown>;
+  for (const field of REQUIRED_FIELDS) {
+    const value = fields[field];
+    if (typeof value !== 'string' || value.trim() === '') {
+      throw new Error(`${manifestPath} is missing a "${field}" string.`);
+    }
+  }
+
+  const manifest = parsed as PluginManifest;
+  if (!(PLUGIN_KINDS as readonly string[]).includes(manifest.kind)) {
+    throw new Error(
+      `Plugin "${manifest.id}" declares unknown kind "${manifest.kind}" ` +
+        `(expected one of ${PLUGIN_KINDS.join(', ')}).`,
+    );
+  }
+  if (major(manifest.sdk) !== major(SDK_VERSION)) {
+    throw new Error(
+      `Plugin "${manifest.id}" targets SDK ${manifest.sdk}, ` +
+        `but this build ships SDK ${SDK_VERSION}.`,
+    );
+  }
+  return manifest;
+}
+
+/**
+ * Absolute path of the module to import for a manifest. `main` is resolved
+ * against the plugin's own directory and must stay inside it — a drop-in
+ * plugin does not get to point the loader at an arbitrary file on the host.
+ */
+export function resolveEntry(
+  manifestPath: string,
+  manifest: PluginManifest,
+): string {
+  const dir = dirname(resolve(manifestPath));
+  const entry = resolve(dir, manifest.main);
+  const rel = relative(dir, entry);
+  if (rel === '' || rel.startsWith('..') || isAbsolute(rel)) {
+    throw new Error(
+      `Plugin "${manifest.id}" has a "main" (${manifest.main}) outside its own directory.`,
+    );
+  }
+  return entry;
+}
+
+function major(version: string): string {
+  return version.split('.')[0] ?? version;
+}
+
+function message(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/core/src/plugin-shape.ts
+++ b/packages/core/src/plugin-shape.ts
@@ -1,0 +1,44 @@
+import type { PluginKind } from '@strata/sdk';
+
+/**
+ * What the orchestrator dereferences on a plugin of each kind. The manifest
+ * only says what a module claims to be; this is the module delivering it.
+ */
+const REQUIRED: Record<PluginKind, readonly Member[]> = {
+  language: [
+    ['extensions', 'array'],
+    ['analyze', 'function'],
+  ],
+  'commit-convention': [['parse', 'function']],
+  'git-metric': [['compute', 'function']],
+  'ai-provider': [
+    ['listModels', 'function'],
+    ['chat', 'function'],
+  ],
+};
+
+type Member = readonly [name: string, type: 'array' | 'function'];
+
+/**
+ * Why `value` is not a usable plugin of `kind`, or `null` if it is. Checked at
+ * load time on purpose: a half-written plugin that passes its manifest would
+ * otherwise register fine and throw in the middle of an analysis, taking the
+ * whole run down with it.
+ */
+export function pluginShapeError(
+  kind: PluginKind,
+  value: object,
+): string | null {
+  const members = value as Record<string, unknown>;
+  for (const [name, type] of REQUIRED[kind]) {
+    const member = members[name];
+    const ok =
+      type === 'array' ? Array.isArray(member) : typeof member === 'function';
+    if (!ok) {
+      return type === 'array'
+        ? `is missing the "${name}" array every ${kind} plugin must expose`
+        : `is missing ${name}(), which every ${kind} plugin must implement`;
+    }
+  }
+  return null;
+}

--- a/packages/core/src/plugins-dir.ts
+++ b/packages/core/src/plugins-dir.ts
@@ -1,0 +1,19 @@
+import { resolve } from 'node:path';
+
+/**
+ * Default location, relative to the working directory — in the container that
+ * is `/app/.strata/plugins`, inside the volume that already survives restarts.
+ */
+const DEFAULT_DIR = '.strata/plugins';
+
+/**
+ * Where drop-in third-party plugins live: `STRATA_PLUGINS_DIR`, else
+ * `<cwd>/.strata/plugins`. Always absolute, and not required to exist — the
+ * loader treats a missing directory as "no third-party plugins installed".
+ *
+ * Surfaced in the UI as *Settings → Plugins & engine → Plugins directory*.
+ */
+export function userPluginsDir(): string {
+  const configured = process.env.STRATA_PLUGINS_DIR?.trim();
+  return resolve(configured || DEFAULT_DIR);
+}

--- a/packages/core/src/registry.test.ts
+++ b/packages/core/src/registry.test.ts
@@ -1,0 +1,237 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Logger, PluginKind } from '@strata/sdk';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { PluginRegistry } from './registry.js';
+
+/**
+ * Third-party plugin discovery: a user plugins directory is scanned the same
+ * way built-ins are, but nothing in it is trusted — a broken, hostile or
+ * clashing plugin must cost only itself.
+ */
+
+const silent: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+let dir: string;
+
+/** The recorded skip reasons — asserting on these also pins their count. */
+function errors(registry: PluginRegistry): string[] {
+  return registry.failures().map((f) => f.error);
+}
+
+const PLUGIN_SOURCE = (kind: PluginKind) => `export default {
+  kind: ${JSON.stringify(kind)},
+  extensions: ['ts'],
+  convention: 'test',
+  id: 'test',
+  async analyze() { return { graph: { nodes: [], edges: [], cycles: [] }, deadCode: [], metrics: [] }; },
+  async compute() { return { id: 'test', label: 'Test', points: [] }; },
+  parse() { return { type: 'feat', breaking: false, subject: '', tags: [], valid: true }; },
+};
+`;
+
+/** Write a plugin directory; `manifest` overrides merge into a valid manifest. */
+function writePlugin(
+  name: string,
+  overrides: Record<string, unknown> = {},
+  kind: PluginKind = 'language',
+): string {
+  const pluginDir = join(dir, name);
+  mkdirSync(pluginDir, { recursive: true });
+  writeFileSync(join(pluginDir, 'index.js'), PLUGIN_SOURCE(kind));
+  writeFileSync(
+    join(pluginDir, 'strata.plugin.json'),
+    JSON.stringify({
+      id: `strata-${name}`,
+      name,
+      kind,
+      version: '0.1.0',
+      sdk: '0.1.0',
+      main: './index.js',
+      ...overrides,
+    }),
+  );
+  return pluginDir;
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'strata-plugins-'));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('loadDirectory', () => {
+  it('loads every installed plugin, tagged as third-party', async () => {
+    writePlugin('alpha');
+    writePlugin('beta', {}, 'git-metric');
+
+    const registry = new PluginRegistry(silent);
+    const loaded = await registry.loadDirectory(dir);
+
+    expect(loaded.map((l) => l.manifest.id)).toEqual([
+      'strata-alpha',
+      'strata-beta',
+    ]);
+    expect(loaded.every((l) => l.source === 'user')).toBe(true);
+    expect(registry.byKind('language')).toHaveLength(1);
+    expect(registry.byKind('git-metric')).toHaveLength(1);
+    expect(registry.failures()).toEqual([]);
+  });
+
+  it('ignores directories without a manifest', async () => {
+    writePlugin('alpha');
+    mkdirSync(join(dir, 'node_modules', 'left-over'), { recursive: true });
+    writeFileSync(join(dir, 'README.md'), '# not a plugin');
+
+    const registry = new PluginRegistry(silent);
+    const loaded = await registry.loadDirectory(dir);
+
+    expect(loaded).toHaveLength(1);
+    expect(registry.failures()).toEqual([]);
+  });
+
+  it('follows a symlinked plugin directory', async () => {
+    const source = writePlugin('alpha');
+    const other = mkdtempSync(join(tmpdir(), 'strata-link-'));
+    try {
+      symlinkSync(source, join(other, 'linked'), 'dir');
+      const registry = new PluginRegistry(silent);
+      expect(await registry.loadDirectory(other)).toHaveLength(1);
+    } finally {
+      rmSync(other, { recursive: true, force: true });
+    }
+  });
+
+  it('treats a missing directory as no plugins installed', async () => {
+    const registry = new PluginRegistry(silent);
+
+    expect(await registry.loadDirectory(join(dir, 'nope'))).toEqual([]);
+    expect(registry.failures()).toEqual([]);
+  });
+
+  it('keeps loading after a broken plugin, and records why it was skipped', async () => {
+    writePlugin('broken', { sdk: '9.0.0' });
+    writePlugin('good');
+
+    const registry = new PluginRegistry(silent);
+    const loaded = await registry.loadDirectory(dir);
+
+    expect(loaded.map((l) => l.manifest.id)).toEqual(['strata-good']);
+    expect(registry.failures()).toEqual([
+      {
+        manifestPath: join(dir, 'broken', 'strata.plugin.json'),
+        source: 'user',
+        error: expect.stringMatching(/targets SDK 9\.0\.0/),
+      },
+    ]);
+  });
+});
+
+describe('rejected plugins', () => {
+  it('rejects a manifest missing a required field', async () => {
+    writePlugin('alpha', { main: undefined });
+
+    const registry = new PluginRegistry(silent);
+    await registry.loadDirectory(dir);
+
+    expect(errors(registry)).toEqual([
+      expect.stringMatching(/missing a "main" string/),
+    ]);
+  });
+
+  it('rejects an unknown kind', async () => {
+    writePlugin('alpha', { kind: 'wat' });
+
+    const registry = new PluginRegistry(silent);
+    await registry.loadDirectory(dir);
+
+    expect(errors(registry)).toEqual([
+      expect.stringMatching(/unknown kind "wat"/),
+    ]);
+  });
+
+  it('rejects a "main" pointing outside the plugin directory', async () => {
+    writePlugin('alpha', { main: '../escape.js' });
+    writeFileSync(join(dir, 'escape.js'), 'export default { kind: "language" };');
+
+    const registry = new PluginRegistry(silent);
+    await registry.loadDirectory(dir);
+
+    expect(registry.all()).toEqual([]);
+    expect(errors(registry)).toEqual([
+      expect.stringMatching(/outside its own directory/),
+    ]);
+  });
+
+  it('rejects a module whose exported kind contradicts its manifest', async () => {
+    const pluginDir = writePlugin('alpha');
+    writeFileSync(join(pluginDir, 'index.js'), PLUGIN_SOURCE('ai-provider'));
+
+    const registry = new PluginRegistry(silent);
+    await registry.loadDirectory(dir);
+
+    expect(errors(registry)).toEqual([
+      expect.stringMatching(
+        /declared as kind "language" but exports kind "ai-provider"/,
+      ),
+    ]);
+  });
+
+  it('rejects a module with no default export', async () => {
+    const pluginDir = writePlugin('alpha');
+    writeFileSync(join(pluginDir, 'index.js'), 'export const nope = 1;');
+
+    const registry = new PluginRegistry(silent);
+    await registry.loadDirectory(dir);
+
+    expect(errors(registry)).toEqual([
+      expect.stringMatching(/must default-export/),
+    ]);
+  });
+
+  it('refuses to let a third-party plugin shadow a loaded id', async () => {
+    writePlugin('alpha');
+    writePlugin('copycat', { id: 'strata-alpha' });
+
+    const registry = new PluginRegistry(silent);
+    const loaded = await registry.loadDirectory(dir);
+
+    expect(loaded.map((l) => l.manifestPath)).toEqual([
+      join(dir, 'alpha', 'strata.plugin.json'),
+    ]);
+    expect(errors(registry)).toEqual([
+      expect.stringMatching(/already loaded from/),
+    ]);
+  });
+});
+
+describe('loadFrom', () => {
+  it('throws rather than recording, so a built-in failure is not silent', async () => {
+    const pluginDir = writePlugin('alpha', { sdk: '9.0.0' });
+
+    const registry = new PluginRegistry(silent);
+    await expect(
+      registry.loadFrom(join(pluginDir, 'strata.plugin.json')),
+    ).rejects.toThrow(/targets SDK 9\.0\.0/);
+    expect(registry.failures()).toEqual([]);
+  });
+
+  it('defaults to the built-in source', async () => {
+    const pluginDir = writePlugin('alpha');
+
+    const registry = new PluginRegistry(silent);
+    const loaded = await registry.loadFrom(
+      join(pluginDir, 'strata.plugin.json'),
+    );
+
+    expect(loaded.source).toBe('builtin');
+  });
+});

--- a/packages/core/src/registry.test.ts
+++ b/packages/core/src/registry.test.ts
@@ -171,6 +171,16 @@ describe('rejected plugins', () => {
     ]);
   });
 
+  it('allows an entry in a child directory whose name starts with ..', async () => {
+    const pluginDir = writePlugin('alpha', { main: './..lib/index.js' });
+    mkdirSync(join(pluginDir, '..lib'));
+    writeFileSync(join(pluginDir, '..lib', 'index.js'), PLUGIN_SOURCE('language'));
+
+    const registry = new PluginRegistry(silent);
+
+    expect(await registry.loadDirectory(dir)).toHaveLength(1);
+  });
+
   it('rejects a module whose exported kind contradicts its manifest', async () => {
     const pluginDir = writePlugin('alpha');
     writeFileSync(join(pluginDir, 'index.js'), PLUGIN_SOURCE('ai-provider'));
@@ -182,6 +192,23 @@ describe('rejected plugins', () => {
       expect.stringMatching(
         /declared as kind "language" but exports kind "ai-provider"/,
       ),
+    ]);
+  });
+
+  it('rejects a plugin that is missing what its kind must implement', async () => {
+    const pluginDir = writePlugin('alpha');
+    // Passes the manifest and the kind check, but would throw mid-analysis.
+    writeFileSync(
+      join(pluginDir, 'index.js'),
+      'export default { kind: "language", extensions: ["ts"] };',
+    );
+
+    const registry = new PluginRegistry(silent);
+    await registry.loadDirectory(dir);
+
+    expect(registry.all()).toEqual([]);
+    expect(errors(registry)).toEqual([
+      expect.stringMatching(/is missing analyze\(\)/),
     ]);
   });
 

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -1,42 +1,132 @@
-import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { dirname, resolve } from 'node:path';
-import { SDK_VERSION, type PluginManifest, type StrataPlugin } from '@strata/sdk';
+import type { Logger, PluginManifest, StrataPlugin } from '@strata/sdk';
+import { discoverPlugins } from './discover.js';
+import { createConsoleLogger } from './logger.js';
+import { readManifest, resolveEntry } from './manifest.js';
+
+/** Where a plugin came from: shipped with Strata, or dropped in by the user. */
+export type PluginSource = 'builtin' | 'user';
 
 /** A loaded plugin paired with the manifest it came from. */
 export interface LoadedPlugin {
   manifest: PluginManifest;
   plugin: StrataPlugin;
+  source: PluginSource;
+  /** Absolute path of the manifest, so the UI can say where it came from. */
+  manifestPath: string;
+}
+
+/** A plugin that was found but could not be loaded, and why. */
+export interface PluginLoadFailure {
+  manifestPath: string;
+  source: PluginSource;
+  error: string;
 }
 
 /**
  * Holds every plugin the app knows about and lets the orchestrator look them
- * up by kind. Plugins are discovered from `strata.plugin.json` manifests.
+ * up by kind. Plugins are discovered from `strata.plugin.json` manifests —
+ * the built-ins that ship with Strata and, through `loadDirectory`, whatever a
+ * user installed in their plugins directory.
+ *
+ * A third-party plugin that fails to load must never take the app down with
+ * it, so `load`/`loadDirectory` contain the error and record it in `failures()`.
  */
 export class PluginRegistry {
   private readonly plugins: LoadedPlugin[] = [];
+  private readonly loadFailures: PluginLoadFailure[] = [];
 
-  /** Load a plugin from the directory containing its `strata.plugin.json`. */
-  async loadFrom(manifestPath: string): Promise<LoadedPlugin> {
-    const manifest = JSON.parse(
-      await readFile(manifestPath, 'utf8'),
-    ) as PluginManifest;
+  constructor(
+    private readonly log: Logger = createConsoleLogger('strata:plugins'),
+  ) {}
 
-    const wantMajor = SDK_VERSION.split('.')[0];
-    const gotMajor = String(manifest.sdk).split('.')[0];
-    if (wantMajor !== gotMajor) {
+  /**
+   * Load a plugin from its `strata.plugin.json`. Throws if the manifest is
+   * invalid, targets another SDK major, clashes with a loaded id, or does not
+   * export what it declares.
+   */
+  async loadFrom(
+    manifestPath: string,
+    source: PluginSource = 'builtin',
+  ): Promise<LoadedPlugin> {
+    const path = resolve(manifestPath);
+    const manifest = await readManifest(path);
+
+    // First one wins, and built-ins load first: a drop-in plugin can neither
+    // shadow a first-party id nor silently replace another third-party plugin.
+    const clash = this.plugins.find((l) => l.manifest.id === manifest.id);
+    if (clash) {
       throw new Error(
-        `Plugin "${manifest.id}" targets SDK ${manifest.sdk}, ` +
-          `but this build ships SDK ${SDK_VERSION}.`,
+        `Plugin id "${manifest.id}" is already loaded from ${clash.manifestPath}.`,
       );
     }
 
-    const entry = resolve(dirname(manifestPath), manifest.main);
+    const entry = resolveEntry(path, manifest);
     const mod = (await import(pathToFileURL(entry).href)) as {
-      default: StrataPlugin;
+      default?: unknown;
     };
-    const loaded: LoadedPlugin = { manifest, plugin: mod.default };
+    const plugin = mod.default;
+    if (!isPlugin(plugin)) {
+      throw new Error(
+        `Plugin "${manifest.id}" (${entry}) must default-export a plugin object ` +
+          `built with one of the SDK's define* helpers.`,
+      );
+    }
+    if (plugin.kind !== manifest.kind) {
+      throw new Error(
+        `Plugin "${manifest.id}" is declared as kind "${manifest.kind}" ` +
+          `but exports kind "${plugin.kind}".`,
+      );
+    }
+
+    const loaded: LoadedPlugin = {
+      manifest,
+      plugin,
+      source,
+      manifestPath: path,
+    };
     this.plugins.push(loaded);
+    return loaded;
+  }
+
+  /**
+   * `loadFrom` that never throws: on failure it warns, records the reason and
+   * returns `null`, so one broken plugin costs only itself.
+   */
+  async load(
+    manifestPath: string,
+    source: PluginSource = 'builtin',
+  ): Promise<LoadedPlugin | null> {
+    try {
+      return await this.loadFrom(manifestPath, source);
+    } catch (err) {
+      this.fail(resolve(manifestPath), source, err);
+      return null;
+    }
+  }
+
+  /**
+   * Load every plugin installed in a plugins directory. A missing directory
+   * loads nothing; an unreadable one is recorded as a failure.
+   */
+  async loadDirectory(
+    dir: string,
+    source: PluginSource = 'user',
+  ): Promise<LoadedPlugin[]> {
+    let manifests: string[];
+    try {
+      manifests = await discoverPlugins(dir);
+    } catch (err) {
+      this.fail(resolve(dir), source, err);
+      return [];
+    }
+
+    const loaded: LoadedPlugin[] = [];
+    for (const manifestPath of manifests) {
+      const plugin = await this.load(manifestPath, source);
+      if (plugin) loaded.push(plugin);
+    }
     return loaded;
   }
 
@@ -62,4 +152,27 @@ export class PluginRegistry {
   all(): readonly LoadedPlugin[] {
     return this.plugins;
   }
+
+  /** Plugins that were found but skipped — surfaced in the settings UI. */
+  failures(): readonly PluginLoadFailure[] {
+    return this.loadFailures;
+  }
+
+  private fail(
+    manifestPath: string,
+    source: PluginSource,
+    err: unknown,
+  ): void {
+    const error = err instanceof Error ? err.message : String(err);
+    this.log.warn(`skipped ${manifestPath}: ${error}`);
+    this.loadFailures.push({ manifestPath, source, error });
+  }
+}
+
+function isPlugin(value: unknown): value is StrataPlugin {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { kind?: unknown }).kind === 'string'
+  );
 }

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -4,6 +4,7 @@ import type { Logger, PluginManifest, StrataPlugin } from '@strata/sdk';
 import { discoverPlugins } from './discover.js';
 import { createConsoleLogger } from './logger.js';
 import { readManifest, resolveEntry } from './manifest.js';
+import { pluginShapeError } from './plugin-shape.js';
 
 /** Where a plugin came from: shipped with Strata, or dropped in by the user. */
 export type PluginSource = 'builtin' | 'user';
@@ -78,6 +79,10 @@ export class PluginRegistry {
         `Plugin "${manifest.id}" is declared as kind "${manifest.kind}" ` +
           `but exports kind "${plugin.kind}".`,
       );
+    }
+    const shapeError = pluginShapeError(manifest.kind, plugin);
+    if (shapeError) {
+      throw new Error(`Plugin "${manifest.id}" (${entry}) ${shapeError}.`);
     }
 
     const loaded: LoadedPlugin = {

--- a/packages/sdk/ARCHITECTURE.md
+++ b/packages/sdk/ARCHITECTURE.md
@@ -46,8 +46,12 @@ path (`@strata/sdk`).
 
 ## 5. Runtime
 
-None — compile-time only. The `define*` helpers merely stamp the `kind`
-discriminant so the core can route a plugin without reflection.
+Almost none, but not zero: the `define*` helpers merely stamp the `kind`
+discriminant so the core can route a plugin without reflection, and
+`PLUGIN_KINDS` is the kind list as a value, for loaders validating a manifest.
+Both survive compilation, so a built plugin still imports `@strata/sdk` at
+runtime — it must be resolvable from the plugin (see
+[`docs/PLUGINS.md`](../../docs/PLUGINS.md)).
 
 ## 6. Decisions
 

--- a/packages/sdk/ARCHITECTURE.md
+++ b/packages/sdk/ARCHITECTURE.md
@@ -33,7 +33,7 @@ path (`@strata/sdk`).
 | File | Contents |
 |------|----------|
 | `version.ts` | `SDK_VERSION` |
-| `manifest.ts` | `PluginKind`, `PluginManifest` |
+| `manifest.ts` | `PluginKind`, `PLUGIN_KINDS` (the same list as a value, for loaders), `PluginManifest` |
 | `logger.ts` | `Logger` |
 | `repo.ts` | `RepoFile`, `RepoContext` |
 | `cache.ts` | `PluginCache` — the blob-keyed incremental cache contract |

--- a/packages/sdk/src/manifest.ts
+++ b/packages/sdk/src/manifest.ts
@@ -1,8 +1,15 @@
-export type PluginKind =
-  | 'language'
-  | 'commit-convention'
-  | 'git-metric'
-  | 'ai-provider';
+/**
+ * Every plugin kind, as a value — a loader validating a hand-written manifest
+ * needs the list at runtime, not just the type.
+ */
+export const PLUGIN_KINDS = [
+  'language',
+  'commit-convention',
+  'git-metric',
+  'ai-provider',
+] as const;
+
+export type PluginKind = (typeof PLUGIN_KINDS)[number];
 
 /** Parsed from `strata.plugin.json`, sitting next to a plugin's package.json. */
 export interface PluginManifest {

--- a/packages/server/ARCHITECTURE.md
+++ b/packages/server/ARCHITECTURE.md
@@ -4,7 +4,8 @@
 
 ## 1. Purpose & Goals
 
-The **HTTP boundary**. A thin Fastify app that discovers first-party plugins,
+The **HTTP boundary**. A thin Fastify app that discovers plugins — the
+first-party ones plus whatever is installed in the user plugins directory —
 wires them into a `Strata` instance, and exposes analysis over REST for the web
 UI and CI. Keeps transport concerns out of the core.
 
@@ -23,7 +24,7 @@ UI and CI. Keeps transport concerns out of the core.
 | Method | Path | Purpose |
 |--------|------|---------|
 | GET | `/health` | Liveness. |
-| GET | `/plugins` | List loaded plugin manifests. |
+| GET | `/plugins` | What loaded, from where, and what was skipped: `{ directory, plugins, failures }` — each plugin its manifest plus a `source` (`builtin`/`user`). |
 | POST | `/analyze` | Body `{ root, rev?, historyLimit?, cache? }` → `AnalysisReport` (incl. cache stats). |
 | DELETE | `/cache` | Empty the incremental cache. |
 
@@ -34,7 +35,7 @@ UI and CI. Keeps transport concerns out of the core.
 | `index.ts` | Barrel — the package's public surface. |
 | `app.ts` | `createServer()` — registry, one `Strata`, routes, shutdown hook. |
 | `main.ts` | Process entry point (`node dist/main.js`). |
-| `registry.ts` | `buildRegistry()` — load the built-in plugin manifests. |
+| `registry.ts` | `buildRegistry()` — load the built-ins, then the user plugins directory. |
 | `routes/health.ts` … `routes/cache.ts` | One module per endpoint. |
 | `routes/index.ts` | `registerRoutes()` + the `RouteContext` they share. |
 
@@ -47,7 +48,11 @@ happens once at startup.
 
 - **Fastify** for schema-friendly, fast HTTP with low overhead.
 - **Built-ins discovered from manifests** (not hard-wired imports), so adding a
-  first-party plugin is a one-line list change; third-party dir loading is next.
+  first-party plugin is a one-line list change. Built-ins load first, then
+  `STRATA_PLUGINS_DIR`, so a drop-in third-party plugin can extend Strata but
+  never shadow a first-party id.
+- **A plugin that will not load never fails startup** — it is reported on
+  `GET /plugins` instead, which is what the plugins settings screen reads.
 - **One long-lived `Strata`**, so the cache is opened once and closed with the
   server (`onClose`), not per request.
 

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
-import { PluginRegistry } from '@strata/core';
+import { PluginRegistry, userPluginsDir } from '@strata/core';
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
 
@@ -12,17 +12,18 @@ const BUILTINS = [
 ];
 
 /**
- * Discover and load the built-in plugins. In a real deployment this also scans
- * a user plugins directory (see docs/PLUGINS.md).
+ * Discover and load plugins: the built-ins that ship here, then every plugin
+ * installed in the user plugins directory (see docs/PLUGINS.md). Built-ins go
+ * first, so a drop-in plugin can never take over an id Strata ships with.
+ *
+ * Neither step can fail startup — a plugin that will not load is recorded in
+ * `registry.failures()` and served on `GET /plugins`.
  */
 export async function buildRegistry(): Promise<PluginRegistry> {
   const registry = new PluginRegistry();
   for (const rel of BUILTINS) {
-    try {
-      await registry.loadFrom(resolve(REPO_ROOT, rel));
-    } catch (err) {
-      console.warn(`skip plugin ${rel}:`, (err as Error).message);
-    }
+    await registry.load(resolve(REPO_ROOT, rel), 'builtin');
   }
+  await registry.loadDirectory(userPluginsDir(), 'user');
   return registry;
 }

--- a/packages/server/src/routes/plugins.ts
+++ b/packages/server/src/routes/plugins.ts
@@ -1,7 +1,18 @@
 import type { FastifyInstance } from 'fastify';
+import { userPluginsDir } from '@strata/core';
 import type { RouteContext } from './context.js';
 
-/** The manifests of every plugin the server loaded at startup. */
+/**
+ * What the server loaded at startup: every plugin's manifest tagged with where
+ * it came from, the directory third-party plugins are read from, and anything
+ * that was found but skipped — all three drive the plugins settings screen.
+ */
 export function pluginsRoute(app: FastifyInstance, ctx: RouteContext): void {
-  app.get('/plugins', async () => ctx.registry.all().map((l) => l.manifest));
+  app.get('/plugins', async () => ({
+    directory: userPluginsDir(),
+    plugins: ctx.registry
+      .all()
+      .map((l) => ({ ...l.manifest, source: l.source })),
+    failures: ctx.registry.failures(),
+  }));
 }

--- a/scripts/analyze.mjs
+++ b/scripts/analyze.mjs
@@ -15,10 +15,10 @@ if (!target) {
   process.exit(1);
 }
 
-const { PluginRegistry, Strata } = await loadCore(repoRoot);
-const registry = await builtinRegistry(repoRoot, PluginRegistry);
+const core = await loadCore(repoRoot);
+const registry = await builtinRegistry(repoRoot, core);
 
-const strata = new Strata(registry);
+const strata = new core.Strata(registry);
 let report;
 try {
   report = await strata.analyze({ root: resolve(target), historyLimit });

--- a/scripts/lib/core.mjs
+++ b/scripts/lib/core.mjs
@@ -19,11 +19,15 @@ export async function loadCore(repoRoot) {
   }
 }
 
-/** A registry with every built-in plugin loaded. */
-export async function builtinRegistry(repoRoot, PluginRegistry) {
+/**
+ * A registry with every built-in plugin loaded, plus whatever is installed in
+ * the user plugins directory — the CLI sees the same plugins as the server.
+ */
+export async function builtinRegistry(repoRoot, { PluginRegistry, userPluginsDir }) {
   const registry = new PluginRegistry();
   for (const rel of BUILTIN_PLUGINS) {
-    await registry.loadFrom(resolve(repoRoot, rel));
+    await registry.load(resolve(repoRoot, rel), 'builtin');
   }
+  await registry.loadDirectory(userPluginsDir(), 'user');
   return registry;
 }


### PR DESCRIPTION
## What

Plugins are no longer limited to the three built-ins listed in the server. The
registry also scans a **drop-in plugins directory** — `STRATA_PLUGINS_DIR`,
default `<cwd>/.strata/plugins` (`/app/.strata/plugins` in the container) — with
one subdirectory per plugin, each holding its `strata.plugin.json`. A missing
directory means "nothing installed", not an error; symlinked plugin directories
are followed, and manifests are sorted so load order never depends on the
filesystem.

Nothing in that directory is first-party code, so the loader validates rather
than trusts:

- every manifest field is checked, and `kind` must be one of the four;
- `main` must resolve **inside the plugin's own directory**;
- the module's exported `kind` must match the manifest;
- ids are first-one-wins and built-ins load first, so a drop-in can never shadow
  a first-party id;
- a plugin that trips any of these is skipped and recorded — one broken
  third-party plugin must not fail startup.

`GET /plugins` now answers `{ directory, plugins, failures }` — each plugin its
manifest plus a `source` (`builtin`/`user`) — the three things *Settings → Plugins & engine → Plugins
directory* needs. **Breaking response shape**, but `apps/web` is still a
placeholder, so there is no consumer yet. `scripts/analyze.mjs` loads the same
set, so the CLI and the server see the same plugins.

New in `@strata/core`: `manifest.ts` (validate a manifest + its entry path),
`discover.ts` (scan a plugins directory), `plugins-dir.ts` (`userPluginsDir()` —
the env lookup sits next to the existing `STRATA_CACHE_DIR` one, which is what
lets the CLI reuse it).

Not attempted, and flagged in `packages/core/ARCHITECTURE.md` and
`docs/ARCHITECTURE.md`: a plugin runs **in-process with the server's
privileges**. The validation above stops malformed and misdeclared plugins, not
malicious ones — installing a plugin stays a trust decision, and isolation
(worker threads / permissions) is its own piece of work.

## Why

Extending Strata meant forking it. Closes #2.

## Type of change

- [x] feat / fix / perf / refactor
- [x] docs / test / build / ci / chore

## Checklist

- [x] `pnpm build && pnpm test && pnpm lint` pass locally (`make check`)
- [x] Added/updated tests where it made sense — 13 tests in
      `packages/core/src/registry.test.ts` covering discovery, symlinks, a
      missing directory, and every rejection path
- [x] Docs updated — new *Installing a plugin* section in `docs/PLUGINS.md`,
      plus the arch docs, README, `.env.example`, Dockerfile, `compose.yml`, and
      the backlog item checked off

Verified by hand as well: with a drop-in `strata-hello` plugin plus a
deliberately SDK-mismatched one in `$STRATA_PLUGINS_DIR`, `/plugins` returned
the three built-ins + one `user` plugin and the mismatch in `failures[]`, and
`scripts/analyze.mjs` loaded the same set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for drop-in third-party plugins from a configurable directory.
  - Built-in plugins load before third-party plugins, with duplicate IDs protected.
  - Added plugin validation, source information, and safe path handling.
  - Updated `/plugins` to show the plugin directory, loaded plugins, and load failures.
  - Plugin failures are reported without preventing application startup.

- **Documentation**
  - Documented plugin installation, discovery, configuration, persistence, validation, and troubleshooting.
  - Added the `STRATA_PLUGINS_DIR` configuration example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->