### PR TITLE
feat(plugin-language-typescript): measure complexity, nesting and duplication

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -81,7 +81,9 @@ here exists yet.
 - [ ] **P0** Real dead code — unreferenced exports, unreachable files, unused deps.
       The mockup's *Dead code* table is the target shape: path, symbol, reason
       (`unreferenced-export` / `unreachable-file` / `unused-dependency`), line.
-- [ ] **P0** Real metrics — cyclomatic complexity, nesting, duplication
+- [x] Real metrics — cyclomatic complexity, max nesting depth and cross-file
+      duplication per file, counted over lexed source (comments and literals
+      blanked) rather than raw text. Exact once tree-sitter replaces the lexer.
 - [ ] **P0** Graph summary in the language result — node/edge counts, cycle count,
       and fan-in/fan-out ranking (the mockup's *Max fan-in · sdk · 7* panel).
 - [ ] **P1** Emit each SCC as an ordered path so the UI can print the cycle as

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ place and build. The web UI and richer analyzers are next — see
 **Per-language analysis** (one plugin per language)
 - Dependency graph + import-cycle detection ✅ (TS/JS starter)
 - Dead code (unreferenced exports, unreachable files) ⏳
-- Metrics: LOC, complexity, duplication ⏳
+- Metrics: LOC, cyclomatic complexity, nesting, duplication ✅ (TS/JS)
 - Angular module: component/DI graph, lazy boundaries ⏳
 - PHP module ⏳
 
@@ -106,7 +106,7 @@ packages/
 plugins/
   commit-conventional/     Conventional Commits parser
   git-hotspots/            churn × complexity metric
-  language-typescript/     TS/JS import graph + cycles
+  language-typescript/     TS/JS import graph, cycles + code metrics
   ai-provider-template/    copy-me AI backend
 apps/
   web/                     web UI (placeholder — scaffold here)

--- a/packages/sdk/src/language.ts
+++ b/packages/sdk/src/language.ts
@@ -13,6 +13,8 @@ export interface CodeMetric {
   loc: number;
   /** Cyclomatic complexity if the plugin computes it. */
   complexity?: number;
+  /** Deepest nesting of control-flow blocks, if computed. */
+  nesting?: number;
   /** 0–1 fraction of lines duplicated elsewhere, if computed. */
   duplication?: number;
 }

--- a/plugins/language-typescript/ARCHITECTURE.md
+++ b/plugins/language-typescript/ARCHITECTURE.md
@@ -6,8 +6,9 @@
 ## 1. Purpose & Goals
 
 Per-language analysis for **TypeScript / JavaScript**: build a file-level import
-dependency graph, detect import cycles, and report basic metrics. The reference
-language plugin — Angular and other TS-based analyzers build on its shape.
+dependency graph, detect import cycles, and measure each file (LOC, cyclomatic
+complexity, nesting depth, duplication). The reference language plugin — Angular
+and other TS-based analyzers build on its shape.
 
 ## 2. Constraints
 
@@ -25,26 +26,45 @@ language plugin — Angular and other TS-based analyzers build on its shape.
 
 | File | Responsibility |
 |------|----------------|
-| `index.ts` | The plugin: assemble nodes/edges, return `LanguageAnalysis`. |
-| `scan.ts` | Regex scan of one file → `{ loc, specs }`, cached per blob via `ctx.cache`. |
+| `index.ts` | The plugin: assemble nodes/edges/metrics, return `LanguageAnalysis`. |
+| `scan.ts` | Everything derivable from one file → `{ loc, specs, complexity, nesting, fingerprint }`, cached per blob via `ctx.cache`. |
+| `strip.ts` | The lexer: `stripNonCode` blanks comments, literals and regexes; `stripComments` blanks comments only. |
+| `complexity.ts` | McCabe cyclomatic complexity — 1 + decision points. |
+| `nesting.ts` | Deepest nesting of control-flow blocks. |
+| `fingerprint.ts` | Window hashes of one file's code — the per-file half of clone detection. |
+| `duplication.ts` | Compare fingerprints across files → duplicated share per file. |
 | `resolve.ts` | Map a relative specifier to a known file (`.ts`, `/index.ts`, …); bare imports ignored. |
 | `cycles.ts` | Tarjan's SCC; components with > 1 node are cycles. |
 
 ## 5. Runtime
 
-`analyze(ctx)` iterates the matched files, builds nodes/edges, computes cycles,
-returns `{ graph, deadCode, metrics }`.
+`analyze(ctx)` iterates the matched files, builds nodes/edges and collects each
+file's scan, then runs the one cross-file pass (duplication) and returns
+`{ graph, deadCode, metrics }`.
 
 ## 6. Decisions
 
 - **Regex now, tree-sitter next** — accurate module resolution, dead-code via
   real export-usage, and per-symbol edges come with the parser upgrade; the
   returned shape won't change.
-- **Cache the scan, not the resolution** — specifier resolution depends on the
-  whole file set, so only the contents-derived half is cacheable per blob.
+- **Cache the scan, not the resolution** — specifier resolution and fingerprint
+  matching depend on the whole file set, so only the contents-derived half is
+  cacheable per blob.
+- **Lex before counting** — metrics measure stripped text, never raw source, so
+  an `if` in a doc comment or a brace in a string cannot skew them.
+- **Strip differently per metric** — complexity and nesting count syntax, so
+  literals go; duplication compares code, so literals stay (otherwise every
+  barrel of `export * from './x.js'` reads as a wholesale clone).
+- **Whole-file metrics** — the file is the unit the graph, the hotspot map and
+  the dead-code table already address; per-function numbers wait for the parser.
 
 ## 7. Quality & Risks
 
 - **Risk:** regex misses dynamic imports / path aliases → missing or false edges.
   **Mitigation:** replace with tree-sitter / the TS compiler API (backlog).
+- **Risk:** the lexer's `/` heuristic can read a regex after `)` as division.
+  **Mitigation:** it only mis-blanks a literal, never a control keyword; gone
+  with the parser upgrade.
 - **Debt:** `deadCode` is a stub until real parsing lands.
+- **Debt:** complexity counts TypeScript conditional types (`T extends U ? …`)
+  as branches, and nesting only sees braced blocks.

--- a/plugins/language-typescript/package.json
+++ b/plugins/language-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@strata/plugin-language-typescript",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "TypeScript/JavaScript language-analysis plugin for Strata.",
   "license": "Apache-2.0",
   "type": "module",

--- a/plugins/language-typescript/src/complexity.test.ts
+++ b/plugins/language-typescript/src/complexity.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { cyclomaticComplexity } from './complexity.js';
+import { stripNonCode } from './strip.js';
+
+const complexityOf = (source: string): number =>
+  cyclomaticComplexity(stripNonCode(source));
+
+describe('cyclomaticComplexity', () => {
+  it('is 1 for straight-line code', () => {
+    expect(complexityOf('const a = 1;\nfoo(a);\n')).toBe(1);
+  });
+
+  it('counts every branch, loop, case and catch', () => {
+    const source = `
+      function f(xs) {
+        for (const x of xs) {
+          if (x) return 1;
+          else if (!x) return 2;
+          switch (x) {
+            case 1: break;
+            case 2: break;
+            default: break;
+          }
+        }
+        while (g()) h();
+        try { i(); } catch { j(); }
+      }`;
+
+    // 1 + for + if + if + case + case + while + catch
+    expect(complexityOf(source)).toBe(8);
+  });
+
+  it('counts a do…while once', () => {
+    expect(complexityOf('do { a(); } while (b());')).toBe(2);
+  });
+
+  it('counts logical operators and ternaries', () => {
+    expect(complexityOf('const a = b && c || d ?? e;')).toBe(4);
+    expect(complexityOf('const a = b ? c : d;')).toBe(2);
+  });
+
+  it('does not count optional chaining or optional parameters', () => {
+    expect(complexityOf('function f(a?: string, b?) { return a?.length; }')).toBe(1);
+    expect(complexityOf('interface I { a?: string; b?: number }')).toBe(1);
+  });
+
+  it('ignores keywords in comments, strings and identifiers', () => {
+    const source = `
+      // if (a) for (b) while (c)
+      const clarify = 'case && ||';
+      const notified = 1;
+      notify(clarify, notified);`;
+
+    expect(complexityOf(source)).toBe(1);
+  });
+});

--- a/plugins/language-typescript/src/complexity.ts
+++ b/plugins/language-typescript/src/complexity.ts
@@ -1,0 +1,24 @@
+/**
+ * A decision point is anything that adds a path through the code.
+ *
+ * `else` and `default` add none — they are the fall-through of a branch that is
+ * already counted — and `do … while` is counted once, by its `while`. The last
+ * alternative is the ternary `?`; everything else a `?` can be in TypeScript is
+ * excluded by the lookahead: `??`, `?.`, and an optional parameter or property
+ * (`a?: T`, `a?, b`, `a?)`).
+ */
+const DECISION_POINT =
+  /\b(?:if|for|while|case|catch)\b|&&|\|\||\?\?|\?(?![?.:,)\]])/g;
+
+/**
+ * McCabe cyclomatic complexity of one file: one path through it, plus one per
+ * decision point. Whole-file rather than per-function — the file is the unit
+ * the graph, the hotspot map and the dead-code table all address, so the
+ * numbers stay comparable.
+ *
+ * Expects text that already went through `stripNonCode`; run on raw source it
+ * would count the `if` in every comment.
+ */
+export function cyclomaticComplexity(code: string): number {
+  return 1 + (code.match(DECISION_POINT)?.length ?? 0);
+}

