### PR TITLE
feat(plugin-git-coupling): rank files that change together

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -63,8 +63,9 @@ here exists yet.
 - [ ] **P0** Commit analytics aggregates behind the *Commit analytics* screen —
       per-type and per-scope counts, convention-validity rate (`96% valid ·
       6 non-conforming`), breaking-change count, and a weekly activity series.
-- [ ] **P0** Change coupling — files that change together (temporal coupling).
-      Appears as a *planned* toggle under *Project settings → Metrics*.
+- [x] Change coupling — files that change together (temporal coupling).
+      Thresholds (min changes/shared/degree) are still fixed constants; they
+      become the *Project settings → Metrics* toggles.
 - [ ] **P1** Knowledge map / bus factor — contribution concentration per file/dir
 - [ ] **P1** Code age — stable vs. actively-churning regions
 - [ ] **P1** Ignore-globs for metrics (exclude lockfiles/generated) — shares the

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ the tool grows without the core changing.
 ## Status
 
 🚧 **Early scaffold.** The plugin contracts (`@strata/sdk`), the orchestrator
-(`@strata/core`), the API (`@strata/server`) and four example plugins are in
+(`@strata/core`), the API (`@strata/server`) and five example plugins are in
 place and build. The web UI and richer analyzers are next — see
 [`BACKLOG`](#roadmap).
 
@@ -20,7 +20,7 @@ place and build. The web UI and richer analyzers are next — see
 
 **Git / history intelligence**
 - Hotspots — change frequency × complexity ✅ (starter metric)
-- Change coupling — files that change together ⏳
+- Change coupling — files that change together ✅
 - Knowledge map / bus factor ⏳
 - Commit-convention analytics — Conventional Commits ✅, gitmoji/custom via plugin ⏳
 

--- a/apps/web/ARCHITECTURE.md
+++ b/apps/web/ARCHITECTURE.md
@@ -25,6 +25,7 @@ providers. The face of Strata for browser/self-host use.
 | View | Source in report |
 |------|------------------|
 | Hotspot treemap | `metrics["hotspots"]` |
+| Change coupling | `metrics["change-coupling"]` (pair list / chord) |
 | Dependency graph | `languages[*].graph` (Cytoscape/d3) |
 | Commit analytics | `commits[]` (type/scope/breaking) |
 | Settings | AI provider registration |

--- a/apps/web/ARCHITECTURE.md
+++ b/apps/web/ARCHITECTURE.md
@@ -24,8 +24,8 @@ providers. The face of Strata for browser/self-host use.
 
 | View | Source in report |
 |------|------------------|
-| Hotspot treemap | `metrics["hotspots"]` |
-| Change coupling | `metrics["change-coupling"]` (pair list / chord) |
+| Hotspot treemap | `metrics.find((m) => m.id === "hotspots")` |
+| Change coupling | `metrics.find((m) => m.id === "change-coupling")` (pair list / chord) |
 | Dependency graph | `languages[*].graph` (Cytoscape/d3) |
 | Commit analytics | `commits[]` (type/scope/breaking) |
 | Settings | AI provider registration |

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -6,8 +6,10 @@ This is a **placeholder**. Scaffold the frontend of your choice here — the
 recommendation in the design doc is Vite + SvelteKit (or Next.js) + Tailwind,
 talking to `@strata/server` over REST. Suggested first views:
 
-- **Hotspot treemap** — from `GET/POST /analyze` → `metrics["hotspots"]`.
-- **Change coupling** — from `metrics["change-coupling"]` (pairs, degree in `%`).
+- **Hotspot treemap** — from `GET/POST /analyze` → the `metrics` series with
+  `id: "hotspots"` (the report's `metrics` is an array of `MetricSeries`).
+- **Change coupling** — the `metrics` series with `id: "change-coupling"`
+  (pairs, degree in `%`).
 - **Dependency graph** — from `languages[*].graph` (render with Cytoscape/d3).
 - **Commit analytics** — from `commits[]` (types, scopes, breaking changes).
 - **Settings** — register AI providers and API keys.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -7,6 +7,7 @@ recommendation in the design doc is Vite + SvelteKit (or Next.js) + Tailwind,
 talking to `@strata/server` over REST. Suggested first views:
 
 - **Hotspot treemap** — from `GET/POST /analyze` → `metrics["hotspots"]`.
+- **Change coupling** — from `metrics["change-coupling"]` (pairs, degree in `%`).
 - **Dependency graph** — from `languages[*].graph` (render with Cytoscape/d3).
 - **Commit analytics** — from `commits[]` (types, scopes, breaking changes).
 - **Settings** — register AI providers and API keys.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -94,6 +94,7 @@ strata/
 │                  app.ts · main.ts (entry) · registry.ts · routes/*
 ├── plugins/
 │   ├── commit-conventional/      Conventional Commits parser   (commit-convention)
+│   ├── git-coupling/             change-coupling metric         (git-metric)
 │   ├── git-hotspots/             churn × complexity metric      (git-metric)
 │   ├── language-typescript/      TS/JS import graph + cycles     (language)
 │   └── ai-provider-template/     copy-me AI backend              (ai-provider)
@@ -111,6 +112,7 @@ Quality/Risks). Start here:
 - [`packages/core/ARCHITECTURE.md`](../packages/core/ARCHITECTURE.md)
 - [`packages/server/ARCHITECTURE.md`](../packages/server/ARCHITECTURE.md)
 - [`plugins/commit-conventional/ARCHITECTURE.md`](../plugins/commit-conventional/ARCHITECTURE.md)
+- [`plugins/git-coupling/ARCHITECTURE.md`](../plugins/git-coupling/ARCHITECTURE.md)
 - [`plugins/git-hotspots/ARCHITECTURE.md`](../plugins/git-hotspots/ARCHITECTURE.md)
 - [`plugins/language-typescript/ARCHITECTURE.md`](../plugins/language-typescript/ARCHITECTURE.md)
 - [`plugins/ai-provider-template/ARCHITECTURE.md`](../plugins/ai-provider-template/ARCHITECTURE.md)

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -62,7 +62,7 @@ export default defineCommitConventionPlugin({
 import { defineGitMetricPlugin } from '@strata/sdk';
 
 export default defineGitMetricPlugin({
-  id: 'change-coupling',
+  id: 'code-age',
   async compute(ctx, history) {
     /* → MetricSeries { id, label, points } */
   },

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -7,6 +7,7 @@ const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
 /** The first-party plugins that ship in this repo. */
 const BUILTINS = [
   'plugins/commit-conventional/strata.plugin.json',
+  'plugins/git-coupling/strata.plugin.json',
   'plugins/git-hotspots/strata.plugin.json',
   'plugins/language-typescript/strata.plugin.json',
 ];

--- a/plugins/git-coupling/ARCHITECTURE.md
+++ b/plugins/git-coupling/ARCHITECTURE.md
@@ -1,0 +1,65 @@
+# Module: `@strata/plugin-git-coupling` — Architecture (arc42)
+
+> Trimmed arc42, consistent with [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md).
+> Kind: **git-metric**.
+
+## 1. Purpose & Goals
+
+Surface **change coupling** (temporal coupling): pairs of files that keep
+changing in the same commit. Where hotspots rank single files by cost, coupling
+names dependencies the compiler cannot see — a route and its client, a component
+and its fixture — and a coupled pair that straddles a module boundary is an
+architectural smell.
+
+## 2. Constraints
+
+- Language-agnostic; history is the only input.
+- Reads history only through `RepoContext.git()`.
+- Pair counting is quadratic in a commit's file count, so commit size is capped.
+
+## 3. Interfaces (Context)
+
+- **Depends on:** `@strata/sdk`.
+- **Consumed by:** the core's git-metric step → `MetricSeries { id: "change-coupling", unit: "%" }`.
+- **Manifest:** `strata.plugin.json` (`kind: git-metric`).
+
+## 4. Building Blocks
+
+| File | Responsibility |
+|------|----------------|
+| `index.ts` | The plugin: thresholds, then commits → co-changes → ranked points. |
+| `commits.ts` | The changed-path set per analysed commit (`git log --name-only -n <N> <sha>`). Root-commit safe; merges contribute nothing. |
+| `pairs.ts` | Count per-file changes and per-pair co-changes; skip oversized commits. |
+| `coupling.ts` | Coupling degree, thresholds, ranking, and the `MetricPoint` shape. |
+
+## 5. Runtime
+
+`compute(ctx, history)` → one point per surviving pair:
+
+- `subject` — `"a ↔ b"`, `value` — coupling degree in percent,
+- `meta` — `fileA`, `fileB`, `sharedChanges`, `changesA`, `changesB`.
+
+Degree averages the two files' change counts:
+`100 × shared / ((changesA + changesB) / 2)`.
+
+## 6. Decisions
+
+- **Average, not minimum** (as in code-maat): symmetric, and a constantly
+  churning file does not read as coupled to everything it accompanies.
+- **Only files present at the analysed revision** are reported — a pair that no
+  longer exists is history, not a warning.
+- **Commits over 30 files are skipped**: a sweeping rename or format pass
+  couples everything to everything, and the pair count is quadratic.
+- **Defaults** (`minChanges 3`, `minSharedChanges 2`, `minDegree 30%`, top 500)
+  follow code-maat's spirit, loosened so a young repo still shows a signal.
+- No `ctx.cache` use: the result is a function of history, not of file contents,
+  and the core already caches the whole run by history window.
+
+## 7. Quality & Risks
+
+- **Risk:** generated files (lockfiles) couple to everything that touches them.
+  **Mitigation:** ignore-globs for metrics (backlog).
+- **Risk:** renames read as a deleted and an added path, splitting a file's
+  history. **Mitigation:** follow renames once the git layer exposes them.
+- **Risk:** thresholds are fixed. **Mitigation:** expose them as project
+  settings when *Project settings → Metrics* lands.

--- a/plugins/git-coupling/package.json
+++ b/plugins/git-coupling/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@strata/plugin-git-coupling",
+  "version": "0.1.0",
+  "description": "Change-coupling (files that change together) git-metric plugin for Strata.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "files": [
+    "dist",
+    "strata.plugin.json"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@strata/sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.13.3",
+    "typescript": "^7.0.2"
+  }
+}