--- a/plugins/language-typescript/src/duplication.test.ts
+++ b/plugins/language-typescript/src/duplication.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { duplicationByPath } from './duplication.js';
+import { CLONE_WINDOW, fingerprint } from './fingerprint.js';
+import { stripComments } from './strip.js';
+
+/** A block of `n` distinct, long-enough-to-count lines. */
+const block = (tag: string, n: number): string =>
+  Array.from({ length: n }, (_, i) => `const ${tag}${i} = value(${i});`).join(
+    '\n',
+  );
+
+/** Fingerprint the way `scan.ts` does, so the tests exercise the real input. */
+const prints = (path: string, code: string) => ({
+  path,
+  ...fingerprint(stripComments(code)),
+});
+
+describe('fingerprint', () => {
+  it('needs a full window before it emits anything', () => {
+    expect(fingerprint(block('a', CLONE_WINDOW - 1)).prints).toHaveLength(0);
+    expect(fingerprint(block('a', CLONE_WINDOW)).prints).toHaveLength(1);
+    expect(fingerprint(block('a', CLONE_WINDOW + 2)).prints).toHaveLength(3);
+  });
+
+  it('ignores indentation and blank lines, so a re-indented copy still matches', () => {
+    const plain = fingerprint(block('a', CLONE_WINDOW));
+    const indented = fingerprint(
+      block('a', CLONE_WINDOW)
+        .split('\n')
+        .map((l) => `      ${l}\n`)
+        .join('\n'),
+    );
+
+    expect(indented.prints).toEqual(plain.prints);
+  });
+
+  it('drops punctuation-only lines', () => {
+    expect(fingerprint('}\n};\n});\n{\n').lines).toBe(0);
+  });
+});
+
+describe('duplicationByPath', () => {
+  it('is 0 when nothing is shared', () => {
+    const files = [
+      prints('a.ts', block('a', 20)),
+      prints('b.ts', block('b', 20)),
+    ];
+
+    expect(duplicationByPath(files).get('a.ts')).toBe(0);
+    expect(duplicationByPath(files).get('b.ts')).toBe(0);
+  });
+
+  it('is 1 for a file copied wholesale', () => {
+    const body = block('a', 12);
+    const dup = duplicationByPath([prints('a.ts', body), prints('b.ts', body)]);
+
+    expect(dup.get('a.ts')).toBe(1);
+    expect(dup.get('b.ts')).toBe(1);
+  });
+
+  it('reports the duplicated share of a partly copied file', () => {
+    const shared = block('s', CLONE_WINDOW);
+    const dup = duplicationByPath([
+      prints('a.ts', `${shared}\n${block('a', CLONE_WINDOW)}`),
+      prints('b.ts', shared),
+    ]);
+
+    // The shared half matches; the file's own half does not.
+    expect(dup.get('a.ts')).toBe(0.5);
+    expect(dup.get('b.ts')).toBe(1);
+  });
+
+  it('counts a block a file repeats within itself', () => {
+    const body = block('a', CLONE_WINDOW);
+    const dup = duplicationByPath([prints('a.ts', `${body}\n${body}`)]);
+
+    expect(dup.get('a.ts')).toBe(1);
+  });
+
+  it('does not call a barrel of re-exports a clone of itself', () => {
+    const barrel = ['a', 'b', 'c', 'd', 'e', 'f', 'g']
+      .map((m) => `export * from './${m}.js';`)
+      .join('\n');
+
+    expect(duplicationByPath([prints('index.ts', barrel)]).get('index.ts')).toBe(
+      0,
+    );
+  });
+
+  it('sees through rewritten comments but not through different literals', () => {
+    const body = block('a', CLONE_WINDOW);
+    const recommented = `// a different comment\n${body}`;
+    const relabelled = body.replaceAll('value(', 'other(');
+    const dup = duplicationByPath([
+      prints('a.ts', body),
+      prints('b.ts', recommented),
+      prints('c.ts', relabelled),
+    ]);
+
+    expect(dup.get('a.ts')).toBe(1);
+    expect(dup.get('b.ts')).toBe(1);
+    expect(dup.get('c.ts')).toBe(0);
+  });
+
+  it('reports 0 for a file with no windows at all', () => {
+    const dup = duplicationByPath([prints('tiny.ts', 'export {};')]);
+
+    expect(dup.get('tiny.ts')).toBe(0);
+  });
+});

--- a/plugins/language-typescript/src/duplication.ts
+++ b/plugins/language-typescript/src/duplication.ts
@@ -1,0 +1,41 @@
+import { CLONE_WINDOW, type Fingerprint } from './fingerprint.js';
+
+/** One file's fingerprint, tagged with the path it came from. */
+export interface FilePrints extends Fingerprint {
+  path: string;
+}
+
+/**
+ * Share of each file's code that also appears somewhere else — the cross-file
+ * half of duplicate detection, and the reason duplication cannot be computed
+ * inside the per-blob cache: a file's answer changes when *another* file does.
+ *
+ * A window whose hash occurs more than once is a clone, wherever its twin sits
+ * (another file, or the same file twice over). Every line such a window covers
+ * is marked, and the result is the marked share of the file's significant
+ * lines. Rounded to three decimals — it is a ratio for a bar in the UI, not an
+ * accounting figure.
+ */
+export function duplicationByPath(
+  files: readonly FilePrints[],
+): Map<string, number> {
+  const occurrences = new Map<string, number>();
+  for (const file of files) {
+    for (const print of file.prints) {
+      occurrences.set(print, (occurrences.get(print) ?? 0) + 1);
+    }
+  }
+
+  const duplication = new Map<string, number>();
+  for (const file of files) {
+    const duplicated = new Set<number>();
+    file.prints.forEach((print, start) => {
+      if ((occurrences.get(print) ?? 0) < 2) return;
+      const end = Math.min(start + CLONE_WINDOW, file.lines);
+      for (let line = start; line < end; line++) duplicated.add(line);
+    });
+    const share = file.lines === 0 ? 0 : duplicated.size / file.lines;
+    duplication.set(file.path, Math.round(share * 1000) / 1000);
+  }
+  return duplication;
+}