--- a/plugins/git-coupling/src/commits.test.ts
+++ b/plugins/git-coupling/src/commits.test.ts
@@ -1,0 +1,52 @@
+import type { RawCommit, RepoContext } from '@strata/sdk';
+import { describe, expect, it, vi } from 'vitest';
+import { changedFilesByCommit } from './commits.js';
+
+/** Only `git` is exercised here; the rest of the context is never touched. */
+const context = (out: string) =>
+  ({ git: vi.fn(async () => out) }) as unknown as RepoContext;
+
+const history = (n: number): RawCommit[] =>
+  Array.from({ length: n }, (_, i) => ({
+    sha: `sha${i}`,
+    author: 'Ada',
+    authorEmail: 'ada@example.com',
+    date: '2026-01-01T00:00:00Z',
+    message: 'chore: work',
+  }));
+
+describe('changedFilesByCommit', () => {
+  it('groups the paths of each commit and skips ones that list none', () => {
+    const ctx = context('\x1e\n\na.ts\nb.ts\n\x1e\n\n\x1e\n\nb.ts\n');
+
+    return expect(changedFilesByCommit(ctx, history(3))).resolves.toEqual([
+      ['a.ts', 'b.ts'],
+      ['b.ts'],
+    ]);
+  });
+
+  it('keeps leading and trailing spaces — they are part of the path', async () => {
+    const ctx = context('\x1e\n\n leading.ts\ntrailing.ts \nleading.ts\n');
+
+    // Three distinct paths: trimming would merge two of them and break the
+    // match against `ctx.files`, which does not trim either.
+    await expect(changedFilesByCommit(ctx, history(1))).resolves.toEqual([
+      [' leading.ts', 'trailing.ts ', 'leading.ts'],
+    ]);
+  });
+
+  it('counts a path listed twice in one commit once', async () => {
+    const ctx = context('\x1e\n\na.ts\na.ts\nb.ts\n');
+
+    await expect(changedFilesByCommit(ctx, history(1))).resolves.toEqual([
+      ['a.ts', 'b.ts'],
+    ]);
+  });
+
+  it('does not shell out for an empty history', async () => {
+    const ctx = context('');
+
+    await expect(changedFilesByCommit(ctx, [])).resolves.toEqual([]);
+    expect(ctx.git).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/git-coupling/src/commits.ts
+++ b/plugins/git-coupling/src/commits.ts
@@ -30,13 +30,10 @@ export async function changedFilesByCommit(
 
   const commits: string[][] = [];
   for (const chunk of out.split(SEP)) {
+    // Only empty lines are dropped, never trimmed: a leading or trailing space
+    // is part of a git path, and a trimmed one stops matching `ctx.files`.
     // A set, so a path listed twice in one commit still counts as one change.
-    const paths = new Set(
-      chunk
-        .split('\n')
-        .map((line) => line.trim())
-        .filter(Boolean),
-    );
+    const paths = new Set(chunk.split('\n').filter((line) => line.length > 0));
     if (paths.size > 0) commits.push([...paths]);
   }
   return commits;

--- a/plugins/git-coupling/src/commits.ts
+++ b/plugins/git-coupling/src/commits.ts
@@ -1,0 +1,43 @@
+import type { RawCommit, RepoContext } from '@strata/sdk';
+
+/** Record separator; `--pretty=format:%x1e` prints it once per commit. */
+const SEP = '\x1e';
+
+/**
+ * The set of paths each analysed commit touched, newest first.
+ *
+ * Reads exactly the commits we were given by walking back from the newest sha,
+ * the same window `git-hotspots` uses — so a history cap applies consistently
+ * across metrics and the walk stays correct at the repo's root commit.
+ *
+ * A merge commit shows no files under `--name-only` and yields an empty set,
+ * which is what we want: its changes were already counted on the merged side.
+ */
+export async function changedFilesByCommit(
+  ctx: RepoContext,
+  history: RawCommit[],
+): Promise<string[][]> {
+  if (history.length === 0) return [];
+
+  const out = await ctx.git([
+    'log',
+    '--name-only',
+    `--pretty=format:${SEP}`,
+    '-n',
+    String(history.length),
+    history[0]!.sha,
+  ]);
+
+  const commits: string[][] = [];
+  for (const chunk of out.split(SEP)) {
+    // A set, so a path listed twice in one commit still counts as one change.
+    const paths = new Set(
+      chunk
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean),
+    );
+    if (paths.size > 0) commits.push([...paths]);
+  }
+  return commits;
+}

--- a/plugins/git-coupling/src/coupling.test.ts
+++ b/plugins/git-coupling/src/coupling.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { rankCoupling, type CouplingOptions } from './coupling.js';
+import { countCoChanges } from './pairs.js';
+
+const opts: CouplingOptions = {
+  minChanges: 3,
+  minSharedChanges: 2,
+  minDegree: 30,
+  limit: 500,
+};
+
+/** n commits touching every path in `files`. */
+const times = (n: number, files: string[]): string[][] =>
+  Array.from({ length: n }, () => files);
+
+describe('rankCoupling', () => {
+  it('scores an always-together pair at 100%', () => {
+    const points = rankCoupling(
+      countCoChanges(times(4, ['a.ts', 'a.test.ts']), 30),
+      new Set(['a.ts', 'a.test.ts']),
+      opts,
+    );
+
+    expect(points).toHaveLength(1);
+    expect(points[0]!.subject).toBe('a.test.ts ↔ a.ts');
+    expect(points[0]!.value).toBe(100);
+    expect(points[0]!.meta).toEqual({
+      fileA: 'a.test.ts',
+      fileB: 'a.ts',
+      sharedChanges: 4,
+      changesA: 4,
+      changesB: 4,
+    });
+  });
+
+  it('averages both change counts, so a busy file is not coupled to everything', () => {
+    // barrel.ts: 8 changes, 4 of them alongside leaf.ts (which has 4).
+    const commits = [
+      ...times(4, ['barrel.ts', 'leaf.ts']),
+      ...times(4, ['barrel.ts']),
+    ];
+    const [point] = rankCoupling(
+      countCoChanges(commits, 30),
+      new Set(['barrel.ts', 'leaf.ts']),
+      opts,
+    );
+
+    // 100 × 4 / ((8 + 4) / 2) = 66.7, not the 100% a min-based degree would give.
+    expect(point!.value).toBe(66.7);
+  });
+
+  it('drops thin evidence, weak coupling and files gone at this revision', () => {
+    const commits = [
+      ...times(2, ['thin-a.ts', 'thin-b.ts']), // below minChanges
+      ...times(3, ['weak-a.ts', 'weak-b.ts']),
+      ...times(8, ['weak-a.ts']),
+      ...times(8, ['weak-b.ts']), // 3 shared of avg 11 → 27.3%, below minDegree
+      ...times(3, ['kept.ts', 'deleted.ts']),
+    ];
+    const points = rankCoupling(
+      countCoChanges(commits, 30),
+      new Set(['thin-a.ts', 'thin-b.ts', 'weak-a.ts', 'weak-b.ts', 'kept.ts']),
+      opts,
+    );
+
+    expect(points.map((p) => p.subject)).toEqual([]);
+  });
+
+  it('ranks by degree, then evidence, then path, and honours the limit', () => {
+    const commits = [
+      ...times(3, ['a.ts', 'b.ts']),
+      ...times(3, ['c.ts', 'd.ts']),
+      ...times(1, ['c.ts']),
+      ...times(3, ['e.ts', 'f.ts']),
+    ];
+    const present = new Set(['a.ts', 'b.ts', 'c.ts', 'd.ts', 'e.ts', 'f.ts']);
+
+    const points = rankCoupling(countCoChanges(commits, 30), present, opts);
+    expect(points.map((p) => p.subject)).toEqual([
+      'a.ts ↔ b.ts', // 100%, tie with e/f broken by path
+      'e.ts ↔ f.ts',
+      'c.ts ↔ d.ts', // 3 shared of avg 3.5 → 85.7%
+    ]);
+
+    expect(
+      rankCoupling(countCoChanges(commits, 30), present, { ...opts, limit: 2 }),
+    ).toHaveLength(2);
+  });
+});

--- a/plugins/git-coupling/src/coupling.ts
+++ b/plugins/git-coupling/src/coupling.ts
@@ -1,0 +1,76 @@
+import type { MetricPoint } from '@strata/sdk';
+import { splitPair, type CoChanges } from './pairs.js';
+
+/** Thresholds that decide which pairs are worth reporting. */
+export interface CouplingOptions {
+  /** Ignore a file that changed fewer times than this — too little evidence. */
+  minChanges: number;
+  /** Ignore a pair that changed together fewer times than this. */
+  minSharedChanges: number;
+  /** Ignore a pair coupled below this percentage. */
+  minDegree: number;
+  /** Keep at most this many pairs; pairs are quadratic, reports are read by humans. */
+  limit: number;
+}
+
+/** The pair separator shown in a point's subject. */
+const SUBJECT_SEP = ' ↔ ';
+
+/**
+ * Rank co-changing pairs by coupling degree.
+ *
+ * Degree is the share of a pair's changes that were shared, against the
+ * *average* of the two files' change counts (as in Tornhill's code-maat):
+ *
+ *     degree = 100 × shared / ((changesA + changesB) / 2)
+ *
+ * Averaging keeps the metric symmetric and stops a file that changes constantly
+ * (a barrel, a lockfile) from reading as tightly coupled to everything it
+ * happens to accompany. 100% means the two files never changed apart.
+ *
+ * `present` limits the result to files that still exist at the analysed
+ * revision — a pair whose files were both deleted is history, not a warning.
+ */
+export function rankCoupling(
+  { changes, shared }: CoChanges,
+  present: ReadonlySet<string>,
+  opts: CouplingOptions,
+): MetricPoint[] {
+  const points: MetricPoint[] = [];
+
+  for (const [key, sharedChanges] of shared) {
+    if (sharedChanges < opts.minSharedChanges) continue;
+    const [a, b] = splitPair(key);
+    if (!present.has(a) || !present.has(b)) continue;
+
+    const changesA = changes.get(a) ?? 0;
+    const changesB = changes.get(b) ?? 0;
+    if (changesA < opts.minChanges || changesB < opts.minChanges) continue;
+
+    const degree = round((200 * sharedChanges) / (changesA + changesB));
+    if (degree < opts.minDegree) continue;
+
+    points.push({
+      subject: `${a}${SUBJECT_SEP}${b}`,
+      value: degree,
+      // Both paths separately too, so a UI can link them without re-splitting
+      // the subject.
+      meta: { fileA: a, fileB: b, sharedChanges, changesA, changesB },
+    });
+  }
+
+  // Degree first, then the better-evidenced pair, then the path — a stable
+  // order, so two runs over the same history render identically.
+  points.sort(
+    (x, y) =>
+      y.value - x.value ||
+      (y.meta!.sharedChanges as number) - (x.meta!.sharedChanges as number) ||
+      x.subject.localeCompare(y.subject),
+  );
+  return points.slice(0, opts.limit);
+}
+
+/** One decimal is as much precision as a percentage over a few commits earns. */
+function round(value: number): number {
+  return Math.round(value * 10) / 10;
+}

--- a/plugins/git-coupling/src/index.test.ts
+++ b/plugins/git-coupling/src/index.test.ts
@@ -1,0 +1,67 @@
+import type { RawCommit, RepoContext, RepoFile } from '@strata/sdk';
+import { describe, expect, it, vi } from 'vitest';
+import plugin from './index.js';
+
+/** Commits as git would print them for `--name-only --pretty=format:%x1e`. */
+function gitLog(commits: string[][]): string {
+  return commits.map((files) => `\x1e\n\n${files.join('\n')}\n`).join('');
+}
+
+function context(paths: string[], log: string): RepoContext {
+  return {
+    root: '/repo',
+    rev: 'deadbeef',
+    files: paths.map((path) => ({ path }) as RepoFile),
+    git: vi.fn(async () => log),
+    log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    cache: { file: (_file, compute) => compute(_file) },
+  };
+}
+
+const history = (n: number): RawCommit[] =>
+  Array.from({ length: n }, (_, i) => ({
+    sha: `sha${i}`,
+    author: 'Ada',
+    authorEmail: 'ada@example.com',
+    date: '2026-01-01T00:00:00Z',
+    message: 'chore: work',
+  }));
+
+describe('change-coupling plugin', () => {
+  it('reports the pairs that keep changing together', async () => {
+    const commits = [
+      ['src/route.ts', 'src/client.ts'],
+      ['src/route.ts', 'src/client.ts'],
+      ['src/route.ts', 'src/client.ts'],
+      ['README.md'],
+    ];
+    const ctx = context(
+      ['src/route.ts', 'src/client.ts', 'README.md'],
+      gitLog(commits),
+    );
+
+    const series = await plugin.compute(ctx, history(commits.length));
+
+    expect(series.id).toBe('change-coupling');
+    expect(series.unit).toBe('%');
+    expect(series.points).toHaveLength(1);
+    expect(series.points[0]).toMatchObject({
+      subject: 'src/client.ts ↔ src/route.ts',
+      value: 100,
+      meta: { sharedChanges: 3 },
+    });
+
+    // The window is exactly the history the core handed us.
+    expect(ctx.git).toHaveBeenCalledWith(
+      expect.arrayContaining(['log', '--name-only', '-n', '4', 'sha0']),
+    );
+  });
+
+  it('returns an empty series for an empty history', async () => {
+    const ctx = context(['a.ts'], '');
+    const series = await plugin.compute(ctx, []);
+
+    expect(series.points).toEqual([]);
+    expect(ctx.git).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/git-coupling/src/index.ts
+++ b/plugins/git-coupling/src/index.ts
@@ -1,0 +1,50 @@
+import {
+  defineGitMetricPlugin,
+  type MetricSeries,
+  type RawCommit,
+  type RepoContext,
+} from '@strata/sdk';
+import { changedFilesByCommit } from './commits.js';
+import { rankCoupling, type CouplingOptions } from './coupling.js';
+import { countCoChanges } from './pairs.js';
+
+/**
+ * Change coupling (temporal coupling): files that keep changing in the same
+ * commits.
+ *
+ * Where hotspots ask "which file costs the most?", coupling asks "which files
+ * cannot be changed alone?" — a pair the compiler knows nothing about (a
+ * component and its test fixture, an API route and a client) but that every
+ * change has to touch together. High coupling across module boundaries is the
+ * architectural smell worth acting on.
+ */
+
+/**
+ * Defaults, in the spirit of code-maat's but a little looser so a young repo
+ * still produces a signal.
+ */
+const DEFAULTS: CouplingOptions = {
+  minChanges: 3,
+  minSharedChanges: 2,
+  minDegree: 30,
+  limit: 500,
+};
+
+/** Commits touching more files than this are skipped — see `countCoChanges`. */
+const MAX_FILES_PER_COMMIT = 30;
+
+export default defineGitMetricPlugin({
+  id: 'change-coupling',
+  async compute(ctx: RepoContext, history: RawCommit[]): Promise<MetricSeries> {
+    const commits = await changedFilesByCommit(ctx, history);
+    const coChanges = countCoChanges(commits, MAX_FILES_PER_COMMIT);
+    const present = new Set(ctx.files.map((f) => f.path));
+
+    return {
+      id: 'change-coupling',
+      label: 'Change coupling (files that change together)',
+      unit: '%',
+      points: rankCoupling(coChanges, present, DEFAULTS),
+    };
+  },
+});

--- a/plugins/git-coupling/src/pairs.test.ts
+++ b/plugins/git-coupling/src/pairs.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { countCoChanges, pairKey, splitPair } from './pairs.js';
+
+describe('countCoChanges', () => {
+  it('counts changes per file and per pair', () => {
+    const { changes, shared } = countCoChanges(
+      [
+        ['a.ts', 'b.ts'],
+        ['a.ts', 'b.ts', 'c.ts'],
+        ['a.ts'],
+      ],
+      30,
+    );
+
+    expect(changes.get('a.ts')).toBe(3);
+    expect(changes.get('b.ts')).toBe(2);
+    expect(changes.get('c.ts')).toBe(1);
+    expect(shared.get(pairKey('a.ts', 'b.ts'))).toBe(2);
+    expect(shared.get(pairKey('b.ts', 'c.ts'))).toBe(1);
+    expect(shared.get(pairKey('a.ts', 'd.ts'))).toBeUndefined();
+  });
+
+  it('skips commits that touch more files than the cap', () => {
+    const sweep = ['a.ts', 'b.ts', 'c.ts', 'd.ts'];
+    const { changes, shared } = countCoChanges([['a.ts', 'b.ts'], sweep], 3);
+
+    expect(changes.get('a.ts')).toBe(1);
+    expect(changes.get('d.ts')).toBeUndefined();
+    expect(shared.get(pairKey('a.ts', 'b.ts'))).toBe(1);
+    expect(shared.get(pairKey('c.ts', 'd.ts'))).toBeUndefined();
+  });
+
+  it('keys a pair the same way whichever order it is seen in', () => {
+    expect(pairKey('a.ts', 'b.ts')).toBe(pairKey('b.ts', 'a.ts'));
+    expect(splitPair(pairKey('b.ts', 'a.ts'))).toEqual(['a.ts', 'b.ts']);
+  });
+});

--- a/plugins/git-coupling/src/pairs.ts
+++ b/plugins/git-coupling/src/pairs.ts
@@ -1,0 +1,52 @@
+/** Separator for a pair key; a `\0` cannot occur in a git path. */
+const KEY_SEP = '\0';
+
+/** How often each file changed, and how often each pair of files changed together. */
+export interface CoChanges {
+  /** Commits that touched a path. */
+  changes: Map<string, number>;
+  /** Commits that touched both paths of a pair, keyed by `pairKey`. */
+  shared: Map<string, number>;
+}
+
+/** Order-independent key for a pair of paths. */
+export function pairKey(a: string, b: string): string {
+  return a < b ? `${a}${KEY_SEP}${b}` : `${b}${KEY_SEP}${a}`;
+}
+
+/** Split a `pairKey` back into its two paths. */
+export function splitPair(key: string): [string, string] {
+  const [a, b] = key.split(KEY_SEP);
+  return [a!, b!];
+}
+
+/**
+ * Count per-file changes and per-pair co-changes over the given commits.
+ *
+ * Commits touching more than `maxFilesPerCommit` files are counted for neither:
+ * a sweeping rename or a formatting pass couples everything it touches to
+ * everything else, which is noise, and the pair count is quadratic in the
+ * commit's size — so one huge commit would otherwise dominate both the result
+ * and the runtime.
+ */
+export function countCoChanges(
+  commits: string[][],
+  maxFilesPerCommit: number,
+): CoChanges {
+  const changes = new Map<string, number>();
+  const shared = new Map<string, number>();
+
+  for (const files of commits) {
+    if (files.length > maxFilesPerCommit) continue;
+    for (const path of files) {
+      changes.set(path, (changes.get(path) ?? 0) + 1);
+    }
+    for (let i = 0; i < files.length; i++) {
+      for (let j = i + 1; j < files.length; j++) {
+        const key = pairKey(files[i]!, files[j]!);
+        shared.set(key, (shared.get(key) ?? 0) + 1);
+      }
+    }
+  }
+  return { changes, shared };
+}

--- a/plugins/git-coupling/strata.plugin.json
+++ b/plugins/git-coupling/strata.plugin.json
@@ -1,0 +1,10 @@
+{
+  "id": "strata-git-coupling",
+  "name": "Change coupling",
+  "kind": "git-metric",
+  "version": "0.1.0",
+  "sdk": "0.1.0",
+  "main": "./dist/index.js",
+  "description": "Ranks pairs of files by how often they change in the same commit (temporal coupling).",
+  "author": "Strata"
+}

--- a/plugins/git-coupling/tsconfig.json
+++ b/plugins/git-coupling/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,19 @@ importers:
         specifier: ^7.0.2
         version: 7.0.2
 
+  plugins/git-coupling:
+    dependencies:
+      '@strata/sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk
+    devDependencies:
+      '@types/node':
+        specifier: ^24.13.3
+        version: 24.13.3
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
+
   plugins/git-hotspots:
     dependencies:
       '@strata/sdk':

--- a/scripts/lib/core.mjs
+++ b/scripts/lib/core.mjs
@@ -5,6 +5,7 @@ import { resolve } from 'node:path';
 /** The first-party plugin manifests, same list the server loads. */
 export const BUILTIN_PLUGINS = [
   'plugins/commit-conventional/strata.plugin.json',
+  'plugins/git-coupling/strata.plugin.json',
   'plugins/git-hotspots/strata.plugin.json',
   'plugins/language-typescript/strata.plugin.json',
 ];

--- a/scripts/lib/report.mjs
+++ b/scripts/lib/report.mjs
@@ -1,9 +1,10 @@
 // Render an AnalysisReport for the terminal.
 
-/** Print the whole report: hotspots, commits, cache, per-language graphs. */
+/** Print the whole report: hotspots, coupling, commits, cache, per-language graphs. */
 export function printReport(report, target) {
   console.log(`\nStrata — ${target} @ ${report.rev.slice(0, 8)}\n`);
   printHotspots(report);
+  printCoupling(report);
   printCommits(report);
   printCache(report);
   printLanguages(report);
@@ -16,6 +17,18 @@ function printHotspots(report, limit = 15) {
     console.log(
       `  ${String(p.value).padStart(7)}  ${p.subject}  ` +
         `(churn ${p.meta?.churn}, cx ${p.meta?.complexity})`,
+    );
+  }
+}
+
+function printCoupling(report, limit = 15) {
+  const coupled = report.metrics.find((m) => m.id === 'change-coupling');
+  if (!coupled) return;
+  console.log('\nTop change coupling (files that change together):');
+  for (const p of coupled.points.slice(0, limit)) {
+    console.log(
+      `  ${`${p.value}%`.padStart(7)}  ${p.subject}  ` +
+        `(${p.meta?.sharedChanges} shared of ${p.meta?.changesA}/${p.meta?.changesB})`,
     );
   }
 }


### PR DESCRIPTION
## What

Adds `@strata/plugin-git-coupling`, a first-party **git-metric** plugin that
ranks pairs of files by how often they change in the same commit — the
`change-coupling` series (`unit: "%"`).

- `commits.ts` — the changed-path set per analysed commit
  (`git log --name-only -n <N> <sha>`; same window as `git-hotspots`,
  root-commit safe, merges contribute nothing).
- `pairs.ts` — per-file change counts and per-pair co-change counts. Commits
  touching more than 30 files are skipped: a sweeping rename or format pass
  couples everything to everything, and pair counting is quadratic in commit
  size.
- `coupling.ts` — degree `100 × shared / ((changesA + changesB) / 2)`
  (code-maat's averaging, so a constantly churning file does not read as
  coupled to everything it accompanies), thresholds, stable ranking, top 500.
  Only pairs whose files still exist at the analysed revision are reported.
- Registered as a built-in for the server and the CLI; `scripts/lib/report.mjs`
  now prints a coupling table alongside hotspots.
- `ARCHITECTURE.md` for the module (trimmed arc42), plus README / BACKLOG /
  docs updates.

Live on this repo:

```
Top change coupling (files that change together):
     100%  .env.example ↔ packages/core/src/index.ts  (3 shared of 3/3)
    88.9%  docs/PLUGINS.md ↔ packages/core/ARCHITECTURE.md  (4 shared of 4/5)
```

## Why

Hotspots ask "which file costs the most?"; coupling asks "which files cannot be
changed alone?" — dependencies the compiler knows nothing about, and an
architectural smell when a coupled pair straddles a module boundary.

Closes #8.

Deliberately left for the existing backlog items: renames split a file's
history (needs rename-following in the git layer), and the thresholds are fixed
constants rather than *Project settings → Metrics* toggles — the BACKLOG line
says so rather than claiming them done.

## Type of change

- [x] feat / fix / perf / refactor
- [ ] docs / test / build / ci / chore

## Checklist

- [x] `pnpm build && pnpm test && pnpm lint` pass locally (`make check`)
- [x] Added/updated tests where it made sense (18 tests: unit + end-to-end over a stubbed `RepoContext`)
- [x] Docs updated (README / docs/) if behaviour changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Change coupling metric plugin to identify files that frequently change together.
  * Added a web view showing coupled file pairs, shared-change counts, and percentage-based scores.
  * Added report output for the highest-ranked coupling relationships.
  * Registered the plugin as a built-in example and documented its architecture and usage.

* **Documentation**
  * Updated project documentation to reflect the completed Change coupling feature and five available example plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->