--- a/plugins/language-typescript/src/fingerprint.ts
+++ b/plugins/language-typescript/src/fingerprint.ts
@@ -1,0 +1,55 @@
+import { createHash } from 'node:crypto';
+
+/** Consecutive code lines that must match before a run counts as a clone. */
+export const CLONE_WINDOW = 6;
+
+/** Shorter than this and a line is punctuation (`}`, `});`), not content. */
+const MIN_LINE = 3;
+
+export interface Fingerprint {
+  /** How many significant lines the windows were drawn from. */
+  lines: number;
+  /**
+   * One hash per window, in order: window `i` covers significant lines
+   * `i … i + CLONE_WINDOW - 1`.
+   */
+  prints: string[];
+}
+
+/**
+ * Window hashes of one file's code — the per-file half of duplicate detection.
+ *
+ * Only this half depends on the file alone, so only this half is cacheable per
+ * blob; comparing the prints across files lives in `duplication.ts`.
+ *
+ * Expects text that went through `stripComments`: a copied block is still a
+ * copy when its comments were rewritten, but two lines that differ only in a
+ * string literal are two different lines.
+ *
+ * Whitespace is normalised so a re-indented copy still matches, and lines too
+ * short to carry meaning are dropped — otherwise every file in the repo would
+ * "share" its run of closing braces. Hashes are truncated because a repo's
+ * worth of them is stored in the cache and 64 bits is far past collision-free
+ * for the number of windows a single project has.
+ */
+export function fingerprint(code: string): Fingerprint {
+  const lines = significantLines(code);
+  const prints: string[] = [];
+  for (let i = 0; i + CLONE_WINDOW <= lines.length; i++) {
+    prints.push(hash(lines.slice(i, i + CLONE_WINDOW).join('\n')));
+  }
+  return { lines: lines.length, prints };
+}
+
+function significantLines(code: string): string[] {
+  const lines: string[] = [];
+  for (const line of code.split('\n')) {
+    const normalised = line.trim().replace(/\s+/g, ' ');
+    if (normalised.length > MIN_LINE) lines.push(normalised);
+  }
+  return lines;
+}
+
+function hash(text: string): string {
+  return createHash('sha1').update(text).digest('hex').slice(0, 16);
+}

--- a/plugins/language-typescript/src/index.ts
+++ b/plugins/language-typescript/src/index.ts
@@ -1,13 +1,15 @@
 import {
   defineLanguagePlugin,
+  type CodeMetric,
   type GraphEdge,
   type GraphNode,
   type LanguageAnalysis,
   type RepoContext,
 } from '@strata/sdk';
 import { findCycles } from './cycles.js';
+import { duplicationByPath } from './duplication.js';
 import { resolveLocal } from './resolve.js';
-import { scan } from './scan.js';
+import { scan, type FileScan } from './scan.js';
 
 /**
  * TypeScript / JavaScript language module.
@@ -18,6 +20,10 @@ import { scan } from './scan.js';
  * should parse with tree-sitter (or the TS compiler API) to get accurate module
  * resolution, unreferenced-export dead-code detection, and per-symbol edges.
  * The public shape it returns (LanguageAnalysis) will not change.
+ *
+ * Metrics are real, not placeholders: complexity and nesting are counted over
+ * code with comments and literals blanked out (`strip.ts`), and duplication
+ * compares window hashes across every file (`duplication.ts`).
  */
 export default defineLanguagePlugin({
   extensions: ['ts', 'tsx', 'js', 'jsx', 'mjs', 'cjs'],
@@ -25,33 +31,43 @@ export default defineLanguagePlugin({
     const byPath = new Map(ctx.files.map((f) => [f.path, f]));
     const nodes: GraphNode[] = [];
     const edges: GraphEdge[] = [];
+    const scans = new Map<string, FileScan>();
 
     for (const file of ctx.files) {
       // Reading and scanning is the expensive half and depends only on the
-      // file's contents; resolving specifiers depends on the whole file set,
-      // so it stays out of the cached value.
-      const { loc, specs } = await ctx.cache.file(file, scan);
+      // file's contents; resolving specifiers and matching fingerprints depend
+      // on the whole file set, so they stay out of the cached value.
+      const scanned = await ctx.cache.file(file, scan);
+      scans.set(file.path, scanned);
       nodes.push({
         id: file.path,
         label: file.path,
         kind: 'file',
-        meta: { loc },
+        meta: { loc: scanned.loc },
       });
 
-      for (const spec of specs) {
+      for (const spec of scanned.specs) {
         const target = resolveLocal(file, spec, byPath);
         if (target) edges.push({ from: file.path, to: target, kind: 'import' });
       }
     }
 
+    const duplication = duplicationByPath(
+      [...scans].map(([path, s]) => ({ path, ...s.fingerprint })),
+    );
+    const metrics: CodeMetric[] = [...scans].map(([path, s]) => ({
+      path,
+      loc: s.loc,
+      complexity: s.complexity,
+      nesting: s.nesting,
+      duplication: duplication.get(path) ?? 0,
+    }));
+
     return {
       graph: { nodes, edges, cycles: findCycles(nodes, edges) },
       // TODO: implement via a real parser — export usage across the graph.
       deadCode: [],
-      metrics: nodes.map((n) => ({
-        path: n.id,
-        loc: Number(n.meta?.loc ?? 0),
-      })),
+      metrics,
     };
   },
 });

--- a/plugins/language-typescript/src/nesting.test.ts
+++ b/plugins/language-typescript/src/nesting.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { maxNesting } from './nesting.js';
+import { stripNonCode } from './strip.js';
+
+const nestingOf = (source: string): number => maxNesting(stripNonCode(source));
+
+describe('maxNesting', () => {
+  it('is 0 without control flow', () => {
+    expect(nestingOf('const a = { b: 1 };\nfunction f() { return a; }')).toBe(0);
+  });
+
+  it('counts nested control blocks', () => {
+    const source = `
+      function f(xs) {
+        for (const x of xs) {
+          if (x) {
+            while (x.next) {
+              x = x.next;
+            }
+          }
+        }
+      }`;
+
+    expect(nestingOf(source)).toBe(3);
+  });
+
+  it('reports the deepest nest, not the last one', () => {
+    const source = `
+      if (a) {
+        if (b) {
+          c();
+        }
+      }
+      if (d) {
+        e();
+      }`;
+
+    expect(nestingOf(source)).toBe(2);
+  });
+
+  it('does not count function bodies, classes or object literals', () => {
+    const source = `
+      class C {
+        m() {
+          const handlers = { onX: () => { g(); } };
+          return handlers;
+        }
+      }`;
+
+    expect(nestingOf(source)).toBe(0);
+  });
+
+  it('counts else, do, try and catch blocks', () => {
+    expect(nestingOf('if (a) { b(); } else { c(); }')).toBe(1);
+    expect(nestingOf('try { a(); } catch (e) { b(); } finally { c(); }')).toBe(1);
+    expect(nestingOf('do { if (a) { b(); } } while (c);')).toBe(2);
+  });
+
+  it('does not mistake a call for a control head', () => {
+    expect(nestingOf('render(props) { return null; }')).toBe(0);
+    expect(nestingOf('describe("if", () => { it("for", () => {}); });')).toBe(0);
+  });
+
+  it('counts a block only once for else if', () => {
+    expect(nestingOf('if (a) { b(); } else if (c) { d(); }')).toBe(1);
+  });
+});

--- a/plugins/language-typescript/src/nesting.ts
+++ b/plugins/language-typescript/src/nesting.ts
@@ -1,0 +1,69 @@
+/** Keywords whose `(…)` head is followed by the block they control. */
+const HEAD_KEYWORDS = new Set(['if', 'for', 'while', 'switch', 'catch']);
+
+/** Keywords that open their block directly, with no head in between. */
+const BARE_KEYWORDS = new Set(['else', 'do', 'try', 'finally']);
+
+/**
+ * Deepest nesting of control-flow blocks in one file.
+ *
+ * Complexity counts branches; nesting says how tangled they are — twelve flat
+ * `if`s read fine, four nested ones do not. Only control blocks count: function
+ * bodies, classes and object literals are structure, not depth, so a method
+ * three classes deep still reports 0 until it branches.
+ *
+ * Expects text that already went through `stripNonCode` — a brace inside a
+ * string would otherwise shift every level after it.
+ */
+export function maxNesting(code: string): number {
+  /** One entry per open brace: does it hold a control block? */
+  const blocks: boolean[] = [];
+  let depth = 0;
+  let max = 0;
+
+  for (let i = 0; i < code.length; i++) {
+    const ch = code[i];
+    if (ch === '{') {
+      const control = opensControlBlock(code, i);
+      blocks.push(control);
+      if (control && ++depth > max) max = depth;
+    } else if (ch === '}' && blocks.pop()) depth--;
+  }
+
+  return max;
+}
+
+/** Is the brace at `brace` the body of an `if`/`for`/`else`/…? */
+function opensControlBlock(code: string, brace: number): boolean {
+  const before = skipSpaceBack(code, brace - 1);
+  if (code[before] === ')') {
+    const head = skipSpaceBack(code, beforeMatchingParen(code, before));
+    return HEAD_KEYWORDS.has(wordEndingAt(code, head));
+  }
+  return BARE_KEYWORDS.has(wordEndingAt(code, before));
+}
+
+/** Index just before the `(` matching the `)` at `close`. */
+function beforeMatchingParen(code: string, close: number): number {
+  let open = 1;
+  let i = close - 1;
+  for (; i >= 0 && open > 0; i--) {
+    if (code[i] === ')') open++;
+    else if (code[i] === '(') open--;
+  }
+  return i;
+}
+
+function skipSpaceBack(code: string, from: number): number {
+  let i = from;
+  while (i >= 0 && /\s/.test(code[i]!)) i--;
+  return i;
+}
+
+/** The identifier ending at `end`, or "" if that isn't a word character. */
+function wordEndingAt(code: string, end: number): string {
+  if (end < 0 || !/[\w$]/.test(code[end]!)) return '';
+  let start = end;
+  while (start > 0 && /[\w$]/.test(code[start - 1]!)) start--;
+  return code.slice(start, end + 1);
+}

--- a/plugins/language-typescript/src/scan.test.ts
+++ b/plugins/language-typescript/src/scan.test.ts
@@ -1,0 +1,46 @@
+import type { RepoFile } from '@strata/sdk';
+import { describe, expect, it } from 'vitest';
+import { scan } from './scan.js';
+
+const file = (path: string, text: string): RepoFile => ({
+  path,
+  blob: path,
+  read: async () => text,
+});
+
+describe('scan', () => {
+  it('reports loc, specifiers and every metric from one read', async () => {
+    const scanned = await scan(
+      file(
+        'a.ts',
+        [
+          `import { b } from './b.js';`,
+          'export function f(xs: string[]) {',
+          '  for (const x of xs) {',
+          '    if (x) {',
+          '      return x && b;',
+          '    }',
+          '  }',
+          '  return null;',
+          '}',
+        ].join('\n'),
+      ),
+    );
+
+    expect(scanned.loc).toBe(9);
+    expect(scanned.specs).toEqual(['./b.js']);
+    expect(scanned.complexity).toBe(4); // for + if + &&
+    expect(scanned.nesting).toBe(2);
+    // The two closing braces are punctuation, not content.
+    expect(scanned.fingerprint.lines).toBe(6);
+  });
+
+  it('measures the code, not the comments', async () => {
+    const scanned = await scan(
+      file('b.ts', '// if (a) { for (b) { c(); } }\nexport const d = 1;\n'),
+    );
+
+    expect(scanned.complexity).toBe(1);
+    expect(scanned.nesting).toBe(0);
+  });
+});

--- a/plugins/language-typescript/src/scan.ts
+++ b/plugins/language-typescript/src/scan.ts
@@ -1,14 +1,25 @@
 import type { RepoFile } from '@strata/sdk';
+import { cyclomaticComplexity } from './complexity.js';
+import { fingerprint, type Fingerprint } from './fingerprint.js';
+import { maxNesting } from './nesting.js';
+import { stripComments, stripNonCode } from './strip.js';
 
 /**
  * What we extract from one file — cached per blob, so unchanged files are free.
- * Only contents-derived data belongs here; resolving a specifier needs the
- * whole file set and must stay outside the cached value.
+ * Only contents-derived data belongs here; resolving a specifier and comparing
+ * fingerprints both need the whole file set and must stay outside the cached
+ * value.
  */
 export interface FileScan {
   loc: number;
   /** Relative import specifiers, unresolved. */
   specs: string[];
+  /** McCabe cyclomatic complexity of the whole file. */
+  complexity: number;
+  /** Deepest nesting of control-flow blocks. */
+  nesting: number;
+  /** Window hashes, for the cross-file duplication pass. */
+  fingerprint: Fingerprint;
 }
 
 const IMPORT_RE =
@@ -22,5 +33,16 @@ export async function scan(file: RepoFile): Promise<FileScan> {
     const spec = match[1] ?? match[2];
     if (spec?.startsWith('.')) specs.push(spec); // skip bare/pkg imports
   }
-  return { loc: text.split('\n').length, specs };
+
+  // Specifiers live *in* string literals, so they are read from the raw text.
+  // The metrics each get the text stripped the way they need it: counting
+  // syntax means dropping literals, comparing code means keeping them.
+  const code = stripNonCode(text);
+  return {
+    loc: text.split('\n').length,
+    specs,
+    complexity: cyclomaticComplexity(code),
+    nesting: maxNesting(code),
+    fingerprint: fingerprint(stripComments(text)),
+  };
 }

--- a/plugins/language-typescript/src/strip.test.ts
+++ b/plugins/language-typescript/src/strip.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { stripComments, stripNonCode } from './strip.js';
+
+/**
+ * What survived the strip, with the blanked runs collapsed — asserting on the
+ * exact number of spaces would test the length of the fixtures, not the lexer.
+ * The alignment those spaces preserve gets its own test below.
+ */
+const kept = (source: string): string =>
+  stripNonCode(source).replace(/ +/g, ' ').trim();
+
+describe('stripNonCode', () => {
+  it('keeps the output aligned with the input, character for character', () => {
+    const source = 'const a = 1; // if (x) {\n/* if (y) */ b();\n';
+    const code = stripNonCode(source);
+
+    expect(code).toHaveLength(source.length);
+    expect(code.split('\n')).toEqual(['const a = 1;            ', '             b();', '']);
+  });
+
+  it('blanks comments', () => {
+    expect(kept('a(); // if (x) { y }')).toBe('a();');
+    expect(kept('/* if (x) */ a(); /* while (y)')).toBe('a();');
+  });
+
+  it('blanks strings, quotes and all', () => {
+    expect(kept(`const s = 'if (a) { b }';`)).toBe('const s = ;');
+    expect(kept('const s = "a\\"b" + c;')).toBe('const s = + c;');
+  });
+
+  it('does not let an unterminated quote swallow the rest of the file', () => {
+    const code = stripNonCode("const s = 'oops;\nif (a) b();\n");
+
+    expect(code.split('\n')[1]).toBe('if (a) b();');
+  });
+
+  it('keeps template interpolations and drops the literal around them', () => {
+    expect(kept('const s = `x ${a ? b : c} y`;')).toBe('const s = a ? b : c ;');
+  });
+
+  it('handles a template nested inside an interpolation', () => {
+    expect(kept('f(`a ${g(`b ${c && d}`)} e`);')).toBe('f( g( c && d ) );');
+  });
+
+  it('treats a brace inside an interpolation as code, not as the closer', () => {
+    const code = kept('`${ ((): void => { if (a) b(); })() }` + c;');
+
+    expect(code).toBe('((): void => { if (a) b(); })() + c;');
+  });
+
+  it('blanks a regex literal, quotes and slashes and all', () => {
+    expect(kept(`const re = /['"]\\/\\/[^/]*/g;\nif (a) b();`)).toBe(
+      'const re = ;\nif (a) b();',
+    );
+  });
+
+  it('reads a slash after a value as division, not as a regex', () => {
+    expect(kept('const r = total / count / 2;')).toBe('const r = total / count / 2;');
+  });
+
+  it('reads a slash after a keyword or an operator as a regex', () => {
+    expect(kept('return /a b/.test(s);')).toBe('return .test(s);');
+    expect(kept('const m = s.split(/,/);')).toBe('const m = s.split( );');
+  });
+});
+
+describe('stripComments', () => {
+  it('drops the comments and keeps every literal', () => {
+    const source = [
+      '/** doc */',
+      `export * from './version.js'; // barrel`,
+      'const s = `x ${a ? b : c} y`;',
+      "const re = /a'b/g;",
+    ].join('\n');
+
+    expect(stripComments(source).split('\n')).toEqual([
+      '          ',
+      `export * from './version.js';          `,
+      'const s = `x ${a ? b : c} y`;',
+      "const re = /a'b/g;",
+    ]);
+  });
+
+  it('does not mistake a comment marker inside a literal for a comment', () => {
+    const source = `const url = 'https://example.com'; // gone\nnext();`;
+
+    expect(stripComments(source).split('\n')[0]).toBe(
+      `const url = 'https://example.com';        `,
+    );
+  });
+});

--- a/plugins/language-typescript/src/strip.ts
+++ b/plugins/language-typescript/src/strip.ts
@@ -1,0 +1,201 @@
+/**
+ * Characters that cannot end an expression, so a `/` after one opens a regex
+ * literal rather than dividing. The classic disambiguation heuristic.
+ */
+const BEFORE_REGEX = new Set([
+  '(',
+  '[',
+  '{',
+  ',',
+  ';',
+  ':',
+  '=',
+  '!',
+  '<',
+  '>',
+  '+',
+  '-',
+  '*',
+  '/',
+  '%',
+  '&',
+  '|',
+  '^',
+  '~',
+  '?',
+]);
+
+/** Keywords a regex literal may directly follow (`return /x/`, `case /x/`). */
+const BEFORE_REGEX_KEYWORDS = new Set([
+  'return',
+  'typeof',
+  'instanceof',
+  'in',
+  'of',
+  'new',
+  'delete',
+  'void',
+  'case',
+  'do',
+  'else',
+  'yield',
+  'await',
+  'throw',
+]);
+
+/**
+ * Blank out everything that is not code — comments, string and template
+ * literals, regex bodies — replacing each character with a space and keeping
+ * newlines, so the result lines up with the original line for line.
+ *
+ * Counting syntax in raw text lies: an `if` in a doc comment, a `//` inside a
+ * URL, an unbalanced brace in a message string. Complexity and nesting
+ * therefore measure this. Template *interpolations* survive — `${a ? b : c}`
+ * really is a branch — only the literal parts around them go.
+ */
+export function stripNonCode(source: string): string {
+  return strip(source, false);
+}
+
+/**
+ * Blank the comments and leave every literal in place.
+ *
+ * What duplication compares: two files that differ only in their header comment
+ * are copies, while two lines that differ only in a string — `export * from
+ * './a.js'` and `'./b.js'` — are not. Blanking literals for this pass would
+ * report every barrel file in the repo as a wholesale clone.
+ */
+export function stripComments(source: string): string {
+  return strip(source, true);
+}
+
+/**
+ * The shared lexer. It knows tokens, not structure — enough for the metrics,
+ * and it keeps the plugin dependency-free until tree-sitter lands. Literals are
+ * always *recognised* (a `//` inside a string is not a comment); `keepLiterals`
+ * only decides whether their characters survive.
+ */
+function strip(source: string, keepLiterals: boolean): string {
+  const out: string[] = [];
+  /** Blank `[from, to)` and return the new cursor. */
+  const blank = (from: number, to: number): number => {
+    const end = Math.min(to, source.length);
+    for (let i = from; i < end; i++) out.push(source[i] === '\n' ? '\n' : ' ');
+    return end;
+  };
+  /** Same span, kept verbatim. */
+  const copy = (from: number, to: number): number => {
+    const end = Math.min(to, source.length);
+    for (let i = from; i < end; i++) out.push(source[i]!);
+    return end;
+  };
+  const literal = keepLiterals ? copy : blank;
+
+  /** Brace depth inside each open `${…}`; empty while in plain code. */
+  const interpolations: number[] = [];
+  let inTemplate = false;
+  let i = 0;
+
+  while (i < source.length) {
+    const ch = source[i]!;
+
+    if (inTemplate) {
+      if (ch === '\\') i = literal(i, i + 2);
+      else if (ch === '`') {
+        inTemplate = false;
+        i = literal(i, i + 1);
+      } else if (ch === '$' && source[i + 1] === '{') {
+        interpolations.push(0);
+        inTemplate = false;
+        i = literal(i, i + 2);
+      } else i = literal(i, i + 1);
+      continue;
+    }
+
+    if (ch === '/' && source[i + 1] === '/') {
+      const end = source.indexOf('\n', i);
+      i = blank(i, end === -1 ? source.length : end);
+      continue;
+    }
+    if (ch === '/' && source[i + 1] === '*') {
+      const end = source.indexOf('*/', i + 2);
+      i = blank(i, end === -1 ? source.length : end + 2);
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      i = literal(i, endOfString(source, i, ch));
+      continue;
+    }
+    if (ch === '`') {
+      inTemplate = true;
+      i = literal(i, i + 1);
+      continue;
+    }
+    if (ch === '/' && startsRegex(source, i)) {
+      i = literal(i, endOfRegex(source, i));
+      continue;
+    }
+
+    // The `${` of the enclosing interpolation is not a brace the loop can see
+    // (blanked, or part of the literal), so its `}` is found by counting.
+    const open = interpolations.length - 1;
+    if (open >= 0 && (ch === '{' || ch === '}')) {
+      if (ch === '{') interpolations[open]!++;
+      else if (interpolations[open] === 0) {
+        interpolations.pop();
+        inTemplate = true;
+        i = literal(i, i + 1);
+        continue;
+      } else interpolations[open]!--;
+    }
+
+    out.push(ch);
+    i++;
+  }
+
+  return out.join('');
+}
+
+/** Index just past the closing quote — or the line end, if unterminated. */
+function endOfString(source: string, start: number, quote: string): number {
+  for (let i = start + 1; i < source.length; i++) {
+    const ch = source[i]!;
+    if (ch === '\\') i++;
+    else if (ch === quote) return i + 1;
+    else if (ch === '\n') return i; // don't let one bad quote eat the file
+  }
+  return source.length;
+}
+
+/** Index just past a regex literal's closing `/` and its flags. */
+function endOfRegex(source: string, start: number): number {
+  let inClass = false;
+  for (let i = start + 1; i < source.length; i++) {
+    const ch = source[i]!;
+    if (ch === '\\') i++;
+    else if (ch === '\n') return i;
+    else if (inClass) inClass = ch !== ']';
+    else if (ch === '[') inClass = true;
+    else if (ch === '/') {
+      let end = i + 1;
+      while (end < source.length && /[a-z]/i.test(source[end]!)) end++;
+      return end;
+    }
+  }
+  return source.length;
+}
+
+/** Does the `/` at `at` open a regex literal, or is it a division? */
+function startsRegex(source: string, at: number): boolean {
+  let i = at - 1;
+  while (i >= 0 && /\s/.test(source[i]!)) i--;
+  if (i < 0) return true;
+
+  const ch = source[i]!;
+  if (BEFORE_REGEX.has(ch)) return true;
+  if (!/[\w$]/.test(ch)) return false;
+
+  const end = i + 1;
+  while (i >= 0 && /[\w$]/.test(source[i]!)) i--;
+  return BEFORE_REGEX_KEYWORDS.has(source.slice(i + 1, end));
+}

--- a/plugins/language-typescript/strata.plugin.json
+++ b/plugins/language-typescript/strata.plugin.json
@@ -2,7 +2,7 @@
   "id": "strata-language-typescript",
   "name": "TypeScript / JavaScript",
   "kind": "language",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "sdk": "0.1.0",
   "main": "./dist/index.js",
   "description": "Import dependency graph, cycle detection, and metrics for TS/JS. Angular and other analyzers build on this.",


### PR DESCRIPTION
## What

Real per-file metrics for TS/JS, replacing the LOC-only stub:

| Metric | How |
|---|---|
| **Cyclomatic complexity** | McCabe: 1 + `if`/`for`/`while`/`case`/`catch`/`&&`/`\|\|`/`??`/ternary. `else` and `default` add nothing, `do…while` counts once, and `?.` / `a?: T` / `a?,` are excluded from the ternary match. |
| **Nesting** | Deepest *control-flow* nesting — brace walk that looks back past the `(…)` head for a keyword, so function bodies, classes and object literals don't inflate depth. |
| **Duplication** | 6-line rolling window hashes per file, compared across the whole file set; the result is the duplicated share of each file's significant lines. |

All three count **lexed** source, not raw text. `strip.ts` is a small hand-written lexer that blanks comments, string/template literals and regex bodies, so an `if` in a doc comment or a brace in a message string can't skew a number. Template interpolations survive — `${a ? b : c}` really is a branch.

Duplication uses a second mode that blanks comments but **keeps** literals: a rewritten header shouldn't hide a clone, while two lines differing only in a string aren't the same line. This was found by dogfooding — blanking literals reported every barrel of `export * from './x.js'` as 100% duplicated.

`CodeMetric` gains `nesting?`. Only the cross-file fingerprint comparison runs outside the blob cache — the same split specifier resolution already uses — so the per-file half stays cacheable and a rerun re-reads only what changed. The plugin version is bumped to 0.2.0 so stale `FileScan` cache entries (keyed on plugin version) predating the new fields aren't reused.

**Verified on this repo:** complexity peaks at 18 in `packages/core/src/cache/sqlite.ts`, max nesting 3 in `plugins/git-coupling/src/pairs.ts`, and the top duplication hit is genuine — the `history()` fixture is copy-pasted between `commits.test.ts` and `index.test.ts`.

## Why

Closes #16 (`BACKLOG.md` → Language modules → P0 "Real metrics"). The mockup's metrics panel had nothing to render but LOC.

## Type of change

- [x] feat / fix / perf / refactor
- [ ] docs / test / build / ci / chore

## Checklist

- [x] `pnpm build && pnpm test && pnpm lint` pass locally (`make check`)
- [x] Added/updated tests where it made sense — 37 new tests across the lexer, each metric, and the scan wiring
- [x] Docs updated — plugin `ARCHITECTURE.md` (building blocks, decisions, and the known debt: conditional types count as branches, braceless `if` bodies don't nest), `BACKLOG.md`, `README.md`

## Not in scope

- `.js`-specifier resolution (`./scan.js` never matches `scan.ts`, so most imports don't resolve) belongs to the tree-sitter backlog item.
- Plugin `tsconfig`s compile `*.test.ts` into `dist`; pre-existing for `git-coupling` too, so this PR doesn't diverge unilaterally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)