### PR TITLE
feat(web): scaffold the SvelteKit UI with the theme layer and API client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,13 @@ PORT=4000
 # Directory of repositories to analyse (mounted read-only into the container)
 STRATA_REPOS_DIR=./repos
 
+# --- Web UI (apps/web, dev only) ---------------------------------------------
+# Where the Vite dev server forwards /health, /plugins, /analyze and /cache.
+# The built UI is served from the same origin as the API, so it needs neither.
+STRATA_API_PROXY=http://localhost:4000
+# Bake an absolute API origin into a build instead (that origin then needs CORS):
+# VITE_STRATA_API=https://strata.example.com
+
 # --- Plugins ----------------------------------------------------------------
 # Drop-in directory for third-party plugins: one subdirectory per plugin, each
 # with a strata.plugin.json (see docs/PLUGINS.md). Built-ins always load first.

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -136,8 +136,11 @@ Sans/Mono.
 
 ### Shell
 
-- [ ] **P0** Scaffold the frontend (Vite + SvelteKit/Next + Tailwind) and port the
-      mockup's token set as the theme layer (light + dark, both specified)
+- [x] Scaffold the frontend — Vite + SvelteKit (static SPA) + Tailwind v4, with
+      the token set as the theme layer (`lib/theme/tokens.css`, both palettes,
+      switchable dark / light / system), a typed REST client per endpoint, and
+      IBM Plex self-hosted. The palette is derived from the mockup's
+      description, so expect a tuning pass as screens land.
 - [ ] **P0** App shell — left rail (logo, project switcher, analysis nav, plugin
       count, settings entries), sticky header (breadcrumb, branch + rev chips,
       last-run summary, *Re-analyze*), scrollable main pane

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,3 +116,9 @@ packages/core/src/
 
 Tests sit next to what they test (`cache/cache.test.ts`). When a file starts
 answering two questions, split it rather than adding a section comment.
+
+`make test` runs two vitest projects from the root config: **node** for
+`packages/` and `plugins/`, and **web** for `apps/web`, which needs the Svelte
+compiler and a DOM (`apps/web/vitest.config.ts`). Frontend code is tested the
+same way as everything else — components mount through `src/lib/test/render`
+and are asserted against the DOM.

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,10 @@ distclean: clean ## clean + remove all node_modules
 dev: ## Run the API server in watch mode
 	$(PNPM) --filter @strata/server dev
 
+.PHONY: web
+web: ## Run the web UI in dev mode (:5173, proxies the API to :4000)
+	$(PNPM) --filter @strata/web dev
+
 .PHONY: analyze
 analyze: ## Analyze a repo: make analyze REPO=/path/to/repo [LIMIT=500]
 	@test -n "$(REPO)" || (echo "REPO=/path/to/repo is required" && exit 1)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ the tool grows without the core changing.
 
 🚧 **Early scaffold.** The plugin contracts (`@strata/sdk`), the orchestrator
 (`@strata/core`), the API (`@strata/server`) and five example plugins are in
-place and build. The web UI and richer analyzers are next — see
+place and build. The web UI (`apps/web`) is scaffolded — SvelteKit + Tailwind,
+theme layer and API client wired; the analysis screens are next. See
 [`BACKLOG`](#roadmap).
 
 ## Features (built + planned)
@@ -51,6 +52,7 @@ corepack enable
 make install        # pnpm install
 make check          # build + typecheck + lint + test (the full local gate)
 make dev            # start @strata/server on :4000
+make web            # start the web UI on :5173 (proxies the API to :4000)
 
 # analyse any repo straight from the CLI (no server needed)
 make analyze REPO=/absolute/path/to/a/repo LIMIT=500
@@ -110,7 +112,7 @@ plugins/
   language-typescript/     TS/JS import graph, cycles + code metrics
   ai-provider-template/    copy-me AI backend
 apps/
-  web/                     web UI (placeholder — scaffold here)
+  web/      @strata/web    web UI — SvelteKit SPA + Tailwind (scaffold)
 docs/                      architecture, plugin authoring, ops
 ```
 

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -1,0 +1,3 @@
+.svelte-kit/
+build/
+.vite/

--- a/apps/web/ARCHITECTURE.md
+++ b/apps/web/ARCHITECTURE.md
@@ -1,46 +1,69 @@
 # Module: `@strata/web` — Architecture (arc42)
 
 > Trimmed arc42, consistent with [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md).
-> Status: **placeholder** — to be scaffolded.
+> Status: **scaffolded** — theme layer and API client in place; the workbench
+> shell and the analysis screens are still to build.
 
 ## 1. Purpose & Goals
 
 The **web UI**: dashboards that turn an `AnalysisReport` into hotspot treemaps,
-dependency graphs, and commit analytics, plus a settings screen for AI
-providers. The face of Strata for browser/self-host use.
+dependency graphs, commit analytics and dead-code tables, plus the project- and
+app-scoped settings screens. The face of Strata for browser/self-host use.
 
 ## 2. Constraints
 
-- Talks to `@strata/server` over REST only (no direct core import).
-- Must render in a browser and, later, inside the Tauri desktop shell.
-- Theme-aware, responsive.
+- Talks to `@strata/server` over REST only — no import of `@strata/core`.
+  `@strata/sdk` is used for **types only** (`import type`), so nothing of it is
+  bundled and the contract stays single-sourced.
+- Must render in a browser and, later, inside the Tauri desktop shell → the
+  build is static files, with no Node runtime of its own.
+- Theme-aware (dark + light), responsive.
+- Analysis stays offline: fonts are self-hosted, no CDN or third-party origin.
 
 ## 3. Interfaces (Context)
 
-- **Depends on:** `@strata/server` REST API (`/analyze`, `/plugins`, `/health`).
+- **Depends on:** the `@strata/server` REST API (`/health`, `/plugins`,
+  `/analyze`, `/cache`).
 - **Consumed by:** end users (browser / desktop).
 
-## 4. Building Blocks (planned)
+## 4. Building Blocks
 
-| View | Source in report |
-|------|------------------|
-| Hotspot treemap | `metrics.find((m) => m.id === "hotspots")` |
-| Change coupling | `metrics.find((m) => m.id === "change-coupling")` (pair list / chord) |
-| Dependency graph | `languages[*].graph` (Cytoscape/d3) |
-| Commit analytics | `commits[]` (type/scope/breaking) |
-| Settings | AI provider registration |
+| Block | Responsibility |
+|-------|----------------|
+| `src/app.html` | Document shell; applies the stored theme before first paint |
+| `src/app.css` | Tailwind entry: fonts, `@theme inline` token mapping, base layer |
+| `src/lib/theme/tokens.css` | The palette, twice — dark and light, keyed on `data-theme` |
+| `src/lib/theme/*` | `mode` (types + resolution), `storage`, `apply`, `controller.svelte` (state) |
+| `src/lib/api/*` | `base` (origin), `request` (fetch + `ApiError`), one module per endpoint, `types` |
+| `src/lib/components/*` | Reusable UI pieces |
+| `src/routes/*` | SvelteKit routes; `+layout.ts` pins the app to SPA mode |
 
 ## 5. Runtime
 
-User triggers an analysis → UI POSTs `/analyze` → renders the returned report.
+1. `app.html` reads `strata:theme` from `localStorage` and sets `data-theme`.
+2. The root layout starts the theme controller, which adopts the stored mode
+   and tracks `prefers-color-scheme` while the app is open.
+3. A view calls `lib/api`; failures arrive as one `ApiError` shape.
+4. In dev, Vite proxies the API paths to `:4000`; in production the server
+   serves this build, so the same relative URLs hold.
 
 ## 6. Decisions
 
-- **Recommended stack:** Vite + SvelteKit (or Next.js) + Tailwind — see the
-  design discussion. Deliberately un-scaffolded so the choice stays open.
+| # | Decision | Why |
+|---|----------|-----|
+| 1 | **Vite + SvelteKit + Tailwind v4** | Small runtime, first-class Vite, and Tailwind v4's CSS-first `@theme` matches a token file better than a JS config |
+| 2 | **`adapter-static`, SPA (`ssr = false`)** | The output is a folder of files: `@strata/server` can serve it from the Docker image and Tauri can load it from disk. Analysis is a local API call — nothing needs server rendering |
+| 3 | **Tokens in CSS, mapped with `@theme inline`** | One palette file per theme; utilities resolve the variable at use time, so switching `data-theme` repaints without a rebuild or a duplicate `dark:` class set |
+| 4 | **API paths not prefixed (`/analyze`, not `/api/analyze`)** | Matches the server as it is; dev proxy mirrors the same paths, so dev and production URLs are identical |
+| 5 | **Type-only dependency on `@strata/sdk`** | The report's leaf types stay in sync with the backend without a runtime coupling |
+| 6 | **Self-hosted IBM Plex via `@fontsource`** | Keeps a self-hosted install fully offline |
 
 ## 7. Quality & Risks
 
 - **Risk:** graph rendering perf on large repos. **Mitigation:** virtualise /
   cluster nodes; render server-computed summaries first.
-- **Debt:** everything — this module is a stub. See the backlog.
+- **Risk:** the palette here is derived from the mockup's description rather
+  than exported from it; expect a tuning pass when the screens land.
+- **Debt:** ESLint skips this app (`apps/web/**` is ignored at the root) —
+  `svelte-check` is the only static gate until `eslint-plugin-svelte` is wired in.
+- **Debt:** no component tests yet; only `lib/theme/mode` is covered.

--- a/apps/web/ARCHITECTURE.md
+++ b/apps/web/ARCHITECTURE.md
@@ -37,6 +37,7 @@ app-scoped settings screens. The face of Strata for browser/self-host use.
 | `src/lib/api/*` | `base` (origin), `request` (fetch + `ApiError`), one module per endpoint, `types` |
 | `src/lib/components/*` | Reusable UI pieces |
 | `src/routes/*` | SvelteKit routes; `+layout.ts` pins the app to SPA mode |
+| `src/lib/test/render.ts` | Mounts a component into a detached container for a test |
 
 ## 5. Runtime
 
@@ -66,4 +67,8 @@ app-scoped settings screens. The face of Strata for browser/self-host use.
   than exported from it; expect a tuning pass when the screens land.
 - **Debt:** ESLint skips this app (`apps/web/**` is ignored at the root) —
   `svelte-check` is the only static gate until `eslint-plugin-svelte` is wired in.
-- **Debt:** no component tests yet; only `lib/theme/mode` is covered.
+- **Tests:** `vitest` with the plain Svelte plugin and a `happy-dom`
+  environment (`vitest.config.ts`), wired into the root run as a second
+  project. Covered: theme resolution, storage, the appearance controller, the
+  request helper's error normalisation, and the two stateful components
+  (`ThemeSwitch`, `ServerStatus`). Components mount through `lib/test/render`.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,18 +1,76 @@
 # @strata/web
 
-The web UI (dashboards for hotspots, dependency graphs, commit analytics).
+The Strata web UI — dashboards for hotspots, dependency graphs, commit
+analytics, and the project/app settings screens.
 
-This is a **placeholder**. Scaffold the frontend of your choice here — the
-recommendation in the design doc is Vite + SvelteKit (or Next.js) + Tailwind,
-talking to `@strata/server` over REST. Suggested first views:
+**Stack:** Vite + SvelteKit (Svelte 5 runes) + Tailwind CSS v4, built as a
+static SPA with `@sveltejs/adapter-static`. It talks to `@strata/server` over
+REST only.
 
-- **Hotspot treemap** — from `GET/POST /analyze` → the `metrics` series with
-  `id: "hotspots"` (the report's `metrics` is an array of `MetricSeries`).
-- **Change coupling** — the `metrics` series with `id: "change-coupling"`
-  (pairs, degree in `%`).
-- **Dependency graph** — from `languages[*].graph` (render with Cytoscape/d3).
-- **Commit analytics** — from `commits[]` (types, scopes, breaking changes).
-- **Settings** — register AI providers and API keys.
+## Run it
 
-Wire `dev`/`build`/`typecheck` scripts once scaffolded so the root
-`pnpm` scripts and CI pick it up automatically.
+```bash
+make dev        # terminal 1 — the API on :4000
+make web        # terminal 2 — the UI on :5173
+```
+
+The dev server proxies the API paths (`/health`, `/plugins`, `/analyze`,
+`/cache`) to `http://localhost:4000`, so the UI uses the same relative URLs in
+dev as in production, where the server serves this build itself. Two knobs:
+
+| Variable | Where | Default | Purpose |
+|----------|-------|---------|---------|
+| `STRATA_API_PROXY` | dev server | `http://localhost:4000` | Where Vite forwards API calls |
+| `VITE_STRATA_API` | build | *(empty = same origin)* | Absolute API origin to bake into the build (needs CORS) |
+
+Other targets: `pnpm --filter @strata/web build` (writes `build/`),
+`preview`, and `typecheck` (`svelte-check`).
+
+## Layout
+
+```
+src/
+  app.html            document shell + the pre-paint theme bootstrap
+  app.css             Tailwind entry: fonts, token → theme mapping, base layer
+  lib/
+    theme/            tokens.css (both palettes) + the appearance controller
+    api/              one module per endpoint over a shared request helper
+    components/       reusable UI pieces
+  routes/             SvelteKit routes (SPA: `ssr = false`)
+static/               favicon and anything else served verbatim
+```
+
+## Theming
+
+`lib/theme/tokens.css` holds the mockup's palette twice — dark and light —
+keyed on `data-theme` on `<html>`. `app.css` maps those `--strata-*` variables
+onto Tailwind theme keys with `@theme inline`, so components only ever use
+semantic utilities:
+
+- surfaces — `bg-bg`, `bg-surface`, `bg-elevated`, `border-line`, `border-line-strong`
+- text — `text-ink`, `text-muted`, `text-subtle`
+- accent & status — `accent`, `accent-soft`, `accent-ink`, `ok`, `warn`, `danger`
+- heat ramp — `h1` (cold) … `h5` (hot), for the hotspot treemap and its legend
+
+Never write a literal colour in a component; add a token instead. The
+appearance switch offers *dark / light / system*, remembers the choice in
+`localStorage`, and follows the OS while the app is open. An inline script in
+`app.html` applies the same choice before first paint — it duplicates the
+storage key on purpose, so keep the two in step.
+
+## Status
+
+Scaffold: the theme layer, the typed API client and one page that proves both
+are wired. The app shell (left rail, header, project switcher) and the analysis
+screens are next — see [`BACKLOG.md`](../../BACKLOG.md) and the *web-ui* issues.
+
+Where each screen's data comes from:
+
+| View | Source in the report |
+|------|----------------------|
+| Hotspot treemap | `metrics.find((m) => m.id === 'hotspots')` |
+| Change coupling | `metrics.find((m) => m.id === 'change-coupling')` |
+| Dependency graph | `languages[*].graph` (Cytoscape/d3) |
+| Dead code | `languages[*].deadCode` |
+| Commit analytics | `commits[]` (type / scope / breaking) |
+| Plugins settings | `GET /plugins` |

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -24,7 +24,17 @@ dev as in production, where the server serves this build itself. Two knobs:
 | `VITE_STRATA_API` | build | *(empty = same origin)* | Absolute API origin to bake into the build (needs CORS) |
 
 Other targets: `pnpm --filter @strata/web build` (writes `build/`),
-`preview`, and `typecheck` (`svelte-check`).
+`preview`, `typecheck` (`svelte-check`) and `test`.
+
+## Tests
+
+`vitest` with the plain Svelte plugin and a `happy-dom` environment, configured
+in `vitest.config.ts`. The root `vitest.config.ts` pulls it in as a second
+project, so `make test` at the repo root runs the UI suite alongside the Node
+one — and `pnpm --filter @strata/web test` runs just this app.
+
+Components are mounted with `lib/test/render` and asserted against the DOM;
+there is no testing-library layer to learn.
 
 ## Layout
 
@@ -36,6 +46,7 @@ src/
     theme/            tokens.css (both palettes) + the appearance controller
     api/              one module per endpoint over a shared request helper
     components/       reusable UI pieces
+    test/             test helpers (component mounting)
   routes/             SvelteKit routes (SPA: `ssr = false`)
 static/               favicon and anything else served verbatim
 ```

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -2,12 +2,27 @@
   "name": "@strata/web",
   "version": "0.1.0",
   "private": true,
-  "description": "Strata web UI — dashboards for hotspots, dependency graphs, and commit analytics. (scaffold placeholder)",
+  "description": "Strata web UI — dashboards for hotspots, dependency graphs, and commit analytics.",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
-    "dev": "echo 'TODO: scaffold the frontend here (Vite + SvelteKit or Next.js). See apps/web/README.md.'",
-    "build": "echo 'no-op until the frontend is scaffolded'",
-    "typecheck": "echo 'no-op'"
+    "dev": "vite dev",
+    "build": "vite build",
+    "preview": "vite preview",
+    "typecheck": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json"
+  },
+  "devDependencies": {
+    "@fontsource-variable/ibm-plex-sans": "^5.3.0",
+    "@fontsource/ibm-plex-mono": "^5.3.0",
+    "@strata/sdk": "workspace:*",
+    "@sveltejs/adapter-static": "^3.0.10",
+    "@sveltejs/kit": "^2.70.2",
+    "@sveltejs/vite-plugin-svelte": "^7.3.0",
+    "@tailwindcss/vite": "^4.3.3",
+    "svelte": "^5.56.9",
+    "svelte-check": "^4.7.6",
+    "tailwindcss": "^4.3.3",
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
+    "vite": "^8.2.1"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,6 +9,7 @@
     "dev": "vite dev",
     "build": "vite build",
     "preview": "vite preview",
+    "test": "vitest run",
     "typecheck": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json"
   },
   "devDependencies": {
@@ -19,10 +20,12 @@
     "@sveltejs/kit": "^2.70.2",
     "@sveltejs/vite-plugin-svelte": "^7.3.0",
     "@tailwindcss/vite": "^4.3.3",
+    "happy-dom": "^20.11.2",
     "svelte": "^5.56.9",
     "svelte-check": "^4.7.6",
     "tailwindcss": "^4.3.3",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
-    "vite": "^8.2.1"
+    "vite": "^8.2.1",
+    "vitest": "^4.1.10"
   }
 }

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -1,0 +1,59 @@
+@import 'tailwindcss';
+@import '@fontsource-variable/ibm-plex-sans';
+@import '@fontsource/ibm-plex-mono/400.css';
+@import '@fontsource/ibm-plex-mono/500.css';
+@import './lib/theme/tokens.css';
+
+/* Theme is an attribute on <html>, set before first paint (see app.html). */
+@custom-variant dark (&:where([data-theme='dark'], [data-theme='dark'] *));
+
+/*
+ * `inline` matters here: it bakes `var(--strata-*)` into each utility instead
+ * of a second indirection through `--color-*`, so a utility resolves against
+ * whichever theme block is active on <html> at render time.
+ */
+@theme inline {
+  --font-sans: 'IBM Plex Sans Variable', ui-sans-serif, system-ui, sans-serif;
+  --font-mono: 'IBM Plex Mono', ui-monospace, 'SFMono-Regular', monospace;
+
+  --color-bg: var(--strata-bg);
+  --color-surface: var(--strata-surface);
+  --color-elevated: var(--strata-elevated);
+  --color-line: var(--strata-line);
+  --color-line-strong: var(--strata-line-strong);
+
+  --color-ink: var(--strata-ink);
+  --color-muted: var(--strata-muted);
+  --color-subtle: var(--strata-subtle);
+
+  --color-accent: var(--strata-accent);
+  --color-accent-strong: var(--strata-accent-strong);
+  --color-accent-ink: var(--strata-accent-ink);
+  --color-accent-soft: var(--strata-accent-soft);
+
+  --color-ok: var(--strata-ok);
+  --color-warn: var(--strata-warn);
+  --color-danger: var(--strata-danger);
+
+  --color-h1: var(--strata-h1);
+  --color-h2: var(--strata-h2);
+  --color-h3: var(--strata-h3);
+  --color-h4: var(--strata-h4);
+  --color-h5: var(--strata-h5);
+
+  --shadow-card: var(--strata-shadow);
+}
+
+@layer base {
+  html {
+    background-color: var(--strata-bg);
+  }
+
+  body {
+    @apply bg-bg text-ink font-sans antialiased;
+  }
+
+  :focus-visible {
+    @apply outline-accent outline-2 outline-offset-2;
+  }
+}

--- a/apps/web/src/app.d.ts
+++ b/apps/web/src/app.d.ts
@@ -1,0 +1,19 @@
+/// <reference types="vite/client" />
+
+// See https://svelte.dev/docs/kit/types#app.d.ts
+declare global {
+  namespace App {
+    // interface Error {}
+    // interface Locals {}
+    // interface PageData {}
+    // interface PageState {}
+    // interface Platform {}
+  }
+}
+
+interface ImportMetaEnv {
+  /** Origin of `@strata/server`; empty means same-origin (see lib/api/base). */
+  readonly VITE_STRATA_API?: string;
+}
+
+export {};

--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" href="%sveltekit.assets%/favicon.svg" />
+    <!--
+      Paint in the right theme immediately: without this the page flashes the
+      default dark palette before the app boots. Mirrors `lib/theme` — the key
+      and the three modes must stay in step with it.
+    -->
+    <script>
+      (() => {
+        let mode = 'system';
+        try {
+          const stored = localStorage.getItem('strata:theme');
+          if (stored === 'dark' || stored === 'light' || stored === 'system') {
+            mode = stored;
+          }
+        } catch {
+          // Storage unavailable — fall through to the system preference.
+        }
+        const dark =
+          mode === 'system'
+            ? window.matchMedia('(prefers-color-scheme: dark)').matches
+            : mode === 'dark';
+        document.documentElement.dataset.theme = dark ? 'dark' : 'light';
+      })();
+    </script>
+    %sveltekit.head%
+  </head>
+  <body data-sveltekit-preload-data="hover">
+    <div style="display: contents">%sveltekit.body%</div>
+  </body>
+</html>

--- a/apps/web/src/lib/api/analyze.ts
+++ b/apps/web/src/lib/api/analyze.ts
@@ -1,0 +1,14 @@
+import { apiRequest } from './request';
+import type { AnalysisReport, AnalyzeRequest } from './types';
+
+/** `POST /analyze` — run the pipeline over a repo and return the full report. */
+export function analyze(
+  request: AnalyzeRequest,
+  signal?: AbortSignal,
+): Promise<AnalysisReport> {
+  return apiRequest<AnalysisReport>('/analyze', {
+    method: 'POST',
+    body: request,
+    signal,
+  });
+}

--- a/apps/web/src/lib/api/base.ts
+++ b/apps/web/src/lib/api/base.ts
@@ -1,0 +1,14 @@
+/**
+ * Origin of `@strata/server`. Empty by default: in production the server
+ * serves this build, and in dev Vite proxies the API paths to it, so the same
+ * relative URLs work in both. Point `VITE_STRATA_API` at another origin (which
+ * then needs CORS) when running the UI against a remote workbench.
+ */
+const configured = import.meta.env.VITE_STRATA_API;
+
+export const API_BASE = (configured ?? '').replace(/\/$/, '');
+
+/** Absolute or relative URL for an API path such as `/plugins`. */
+export function apiUrl(path: string): string {
+  return `${API_BASE}${path}`;
+}

--- a/apps/web/src/lib/api/cache.ts
+++ b/apps/web/src/lib/api/cache.ts
@@ -1,0 +1,7 @@
+import { apiRequest } from './request';
+import type { ClearCacheResponse } from './types';
+
+/** `DELETE /cache` — drop every cached result. */
+export function clearCache(signal?: AbortSignal): Promise<ClearCacheResponse> {
+  return apiRequest<ClearCacheResponse>('/cache', { method: 'DELETE', signal });
+}

--- a/apps/web/src/lib/api/health.ts
+++ b/apps/web/src/lib/api/health.ts
@@ -1,0 +1,7 @@
+import { apiRequest } from './request';
+import type { HealthResponse } from './types';
+
+/** `GET /health` — liveness probe. */
+export function fetchHealth(signal?: AbortSignal): Promise<HealthResponse> {
+  return apiRequest<HealthResponse>('/health', { signal });
+}

--- a/apps/web/src/lib/api/index.ts
+++ b/apps/web/src/lib/api/index.ts
@@ -1,0 +1,7 @@
+export { analyze } from './analyze';
+export { API_BASE, apiUrl } from './base';
+export { clearCache } from './cache';
+export { fetchHealth } from './health';
+export { fetchPlugins } from './plugins';
+export { ApiError, apiRequest } from './request';
+export type * from './types';

--- a/apps/web/src/lib/api/plugins.ts
+++ b/apps/web/src/lib/api/plugins.ts
@@ -1,0 +1,7 @@
+import { apiRequest } from './request';
+import type { PluginsResponse } from './types';
+
+/** `GET /plugins` — what loaded, from where, and what was skipped. */
+export function fetchPlugins(signal?: AbortSignal): Promise<PluginsResponse> {
+  return apiRequest<PluginsResponse>('/plugins', { signal });
+}

--- a/apps/web/src/lib/api/request.test.ts
+++ b/apps/web/src/lib/api/request.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ApiError, apiRequest } from './request';
+
+function stubFetch(impl: typeof fetch): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn(impl);
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('apiRequest', () => {
+  it('returns the parsed JSON body', async () => {
+    stubFetch(async () => Response.json({ status: 'ok' }));
+
+    await expect(apiRequest<{ status: string }>('/health')).resolves.toEqual({
+      status: 'ok',
+    });
+  });
+
+  it('GETs without a content-type and asks for JSON', async () => {
+    const fetchMock = stubFetch(async () => Response.json({}));
+
+    await apiRequest('/plugins');
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('/plugins');
+    expect(init.method).toBe('GET');
+    expect(init.body).toBeUndefined();
+    expect(init.headers).toEqual({ accept: 'application/json' });
+  });
+
+  it('serialises a body and sets the content-type', async () => {
+    const fetchMock = stubFetch(async () => Response.json({ rev: 'abc' }));
+
+    await apiRequest('/analyze', { method: 'POST', body: { root: '/repo' } });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.method).toBe('POST');
+    expect(init.body).toBe('{"root":"/repo"}');
+    expect(init.headers).toMatchObject({ 'content-type': 'application/json' });
+  });
+
+  it('passes the abort signal through', async () => {
+    const fetchMock = stubFetch(async () => Response.json({}));
+    const controller = new AbortController();
+
+    await apiRequest('/health', { signal: controller.signal });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.signal).toBe(controller.signal);
+  });
+
+  it("reports the server's own message for a failed request", async () => {
+    stubFetch(async () =>
+      Response.json(
+        { statusCode: 400, error: 'Bad Request', message: 'root is required' },
+        { status: 400 },
+      ),
+    );
+
+    const error = await apiRequest('/analyze', {
+      method: 'POST',
+      body: {},
+    }).catch((err: unknown) => err);
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error).toMatchObject({ status: 400, message: 'root is required' });
+  });
+
+  it('falls back to the status line when the error is not JSON', async () => {
+    stubFetch(
+      async () =>
+        new Response('<html>oops</html>', {
+          status: 500,
+          statusText: 'Internal Server Error',
+        }),
+    );
+
+    const error = await apiRequest('/health').catch((err: unknown) => err);
+
+    expect(error).toMatchObject({
+      status: 500,
+      message: '500 Internal Server Error',
+    });
+  });
+
+  it('turns an unreachable server into an ApiError, not a raw fetch failure', async () => {
+    const cause = new TypeError('Failed to fetch');
+    stubFetch(async () => {
+      throw cause;
+    });
+
+    const error = await apiRequest('/health').catch((err: unknown) => err);
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error).toMatchObject({ status: 0, cause });
+    expect((error as ApiError).message).toContain('Cannot reach');
+  });
+});

--- a/apps/web/src/lib/api/request.ts
+++ b/apps/web/src/lib/api/request.ts
@@ -1,0 +1,77 @@
+import { apiUrl } from './base';
+
+/** Every failed call surfaces as this, so views can render one error shape. */
+export class ApiError extends Error {
+  constructor(
+    readonly url: string,
+    /** HTTP status, or 0 when the request never reached the server. */
+    readonly status: number,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = 'ApiError';
+  }
+}
+
+interface RequestOptions {
+  method?: 'GET' | 'POST' | 'DELETE';
+  /** Serialised as JSON; sets the content-type. */
+  body?: unknown;
+  signal?: AbortSignal;
+}
+
+/** One JSON round-trip against the server, with failures normalised. */
+export async function apiRequest<T>(
+  path: string,
+  { method = 'GET', body, signal }: RequestOptions = {},
+): Promise<T> {
+  const url = apiUrl(path);
+  const headers: Record<string, string> = { accept: 'application/json' };
+  if (body !== undefined) headers['content-type'] = 'application/json';
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method,
+      headers,
+      signal,
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+  } catch (err) {
+    // A network-level failure usually means the server simply is not up —
+    // say so rather than leaking "Failed to fetch" into the UI.
+    throw new ApiError(url, 0, `Cannot reach the Strata server at ${url}.`, {
+      cause: err,
+    });
+  }
+
+  if (!response.ok) {
+    throw new ApiError(
+      url,
+      response.status,
+      await errorMessage(response),
+    );
+  }
+
+  return (await response.json()) as T;
+}
+
+/** Fastify reports errors as `{ statusCode, error, message }`; use that if present. */
+async function errorMessage(response: Response): Promise<string> {
+  const fallback = `${response.status} ${response.statusText}`;
+  try {
+    const payload: unknown = await response.json();
+    if (
+      typeof payload === 'object' &&
+      payload !== null &&
+      'message' in payload &&
+      typeof payload.message === 'string'
+    ) {
+      return payload.message;
+    }
+  } catch {
+    // Not JSON — the status line is all we have.
+  }
+  return fallback;
+}

--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -1,0 +1,69 @@
+import type {
+  LanguageAnalysis,
+  MetricSeries,
+  ParsedCommit,
+  PluginManifest,
+} from '@strata/sdk';
+
+/**
+ * The shapes `@strata/server` puts on the wire. The leaf types come from
+ * `@strata/sdk` — the published contract both sides already share — while the
+ * envelopes below are the HTTP responses themselves, which live nowhere else.
+ *
+ * These are type-only imports: nothing from the SDK is bundled into the app,
+ * and the UI still talks to the server over REST only.
+ */
+
+export type PluginSource = 'builtin' | 'user';
+
+export interface HealthResponse {
+  status: string;
+}
+
+export interface LoadedPluginInfo extends PluginManifest {
+  source: PluginSource;
+}
+
+export interface PluginFailureInfo {
+  manifestPath: string;
+  source: PluginSource;
+  error: string;
+}
+
+export interface PluginsResponse {
+  /** Directory third-party plugins are read from (may not exist yet). */
+  directory: string;
+  plugins: LoadedPluginInfo[];
+  failures: PluginFailureInfo[];
+}
+
+export interface CacheReport {
+  enabled: boolean;
+  path?: string;
+  hits: number;
+  misses: number;
+  runHits: number;
+  runMisses: number;
+  writes: number;
+}
+
+export interface AnalysisReport {
+  rev: string;
+  languages: Record<string, LanguageAnalysis>;
+  metrics: MetricSeries[];
+  commits: ParsedCommit[];
+  cache: CacheReport;
+}
+
+export interface AnalyzeRequest {
+  /** Absolute path of the repo working tree to analyse. */
+  root: string;
+  rev?: string;
+  historyLimit?: number;
+  /** Set false to recompute everything, ignoring the incremental cache. */
+  cache?: boolean;
+}
+
+export interface ClearCacheResponse {
+  cleared: boolean;
+}

--- a/apps/web/src/lib/components/Card.svelte
+++ b/apps/web/src/lib/components/Card.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  interface Props {
+    title: string;
+    hint?: string;
+    children: Snippet;
+  }
+
+  let { title, hint, children }: Props = $props();
+</script>
+
+<section
+  class="bg-surface border-line shadow-card rounded-xl border p-5"
+>
+  <header class="mb-4 flex items-baseline justify-between gap-4">
+    <h2 class="text-sm font-semibold tracking-wide uppercase">{title}</h2>
+    {#if hint}
+      <p class="text-subtle font-mono text-xs">{hint}</p>
+    {/if}
+  </header>
+  {@render children()}
+</section>

--- a/apps/web/src/lib/components/ServerStatus.svelte
+++ b/apps/web/src/lib/components/ServerStatus.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+  import { API_BASE, ApiError, fetchHealth, fetchPlugins } from '$lib/api';
+  import type { PluginsResponse } from '$lib/api';
+
+  let status = $state<'loading' | 'ok' | 'error'>('loading');
+  let health = $state('');
+  let plugins = $state<PluginsResponse | null>(null);
+  let error = $state('');
+
+  // Proof that the client, the dev proxy and the API line up. The real screens
+  // will load through route loaders instead.
+  $effect(() => {
+    const controller = new AbortController();
+    void (async () => {
+      try {
+        const [healthResponse, pluginsResponse] = await Promise.all([
+          fetchHealth(controller.signal),
+          fetchPlugins(controller.signal),
+        ]);
+        health = healthResponse.status;
+        plugins = pluginsResponse;
+        status = 'ok';
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        error =
+          err instanceof ApiError ? err.message : 'Unexpected client error.';
+        status = 'error';
+      }
+    })();
+    return () => controller.abort();
+  });
+</script>
+
+{#if status === 'loading'}
+  <p class="text-muted text-sm">Contacting the server…</p>
+{:else if status === 'error'}
+  <p class="text-danger text-sm">{error}</p>
+  <p class="text-subtle mt-2 text-xs">
+    Start it with <code class="font-mono">make dev</code>.
+  </p>
+{:else if plugins}
+  <dl class="space-y-3 text-sm">
+    <div class="flex items-baseline justify-between gap-4">
+      <dt class="text-muted">Health</dt>
+      <dd class="text-ok font-mono">{health}</dd>
+    </div>
+    <div class="flex items-baseline justify-between gap-4">
+      <dt class="text-muted">API origin</dt>
+      <dd class="text-subtle truncate font-mono text-xs">
+        {API_BASE || 'same origin'}
+      </dd>
+    </div>
+    <div class="flex items-baseline justify-between gap-4">
+      <dt class="text-muted">Plugins directory</dt>
+      <dd class="text-subtle truncate font-mono text-xs">
+        {plugins.directory}
+      </dd>
+    </div>
+  </dl>
+
+  <ul class="border-line mt-4 space-y-2 border-t pt-4">
+    {#each plugins.plugins as plugin (plugin.id)}
+      <li class="flex items-baseline justify-between gap-3 text-sm">
+        <span class="truncate">{plugin.name}</span>
+        <span class="text-subtle shrink-0 font-mono text-xs">
+          {plugin.kind} · {plugin.source}
+        </span>
+      </li>
+    {/each}
+  </ul>
+
+  {#if plugins.failures.length > 0}
+    <p class="text-warn mt-3 text-xs">
+      {plugins.failures.length} plugin(s) skipped.
+    </p>
+  {/if}
+{/if}

--- a/apps/web/src/lib/components/ServerStatus.test.ts
+++ b/apps/web/src/lib/components/ServerStatus.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render } from '$lib/test/render';
+import ServerStatus from './ServerStatus.svelte';
+
+const pluginsResponse = {
+  directory: '/repo/.strata/plugins',
+  plugins: [
+    {
+      id: 'strata-commit-conventional',
+      name: 'Conventional Commits',
+      kind: 'commit-convention',
+      version: '0.1.0',
+      sdk: '0.1.0',
+      main: './dist/index.js',
+      source: 'builtin',
+    },
+  ],
+  failures: [],
+};
+
+/** Answer each API path the component asks for. */
+function stubApi(responses: Record<string, () => Response>) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string) => {
+      const respond = responses[url];
+      if (!respond) throw new Error(`unexpected request: ${url}`);
+      return respond();
+    }),
+  );
+}
+
+let ui: ReturnType<typeof render>;
+
+afterEach(() => {
+  ui?.destroy();
+  vi.unstubAllGlobals();
+});
+
+describe('ServerStatus', () => {
+  it('reports health and the loaded plugins', async () => {
+    stubApi({
+      '/health': () => Response.json({ status: 'ok' }),
+      '/plugins': () => Response.json(pluginsResponse),
+    });
+
+    ui = render(ServerStatus);
+
+    await vi.waitFor(() => {
+      expect(ui.container.textContent).toContain('Conventional Commits');
+    });
+    expect(ui.container.textContent).toContain('/repo/.strata/plugins');
+    expect(ui.container.textContent).toContain('commit-convention · builtin');
+  });
+
+  it('says the server is unreachable instead of showing a blank card', async () => {
+    stubApi({
+      '/health': () => {
+        throw new TypeError('Failed to fetch');
+      },
+      '/plugins': () => Response.json(pluginsResponse),
+    });
+
+    ui = render(ServerStatus);
+
+    await vi.waitFor(() => {
+      expect(ui.container.textContent).toContain('Cannot reach');
+    });
+    expect(ui.container.textContent).toContain('make dev');
+  });
+
+  it('surfaces the message from a failing endpoint', async () => {
+    stubApi({
+      '/health': () => Response.json({ status: 'ok' }),
+      '/plugins': () =>
+        Response.json({ message: 'plugins directory unreadable' }, { status: 500 }),
+    });
+
+    ui = render(ServerStatus);
+
+    await vi.waitFor(() => {
+      expect(ui.container.textContent).toContain('plugins directory unreadable');
+    });
+  });
+});

--- a/apps/web/src/lib/components/ThemeSwitch.svelte
+++ b/apps/web/src/lib/components/ThemeSwitch.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import { theme, THEME_MODES } from '$lib/theme';
+</script>
+
+<div
+  class="border-line bg-surface inline-flex items-center gap-1 rounded-lg border p-1"
+  role="group"
+  aria-label="Theme"
+>
+  {#each THEME_MODES as mode (mode)}
+    <button
+      type="button"
+      class="rounded-md px-3 py-1 text-xs font-medium capitalize transition-colors
+             {theme.mode === mode
+        ? 'bg-accent text-accent-ink'
+        : 'text-muted hover:bg-elevated hover:text-ink'}"
+      aria-pressed={theme.mode === mode}
+      onclick={() => theme.set(mode)}
+    >
+      {mode}
+    </button>
+  {/each}
+</div>

--- a/apps/web/src/lib/components/ThemeSwitch.test.ts
+++ b/apps/web/src/lib/components/ThemeSwitch.test.ts
@@ -1,0 +1,49 @@
+import { flushSync } from 'svelte';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { render } from '$lib/test/render';
+import ThemeSwitch from './ThemeSwitch.svelte';
+
+let ui: ReturnType<typeof render>;
+
+function button(label: string): HTMLButtonElement {
+  const match = [...ui.container.querySelectorAll('button')].find(
+    (element) => element.textContent?.trim() === label,
+  );
+  if (!match) throw new Error(`no "${label}" button`);
+  return match;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  ui = render(ThemeSwitch);
+});
+
+afterEach(() => {
+  ui.destroy();
+});
+
+describe('ThemeSwitch', () => {
+  it('offers the three modes', () => {
+    expect(
+      [...ui.container.querySelectorAll('button')].map((b) =>
+        b.textContent?.trim(),
+      ),
+    ).toEqual(['dark', 'light', 'system']);
+  });
+
+  it('paints the picked theme and marks it as pressed', () => {
+    button('light').click();
+    flushSync();
+
+    expect(document.documentElement.dataset.theme).toBe('light');
+    expect(button('light').getAttribute('aria-pressed')).toBe('true');
+    expect(button('dark').getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('remembers the choice', () => {
+    button('dark').click();
+    flushSync();
+
+    expect(localStorage.getItem('strata:theme')).toBe('dark');
+  });
+});

--- a/apps/web/src/lib/components/TokenPalette.svelte
+++ b/apps/web/src/lib/components/TokenPalette.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+  // Every class below is written out in full: Tailwind scans source text for
+  // candidates, so a composed string like `bg-${name}` would never be emitted.
+  const surfaces = [
+    { token: 'bg', swatch: 'bg-bg' },
+    { token: 'surface', swatch: 'bg-surface' },
+    { token: 'elevated', swatch: 'bg-elevated' },
+    { token: 'line', swatch: 'bg-line' },
+    { token: 'line-strong', swatch: 'bg-line-strong' },
+  ];
+
+  const accents = [
+    { token: 'accent', swatch: 'bg-accent' },
+    { token: 'accent-soft', swatch: 'bg-accent-soft' },
+    { token: 'ok', swatch: 'bg-ok' },
+    { token: 'warn', swatch: 'bg-warn' },
+    { token: 'danger', swatch: 'bg-danger' },
+  ];
+
+  const heat = [
+    { token: 'h1', swatch: 'bg-h1' },
+    { token: 'h2', swatch: 'bg-h2' },
+    { token: 'h3', swatch: 'bg-h3' },
+    { token: 'h4', swatch: 'bg-h4' },
+    { token: 'h5', swatch: 'bg-h5' },
+  ];
+
+  const text = [
+    { token: 'ink', class: 'text-ink' },
+    { token: 'muted', class: 'text-muted' },
+    { token: 'subtle', class: 'text-subtle' },
+    { token: 'accent', class: 'text-accent' },
+  ];
+</script>
+
+{#snippet row(label: string, entries: { token: string; swatch: string }[])}
+  <div>
+    <p class="text-subtle mb-2 text-xs">{label}</p>
+    <ul class="grid grid-cols-5 gap-2">
+      {#each entries as entry (entry.token)}
+        <li>
+          <div
+            class="border-line h-10 rounded-md border {entry.swatch}"
+            aria-hidden="true"
+          ></div>
+          <p class="text-muted mt-1 font-mono text-[11px]">{entry.token}</p>
+        </li>
+      {/each}
+    </ul>
+  </div>
+{/snippet}
+
+<div class="space-y-5">
+  {@render row('Surfaces', surfaces)}
+  {@render row('Accent & status', accents)}
+  {@render row('Heat ramp — cold h1 → hot h5', heat)}
+
+  <div>
+    <p class="text-subtle mb-2 text-xs">Text</p>
+    <ul class="flex flex-wrap gap-4">
+      {#each text as entry (entry.token)}
+        <li class="text-sm {entry.class}">
+          {entry.token}
+          <span class="font-mono text-[11px] opacity-70">Aa</span>
+        </li>
+      {/each}
+    </ul>
+  </div>
+</div>

--- a/apps/web/src/lib/test/render.ts
+++ b/apps/web/src/lib/test/render.ts
@@ -1,0 +1,28 @@
+import { mount, unmount, type Component } from 'svelte';
+
+export interface Rendered {
+  /** The element the component was mounted into. */
+  container: HTMLElement;
+  destroy(): void;
+}
+
+/**
+ * Mount a component into a detached container for a test. Small on purpose —
+ * the assertions read the DOM directly, so there is nothing else to learn.
+ */
+export function render<Props extends Record<string, unknown>>(
+  component: Component<Props>,
+  props: Props = {} as Props,
+): Rendered {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const instance = mount(component, { target: container, props });
+
+  return {
+    container,
+    destroy() {
+      void unmount(instance);
+      container.remove();
+    },
+  };
+}

--- a/apps/web/src/lib/theme/apply.ts
+++ b/apps/web/src/lib/theme/apply.ts
@@ -1,0 +1,9 @@
+import type { ResolvedTheme } from './mode';
+
+/**
+ * The single place the theme touches the DOM: `tokens.css` keys both palettes
+ * off this attribute, so setting it repaints the entire app.
+ */
+export function applyTheme(theme: ResolvedTheme): void {
+  document.documentElement.dataset.theme = theme;
+}

--- a/apps/web/src/lib/theme/controller.svelte.ts
+++ b/apps/web/src/lib/theme/controller.svelte.ts
@@ -1,0 +1,49 @@
+import { applyTheme } from './apply';
+import { resolveTheme, type ResolvedTheme, type ThemeMode } from './mode';
+import { readStoredMode, storeMode } from './storage';
+
+const DARK_QUERY = '(prefers-color-scheme: dark)';
+
+/**
+ * The app's appearance state: the mode the user picked, the OS preference, and
+ * the theme that follows from the two. One instance, exported below — the
+ * `<html>` attribute it writes is global anyway.
+ */
+class ThemeController {
+  #mode = $state<ThemeMode>('system');
+  #prefersDark = $state(true);
+
+  get mode(): ThemeMode {
+    return this.#mode;
+  }
+
+  get resolved(): ResolvedTheme {
+    return resolveTheme(this.#mode, this.#prefersDark);
+  }
+
+  set(mode: ThemeMode): void {
+    this.#mode = mode;
+    storeMode(mode);
+    applyTheme(this.resolved);
+  }
+
+  /**
+   * Adopt the stored choice and track the OS preference. Call once from the
+   * root layout; the returned function detaches the listener.
+   */
+  start(): () => void {
+    const media = window.matchMedia(DARK_QUERY);
+    this.#prefersDark = media.matches;
+    this.#mode = readStoredMode() ?? 'system';
+    applyTheme(this.resolved);
+
+    const onChange = (event: MediaQueryListEvent) => {
+      this.#prefersDark = event.matches;
+      applyTheme(this.resolved);
+    };
+    media.addEventListener('change', onChange);
+    return () => media.removeEventListener('change', onChange);
+  }
+}
+
+export const theme = new ThemeController();

--- a/apps/web/src/lib/theme/controller.test.ts
+++ b/apps/web/src/lib/theme/controller.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { theme } from './controller.svelte';
+import { THEME_STORAGE_KEY } from './storage';
+
+/** A `matchMedia` whose preference the test can flip. */
+function stubMatchMedia(prefersDark: boolean) {
+  const listeners = new Set<(event: MediaQueryListEvent) => void>();
+  const media = {
+    matches: prefersDark,
+    addEventListener: vi.fn((_: string, listener: EventListener) =>
+      listeners.add(listener as (event: MediaQueryListEvent) => void),
+    ),
+    removeEventListener: vi.fn((_: string, listener: EventListener) =>
+      listeners.delete(listener as (event: MediaQueryListEvent) => void),
+    ),
+  };
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn(() => media),
+  );
+
+  return {
+    media,
+    /** Simulate the OS switching theme while the app is open. */
+    change(matches: boolean) {
+      media.matches = matches;
+      for (const listener of listeners) {
+        listener({ matches } as MediaQueryListEvent);
+      }
+    },
+  };
+}
+
+const painted = () => document.documentElement.dataset.theme;
+
+let stop: () => void = () => {};
+
+beforeEach(() => {
+  localStorage.clear();
+  delete document.documentElement.dataset.theme;
+});
+
+afterEach(() => {
+  stop();
+  vi.unstubAllGlobals();
+});
+
+describe('theme controller', () => {
+  it('starts in system mode and paints the OS preference', () => {
+    stubMatchMedia(true);
+
+    stop = theme.start();
+
+    expect(theme.mode).toBe('system');
+    expect(theme.resolved).toBe('dark');
+    expect(painted()).toBe('dark');
+  });
+
+  it('adopts the stored choice over the OS preference', () => {
+    stubMatchMedia(true);
+    localStorage.setItem(THEME_STORAGE_KEY, 'light');
+
+    stop = theme.start();
+
+    expect(theme.mode).toBe('light');
+    expect(painted()).toBe('light');
+  });
+
+  it('remembers and paints an explicit choice', () => {
+    stubMatchMedia(true);
+    stop = theme.start();
+
+    theme.set('light');
+
+    expect(painted()).toBe('light');
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('light');
+  });
+
+  it('follows the OS while in system mode', () => {
+    const os = stubMatchMedia(true);
+    stop = theme.start();
+
+    os.change(false);
+
+    expect(theme.resolved).toBe('light');
+    expect(painted()).toBe('light');
+  });
+
+  it('ignores the OS once a mode is pinned', () => {
+    const os = stubMatchMedia(true);
+    stop = theme.start();
+    theme.set('dark');
+
+    os.change(false);
+
+    expect(theme.resolved).toBe('dark');
+    expect(painted()).toBe('dark');
+  });
+
+  it('detaches the OS listener when stopped', () => {
+    const os = stubMatchMedia(true);
+
+    theme.start()();
+
+    expect(os.media.removeEventListener).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/theme/index.ts
+++ b/apps/web/src/lib/theme/index.ts
@@ -1,0 +1,10 @@
+export { applyTheme } from './apply';
+export { theme } from './controller.svelte';
+export {
+  isThemeMode,
+  resolveTheme,
+  THEME_MODES,
+  type ResolvedTheme,
+  type ThemeMode,
+} from './mode';
+export { readStoredMode, storeMode, THEME_STORAGE_KEY } from './storage';

--- a/apps/web/src/lib/theme/mode.test.ts
+++ b/apps/web/src/lib/theme/mode.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { isThemeMode, resolveTheme } from './mode';
+
+describe('isThemeMode', () => {
+  it('accepts the three modes', () => {
+    expect(isThemeMode('dark')).toBe(true);
+    expect(isThemeMode('light')).toBe(true);
+    expect(isThemeMode('system')).toBe(true);
+  });
+
+  it('rejects anything else stored under the key', () => {
+    expect(isThemeMode('sepia')).toBe(false);
+    expect(isThemeMode(null)).toBe(false);
+    expect(isThemeMode(undefined)).toBe(false);
+  });
+});
+
+describe('resolveTheme', () => {
+  it('takes an explicit mode over the OS preference', () => {
+    expect(resolveTheme('light', true)).toBe('light');
+    expect(resolveTheme('dark', false)).toBe('dark');
+  });
+
+  it('follows the OS preference in system mode', () => {
+    expect(resolveTheme('system', true)).toBe('dark');
+    expect(resolveTheme('system', false)).toBe('light');
+  });
+});

--- a/apps/web/src/lib/theme/mode.ts
+++ b/apps/web/src/lib/theme/mode.ts
@@ -1,0 +1,25 @@
+/** What the user picked. `system` defers to the OS preference. */
+export type ThemeMode = 'dark' | 'light' | 'system';
+
+/** What actually gets painted — `system` is resolved away first. */
+export type ResolvedTheme = 'dark' | 'light';
+
+/** The order the appearance switch renders them in. */
+export const THEME_MODES = [
+  'dark',
+  'light',
+  'system',
+] as const satisfies readonly ThemeMode[];
+
+/** Guards the value read back from storage, which is user-editable. */
+export function isThemeMode(value: unknown): value is ThemeMode {
+  return (THEME_MODES as readonly string[]).includes(value as string);
+}
+
+export function resolveTheme(
+  mode: ThemeMode,
+  prefersDark: boolean,
+): ResolvedTheme {
+  if (mode === 'system') return prefersDark ? 'dark' : 'light';
+  return mode;
+}

--- a/apps/web/src/lib/theme/storage.test.ts
+++ b/apps/web/src/lib/theme/storage.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { readStoredMode, storeMode, THEME_STORAGE_KEY } from './storage';
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe('theme storage', () => {
+  it('round-trips a mode', () => {
+    storeMode('light');
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('light');
+    expect(readStoredMode()).toBe('light');
+  });
+
+  it('is null when nothing was stored', () => {
+    expect(readStoredMode()).toBeNull();
+  });
+
+  it('rejects a hand-edited value rather than applying it', () => {
+    localStorage.setItem(THEME_STORAGE_KEY, 'sepia');
+    expect(readStoredMode()).toBeNull();
+  });
+
+  it('survives storage being unavailable', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('storage disabled');
+    });
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('storage disabled');
+    });
+
+    expect(readStoredMode()).toBeNull();
+    expect(() => storeMode('dark')).not.toThrow();
+  });
+});

--- a/apps/web/src/lib/theme/storage.ts
+++ b/apps/web/src/lib/theme/storage.ts
@@ -1,0 +1,26 @@
+import { isThemeMode, type ThemeMode } from './mode';
+
+/**
+ * Where the choice is remembered. The inline bootstrap in `app.html` reads the
+ * same key before the app boots — keep the two in sync.
+ */
+export const THEME_STORAGE_KEY = 'strata:theme';
+
+/** `null` when nothing valid is stored, or storage is unavailable. */
+export function readStoredMode(): ThemeMode | null {
+  try {
+    const stored = localStorage.getItem(THEME_STORAGE_KEY);
+    return isThemeMode(stored) ? stored : null;
+  } catch {
+    // Private mode / storage disabled: fall back to the system preference.
+    return null;
+  }
+}
+
+export function storeMode(mode: ThemeMode): void {
+  try {
+    localStorage.setItem(THEME_STORAGE_KEY, mode);
+  } catch {
+    // Not being able to remember the choice must not break the switch.
+  }
+}

--- a/apps/web/src/lib/theme/tokens.css
+++ b/apps/web/src/lib/theme/tokens.css
@@ -1,0 +1,78 @@
+/*
+ * Strata design tokens — the mockup's palette, in both themes.
+ *
+ * Every value is a raw `--strata-*` custom property. `app.css` maps them onto
+ * Tailwind's theme keys, so components only ever say `bg-surface` / `text-ink`
+ * and never touch a literal colour. Switching `data-theme` on <html> repaints
+ * the whole app, because the utilities resolve these variables at use time.
+ *
+ * The ramps:
+ *   surfaces  bg → surface → elevated, separated by `line`
+ *   text      ink → muted → subtle
+ *   heat      h1 (cold) → h5 (hot), used by the hotspot treemap and legends
+ */
+
+:root,
+[data-theme='dark'] {
+  color-scheme: dark;
+
+  --strata-bg: #0b0e14;
+  --strata-surface: #11151d;
+  --strata-elevated: #171c26;
+  --strata-line: #232a36;
+  --strata-line-strong: #313a4a;
+
+  --strata-ink: #e6ebf2;
+  --strata-muted: #9aa6b8;
+  --strata-subtle: #6b7789;
+
+  --strata-accent: #4da3ff;
+  --strata-accent-strong: #7bbcff;
+  --strata-accent-ink: #06121f;
+  --strata-accent-soft: #14304a;
+
+  --strata-ok: #3fb950;
+  --strata-warn: #d29922;
+  --strata-danger: #f85149;
+
+  --strata-h1: #2b6a8f;
+  --strata-h2: #3f9d8c;
+  --strata-h3: #d9b03c;
+  --strata-h4: #e07a3f;
+  --strata-h5: #d94a3d;
+
+  --strata-shadow: 0 1px 2px rgb(0 0 0 / 0.4), 0 8px 24px rgb(0 0 0 / 0.28);
+}
+
+[data-theme='light'] {
+  color-scheme: light;
+
+  --strata-bg: #f6f7f9;
+  --strata-surface: #ffffff;
+  --strata-elevated: #eef1f5;
+  --strata-line: #dfe3e9;
+  --strata-line-strong: #c3cad4;
+
+  --strata-ink: #10151d;
+  --strata-muted: #55606f;
+  --strata-subtle: #7b8695;
+
+  --strata-accent: #0a66c2;
+  --strata-accent-strong: #084e95;
+  --strata-accent-ink: #ffffff;
+  --strata-accent-soft: #dcebfa;
+
+  --strata-ok: #1a7f37;
+  --strata-warn: #9a6700;
+  --strata-danger: #cf222e;
+
+  /* Darkened a step from the dark ramp: the same hues need more weight to
+     hold contrast against a white surface. */
+  --strata-h1: #2a6488;
+  --strata-h2: #2f8a76;
+  --strata-h3: #a8760f;
+  --strata-h4: #c25e28;
+  --strata-h5: #b3312a;
+
+  --strata-shadow: 0 1px 2px rgb(16 21 29 / 0.06), 0 8px 24px rgb(16 21 29 / 0.08);
+}

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import '../app.css';
+  import { theme } from '$lib/theme';
+
+  let { children } = $props();
+
+  // Adopt the stored appearance and follow the OS while the app is open.
+  $effect(() => theme.start());
+</script>
+
+<div class="min-h-screen bg-bg text-ink">
+  {@render children()}
+</div>

--- a/apps/web/src/routes/+layout.ts
+++ b/apps/web/src/routes/+layout.ts
@@ -1,0 +1,5 @@
+// A single-page app: no server rendering, no prerendered routes. The build is
+// static files that `@strata/server` (and later the Tauri shell) hands over
+// as-is, with every route resolving through the index.html fallback.
+export const ssr = false;
+export const prerender = false;

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import Card from '$lib/components/Card.svelte';
+  import ServerStatus from '$lib/components/ServerStatus.svelte';
+  import ThemeSwitch from '$lib/components/ThemeSwitch.svelte';
+  import TokenPalette from '$lib/components/TokenPalette.svelte';
+  import { theme } from '$lib/theme';
+</script>
+
+<svelte:head>
+  <title>Strata</title>
+</svelte:head>
+
+<main class="mx-auto max-w-5xl px-6 py-12">
+  <header class="mb-10 flex flex-wrap items-end justify-between gap-4">
+    <div>
+      <h1 class="text-2xl font-semibold">Strata</h1>
+      <p class="text-muted mt-1 text-sm">
+        Frontend scaffold — theme layer and API client in place. The workbench
+        shell and the analysis screens come next.
+      </p>
+    </div>
+    <ThemeSwitch />
+  </header>
+
+  <div class="grid gap-6 md:grid-cols-2">
+    <Card title="Design tokens" hint={theme.resolved}>
+      <TokenPalette />
+    </Card>
+
+    <Card title="Server" hint="/health · /plugins">
+      <ServerStatus />
+    </Card>
+  </div>
+</main>

--- a/apps/web/static/favicon.svg
+++ b/apps/web/static/favicon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="Strata">
+  <rect width="32" height="32" rx="7" fill="#0b0e14" />
+  <g fill="none" stroke-width="3" stroke-linecap="round">
+    <path d="M8 10h16" stroke="#d94a3d" />
+    <path d="M8 16h16" stroke="#e07a3f" />
+    <path d="M8 22h16" stroke="#4da3ff" />
+  </g>
+</svg>

--- a/apps/web/svelte.config.js
+++ b/apps/web/svelte.config.js
@@ -1,0 +1,14 @@
+import adapter from '@sveltejs/adapter-static';
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+/** @type {import('@sveltejs/kit').Config} */
+export default {
+  preprocess: vitePreprocess(),
+  kit: {
+    // A pure SPA: every route falls back to index.html, so the build is a
+    // folder of static files. `@strata/server` can serve it straight from the
+    // Docker image, and the Tauri shell can load it from disk — neither of
+    // them wants a Node server in front of the UI.
+    adapter: adapter({ fallback: 'index.html', strict: false }),
+  },
+};

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  // Extends the generated SvelteKit config rather than `tsconfig.base.json`:
+  // this app is bundled by Vite, not compiled by tsc, so it needs bundler
+  // resolution and the DOM lib instead of the repo's NodeNext/Node setup.
+  "extends": "./.svelte-kit/tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "moduleResolution": "bundler"
+  }
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,0 +1,20 @@
+import { sveltekit } from '@sveltejs/kit/vite';
+import tailwindcss from '@tailwindcss/vite';
+import { defineConfig } from 'vite';
+
+/** Where the dev server forwards API calls; the built UI is served same-origin. */
+const target = process.env.STRATA_API_PROXY ?? 'http://localhost:4000';
+
+// The API lives at the root of its origin (`/health`, not `/api/health`), so
+// the dev proxy mirrors those exact paths. Dev and production then use the
+// same URLs and the client needs no base-path juggling.
+const apiPaths = ['/health', '/plugins', '/analyze', '/cache'];
+
+export default defineConfig({
+  plugins: [tailwindcss(), sveltekit()],
+  server: {
+    proxy: Object.fromEntries(
+      apiPaths.map((path) => [path, { target, changeOrigin: true }]),
+    ),
+  },
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,22 @@
+import { fileURLToPath } from 'node:url';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { defineConfig } from 'vitest/config';
+
+// The UI is tested without SvelteKit: the plain Svelte plugin compiles both
+// components and `.svelte.ts` rune modules, which is all these tests need.
+// `conditions: ['browser']` picks Svelte's client build — the server build
+// would render once and never react.
+export default defineConfig({
+  plugins: [svelte()],
+  resolve: {
+    conditions: ['browser'],
+    alias: {
+      $lib: fileURLToPath(new URL('./src/lib', import.meta.url)),
+    },
+  },
+  test: {
+    name: 'web',
+    environment: 'happy-dom',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -99,7 +99,9 @@ strata/
 │   ├── language-typescript/      TS/JS graph, metrics, dead code (language)
 │   └── ai-provider-template/     copy-me AI backend              (ai-provider)
 ├── apps/
-│   └── web/                      Web UI (dashboards) — placeholder
+│   └── web/     @strata/web      Web UI (SvelteKit SPA + Tailwind)
+│                  app.css + lib/theme/ (tokens, both palettes) ·
+│                  lib/api/ (one module per endpoint) · lib/components/ · routes/
 ├── scripts/                      analyze.mjs, new-plugin.mjs (dev actions)
 └── docs/                         this file + per-module ARCHITECTURE.md
 ```
@@ -208,6 +210,7 @@ publish. The Linux desktop job is still a stub — it produces no bundle until
 | ADR-4 | SQLite blob-keyed cache (`node:sqlite`) | Cheap incremental analysis for large repos, with no runtime dependency. |
 | ADR-5 | Docker image is the primary deliverable | Matches "self-host over the browser". |
 | ADR-6 | Vouch file over GitHub team | Works on a personal repo; auditable in git history. |
+| ADR-7 | Web UI is a SvelteKit **static SPA** (Tailwind v4) | The build is plain files: the server can serve it from the same image, and the Tauri shell can load it from disk. Analysis is a local API call, so nothing needs server rendering. |
 
 (Promote these into `docs/adr/NNNN-*.md` as they harden.)
 
@@ -227,7 +230,7 @@ publish. The Linux desktop job is still a stub — it produces no bundle until
 | TS resolution is not the compiler's | An import resolved through neither a relative path nor a `tsconfig` alias (a bundler's own aliases, `package.json` `imports`, a workspace package name) draws no edge | tree-sitter parses every file and `tsconfig.json` `paths`/`baseUrl` are honoured; the remaining schemes are per-project settings on the backlog. |
 | Cache is only as pure as its plugins | A `cache.file()` value that depends on more than the file's contents goes stale | Contract documented in the SDK; plugin version is part of the key, `DELETE /cache` is the escape hatch. |
 | Complexity proxy is indentation-based | Rough hotspot scores | Feed real cyclomatic complexity from language plugins. |
-| Web UI not scaffolded | No visual output yet | Build `apps/web` (see backlog). |
+| Web UI is a scaffold | Only the theme layer and API client exist; no analysis screens yet | Build the shell and views on top (see backlog / the *web-ui* issues). |
 | Third-party plugins run in-process | A plugin has the server's privileges | Manifest/entry validation and id protection on load; installing one is a trust decision, and the plugins directory is operator-controlled. Isolation is a later step. |
 | Vouch-bot needs push to `main` | May hit branch protection | Bypass entry or PR-mode fallback (documented). |
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,7 +4,16 @@ import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
   {
-    ignores: ['**/dist/**', '**/node_modules/**', 'apps/web/**'],
+    // `apps/web` has its own toolchain: `svelte-check` type-checks it, and
+    // linting `.svelte` files needs eslint-plugin-svelte, which this config
+    // does not carry yet.
+    ignores: [
+      '**/dist/**',
+      '**/build/**',
+      '**/.svelte-kit/**',
+      '**/node_modules/**',
+      'apps/web/**',
+    ],
   },
   js.configs.recommended,
   ...tseslint.configs.recommended,

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "build": "pnpm -r build",
     "dev": "pnpm --filter @strata/server dev",
+    "dev:web": "pnpm --filter @strata/web dev",
     "lint": "eslint .",
     "test": "vitest run",
     "typecheck": "pnpm -r typecheck",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ importers:
         version: 8.67.0(@typescript/typescript6@6.0.2)(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0))
+        version: 4.1.10(@types/node@24.13.3)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0))
 
   apps/web:
     devDependencies:
@@ -65,6 +65,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.3.3
         version: 4.3.3(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0))
+      happy-dom:
+        specifier: ^20.11.2
+        version: 20.11.2
       svelte:
         specifier: ^5.56.9
         version: 5.56.9(@typescript-eslint/types@8.67.0)
@@ -80,6 +83,9 @@ importers:
       vite:
         specifier: ^8.2.1
         version: 8.2.1(@types/node@24.13.3)(jiti@2.7.0)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@24.13.3)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0))
 
   packages/core:
     dependencies:
@@ -655,6 +661,12 @@ packages:
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@typescript-eslint/eslint-plugin@8.67.0':
     resolution: {integrity: sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -939,6 +951,10 @@ packages:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
+  buffer-image-size@0.6.4:
+    resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
+    engines: {node: '>=4.0'}
+
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -1037,6 +1053,10 @@ packages:
   enhanced-resolve@5.24.5:
     resolution: {integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==}
     engines: {node: '>=10.13.0'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
 
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -1204,6 +1224,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  happy-dom@20.11.2:
+    resolution: {integrity: sha512-7MB+bJLkxu3SowAfBJbjW+c55kNz5tkR45gu2qzrxznezhLeN5YIlJbwUgSzlGc+qWoZ8Ykg71H5ezz69xixrw==}
+    engines: {node: '>=20.0.0'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -1857,6 +1881,10 @@ packages:
   web-tree-sitter@0.26.12:
     resolution: {integrity: sha512-fvqTNZQBGUgUgfP0mHw+iHf9Yf6bRQrp0A3pSf2v/hSKxkT1beCoIWoLVmlPL7O6dmySfSb/t1aJoJvrgTRStw==}
 
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1874,6 +1902,18 @@ packages:
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
+
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -2305,6 +2345,12 @@ snapshots:
 
   '@types/trusted-types@2.0.7': {}
 
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 24.13.3
+
   '@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(@typescript/typescript6@6.0.2)(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0))(@typescript/typescript6@6.0.2)(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -2556,6 +2602,10 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
+  buffer-image-size@0.6.4:
+    dependencies:
+      '@types/node': 24.13.3
+
   callsites@3.1.0: {}
 
   chai@6.2.2: {}
@@ -2635,6 +2685,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
+
+  entities@7.0.1: {}
 
   env-paths@2.2.1: {}
 
@@ -2821,6 +2873,19 @@ snapshots:
   globals@17.11.0: {}
 
   graceful-fs@4.2.11: {}
+
+  happy-dom@20.11.2:
+    dependencies:
+      '@types/node': 24.13.3
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      buffer-image-size: 0.6.4
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.21.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   has-flag@4.0.0:
     optional: true
@@ -3330,7 +3395,7 @@ snapshots:
     optionalDependencies:
       vite: 8.2.1(@types/node@24.13.3)(jiti@2.7.0)
 
-  vitest@4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0)):
+  vitest@4.1.10(@types/node@24.13.3)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0))
@@ -3354,10 +3419,13 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.13.3
+      happy-dom: 20.11.2
     transitivePeerDependencies:
       - msw
 
   web-tree-sitter@0.26.12: {}
+
+  whatwg-mimetype@3.0.0: {}
 
   which@2.0.2:
     dependencies:
@@ -3375,6 +3443,8 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.2.0
+
+  ws@8.21.3: {}
 
   y18n@5.0.8: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,9 +40,46 @@ importers:
         version: 8.67.0(@typescript/typescript6@6.0.2)(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(jiti@2.6.1))
+        version: 4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0))
 
-  apps/web: {}
+  apps/web:
+    devDependencies:
+      '@fontsource-variable/ibm-plex-sans':
+        specifier: ^5.3.0
+        version: 5.3.0
+      '@fontsource/ibm-plex-mono':
+        specifier: ^5.3.0
+        version: 5.3.0
+      '@strata/sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk
+      '@sveltejs/adapter-static':
+        specifier: ^3.0.10
+        version: 3.0.10(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0)))(@typescript/typescript6@6.0.2)(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0)))
+      '@sveltejs/kit':
+        specifier: ^2.70.2
+        version: 2.70.2(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0)))(@typescript/typescript6@6.0.2)(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0))
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^7.3.0
+        version: 7.3.0(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0))
+      '@tailwindcss/vite':
+        specifier: ^4.3.3
+        version: 4.3.3(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0))
+      svelte:
+        specifier: ^5.56.9
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
+      svelte-check:
+        specifier: ^4.7.6
+        version: 4.7.6(@typescript/typescript6@6.0.2)(picomatch@4.0.5)(svelte@5.56.9(@typescript-eslint/types@8.67.0))
+      tailwindcss:
+        specifier: ^4.3.3
+        version: 4.3.3
+      typescript:
+        specifier: npm:@typescript/typescript6@^6.0.2
+        version: '@typescript/typescript6@6.0.2'
+      vite:
+        specifier: ^8.2.1
+        version: 8.2.1(@types/node@24.13.3)(jiti@2.7.0)
 
   packages/core:
     dependencies:
@@ -308,6 +345,12 @@ packages:
   '@fastify/proxy-addr@5.1.0':
     resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
 
+  '@fontsource-variable/ibm-plex-sans@5.3.0':
+    resolution: {integrity: sha512-agG8tXFEo0hD9+J7npa4vbbWult52eMLVaQ6WQRlhs/iCAojrMAoejru85W9HTVXHfyUj96KM7gp/KGAS87XaQ==}
+
+  '@fontsource/ibm-plex-mono@5.3.0':
+    resolution: {integrity: sha512-eTgnZjZEGk1QtD3ZstF+Vclo2HLAni8YMy34/DxllwZvyz1lR/1RF/xTiAquOBO7MvqBx8D2Ig2WCPMVfdZu7Q==}
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -328,14 +371,30 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@oxc-project/types@0.143.0':
     resolution: {integrity: sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==}
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
+  '@polka/url@1.0.0-next.29':
+    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
   '@rolldown/binding-android-arm64@1.2.3':
     resolution: {integrity: sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==}
@@ -441,8 +500,142 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@sveltejs/acorn-typescript@1.0.13':
+    resolution: {integrity: sha512-wgKggnhZVL9Bfx1OaKKTrYY9BFRk6C8UAkQNUcIv1+llzYrIqy+RZm5HPKzn0NpEBvTVhTqB4kQyllZywsRBRQ==}
+    peerDependencies:
+      acorn: ^8.9.0
+
+  '@sveltejs/adapter-static@3.0.10':
+    resolution: {integrity: sha512-7D9lYFWJmB7zxZyTE/qxjksvMqzMuYrrsyh1f4AlZqeZeACPRySjbC3aFiY55wb1tWUaKOQG9PVbm74JcN2Iew==}
+    peerDependencies:
+      '@sveltejs/kit': ^2.0.0
+
+  '@sveltejs/kit@2.70.2':
+    resolution: {integrity: sha512-RzRoRpuR2KXqc5yMO0akQHDZeT4AslOlznGITURsqHaVbtyYP4Wn3eE3gxj9JcDyNYO0crkxhdwFHc+2vkVm6w==}
+    engines: {node: '>=18.13'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+      '@sveltejs/vite-plugin-svelte': ^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0
+      svelte: ^4.0.0 || ^5.0.0-next.0
+      typescript: ^5.3.3 || ^6.0.0
+      vite: ^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      typescript:
+        optional: true
+
+  '@sveltejs/load-config@0.2.3':
+    resolution: {integrity: sha512-VT3qmUb8pRV2QrZjd8iAmtg8lf4W0TIjZbvXtz5MKei/q96teWZgGJyyidJzOjzZzvdq616eSRVeMYIQChUTAQ==}
+    engines: {node: '>= 18.0.0'}
+
+  '@sveltejs/vite-plugin-svelte@7.3.0':
+    resolution: {integrity: sha512-QbRoJyD92e9R0ufeQIWRHrCC0ObcqSv/aBDdrQMoU+sypav3cDx5wytdQ6GLdXjEMO6xjrXGzfkUygng8JMv0A==}
+    engines: {node: ^20.19 || ^22.12 || >=24}
+    peerDependencies:
+      svelte: ^5.46.4
+      vite: ^8.0.0-beta.7 || ^8.0.0
+
+  '@tailwindcss/node@4.3.3':
+    resolution: {integrity: sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==}
+
+  '@tailwindcss/oxide-android-arm64@4.3.3':
+    resolution: {integrity: sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.3':
+    resolution: {integrity: sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.3.3':
+    resolution: {integrity: sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.3':
+    resolution: {integrity: sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3':
+    resolution: {integrity: sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.3':
+    resolution: {integrity: sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
+    resolution: {integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
+    resolution: {integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.3':
+    resolution: {integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.3':
+    resolution: {integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.3':
+    resolution: {integrity: sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.3':
+    resolution: {integrity: sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.3.3':
+    resolution: {integrity: sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/vite@4.3.3':
+    resolution: {integrity: sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/cookie@0.6.0':
+    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -458,6 +651,9 @@ packages:
 
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@typescript-eslint/eslint-plugin@8.67.0':
     resolution: {integrity: sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==}
@@ -716,6 +912,10 @@ packages:
     resolution: {integrity: sha512-DhBpBfXL4SS2uC0N922MMajKR3CdrTG0u2or1PNYgXMsrSzViJrbtvT0nCLlLGUI0plam/ZZCs7aAauHtW9thw==}
     engines: {node: '>=22'}
 
+  aria-query@5.3.1:
+    resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
+    engines: {node: '>= 0.4'}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -726,6 +926,10 @@ packages:
 
   avvio@9.3.0:
     resolution: {integrity: sha512-g2tQ7LE7oOSqDfwEm3M+ZCMTJc7KiZCdJ4UwyZJb5ckTKyYu50OYmvv0mCFXPuYXoM4zkSt8zM9XQ9KCvxA74A==}
+
+  axobject-query@4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
+    engines: {node: '>= 0.4'}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -743,9 +947,17 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
   cliui@9.0.1:
     resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
     engines: {node: '>=20'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   conventional-changelog-angular@9.3.0:
     resolution: {integrity: sha512-0MWQLVUT1oVCsUGs9aAWteBVxPlLwJTn5VbQH7B0B3fDizZgrJ9QGnKl/2mp1+5P7153GCBCjO/v1aKJ6eysCg==}
@@ -762,6 +974,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@0.6.0:
+    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
+    engines: {node: '>= 0.6'}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
@@ -800,6 +1016,10 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -808,8 +1028,15 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  devalue@5.9.0:
+    resolution: {integrity: sha512-RWrqdArjvPbsATEhOPUo6Wndc/iWnkWKlhIrdlF3zMMYo/c3CVtoaVAyLtWxz5h8nSlkHzxnzV2uLydPXmtF+A==}
+
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
+  enhanced-resolve@5.24.5:
+    resolution: {integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==}
+    engines: {node: '>=10.13.0'}
 
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -854,6 +1081,9 @@ packages:
       jiti:
         optional: true
 
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
   espree@11.2.0:
     resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
@@ -861,6 +1091,14 @@ packages:
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
+
+  esrap@2.3.3:
+    resolution: {integrity: sha512-OETBYYsX6L8btUkOyi8AcdtlfpsyNO9nCmP92U/Cxm07epHeLo5we1ck6z0HsbB/jxWlfmEBF9oobZKqSBWD4Q==}
+    peerDependencies:
+      '@typescript-eslint/types': ^8.2.0
+    peerDependenciesMeta:
+      '@typescript-eslint/types':
+        optional: true
 
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
@@ -964,6 +1202,9 @@ packages:
     resolution: {integrity: sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==}
     engines: {node: '>=18'}
 
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -1012,11 +1253,18 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-reference@3.0.3:
+    resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
+
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
   js-tokens@4.0.0:
@@ -1047,6 +1295,10 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
+
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
@@ -1054,16 +1306,34 @@ packages:
   light-my-request@6.6.0:
     resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
   lightningcss-android-arm64@1.33.0:
     resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [android]
 
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
   lightningcss-darwin-arm64@1.33.0:
     resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
     os: [darwin]
 
   lightningcss-darwin-x64@1.33.0:
@@ -1072,17 +1342,36 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
   lightningcss-freebsd-x64@1.33.0:
     resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
   lightningcss-linux-arm-gnueabihf@1.33.0:
     resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm]
     os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.33.0:
     resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
@@ -1091,12 +1380,26 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   lightningcss-linux-arm64-musl@1.33.0:
     resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.33.0:
     resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
@@ -1105,6 +1408,13 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   lightningcss-linux-x64-musl@1.33.0:
     resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
@@ -1112,10 +1422,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
   lightningcss-win32-arm64-msvc@1.33.0:
     resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
     os: [win32]
 
   lightningcss-win32-x64-msvc@1.33.0:
@@ -1124,12 +1446,19 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   lightningcss@1.33.0:
     resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
     engines: {node: '>= 12.0.0'}
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  locate-character@3.0.0:
+    resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -1138,9 +1467,20 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  magic-string@1.2.0:
+    resolution: {integrity: sha512-ptco+HFxTLgjafSLim2LojBSwfg5feBjd+SqyiwdGkzC38UPdZy3zgrHMI2CoTf5fJL38tbHMYWVzIH8BxGqJw==}
+
   minimatch@10.2.6:
     resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
     engines: {node: 18 || 20 || >=22}
+
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
+  mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
+    engines: {node: '>=10'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1230,6 +1570,10 @@ packages:
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
   real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
@@ -1265,6 +1609,10 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
+
   safe-regex2@5.1.1:
     resolution: {integrity: sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==}
     hasBin: true
@@ -1284,6 +1632,9 @@ packages:
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
+  set-cookie-parser@3.1.2:
+    resolution: {integrity: sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -1294,6 +1645,10 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
+    engines: {node: '>=18'}
 
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
@@ -1328,6 +1683,25 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  svelte-check@4.7.6:
+    resolution: {integrity: sha512-t2scM//ZuVbSY/T2w6FSBw1v9s2NEmh/g+sy1lqtosW5ylBV5AF4wFb1Ts9Kf3MbfPDUDJDZ9L436YT0SPTdvw==}
+    engines: {node: '>= 18.0.0'}
+    hasBin: true
+    peerDependencies:
+      svelte: ^4.0.0 || ^5.0.0-next.0
+      typescript: ^5.0.0 || ^6.0.0
+
+  svelte@5.56.9:
+    resolution: {integrity: sha512-VT8kSnlEg8069w7AiCcAk3Yf5xvMnrGTagVOmU/OpOLHaHnNqXhWZCH/4EVga/bT/HtWhvE6/fHrXLErx7OnJA==}
+    engines: {node: '>=18'}
+
+  tailwindcss@4.3.3:
+    resolution: {integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
+
   thread-stream@4.2.0:
     resolution: {integrity: sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==}
     engines: {node: '>=20'}
@@ -1350,6 +1724,10 @@ packages:
   toad-cache@3.7.4:
     resolution: {integrity: sha512-m1TdR/rvT7kgGJZhspNtXdsdYk0fddFpJJFlG5s+UkPFo6lkLoZ3YLOaovPYjq1R75NP5JfeTlSHaOsE09peCg==}
     engines: {node: '>=20'}
+
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -1425,6 +1803,14 @@ packages:
       tsx:
         optional: true
       yaml:
+        optional: true
+
+  vitefu@1.1.3:
+    resolution: {integrity: sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==}
+    peerDependencies:
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      vite:
         optional: true
 
   vitest@4.1.10:
@@ -1504,6 +1890,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zimmerframe@1.1.4:
+    resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
 
 snapshots:
 
@@ -1691,6 +2080,10 @@ snapshots:
       '@fastify/forwarded': 3.0.2
       ipaddr.js: 2.5.0
 
+  '@fontsource-variable/ibm-plex-sans@5.3.0': {}
+
+  '@fontsource/ibm-plex-mono@5.3.0': {}
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -1707,11 +2100,30 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@oxc-project/types@0.143.0': {}
 
   '@pinojs/redact@0.4.0': {}
+
+  '@polka/url@1.0.0-next.29': {}
 
   '@rolldown/binding-android-arm64@1.2.3':
     optional: true
@@ -1765,10 +2177,119 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@sveltejs/acorn-typescript@1.0.13(acorn@8.18.0)':
+    dependencies:
+      acorn: 8.18.0
+
+  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0)))(@typescript/typescript6@6.0.2)(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0)))':
+    dependencies:
+      '@sveltejs/kit': 2.70.2(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0)))(@typescript/typescript6@6.0.2)(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0))
+
+  '@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0)))(@typescript/typescript6@6.0.2)(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0))':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@sveltejs/acorn-typescript': 1.0.13(acorn@8.18.0)
+      '@sveltejs/vite-plugin-svelte': 7.3.0(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0))
+      '@types/cookie': 0.6.0
+      acorn: 8.18.0
+      cookie: 0.6.0
+      devalue: 5.9.0
+      esm-env: 1.2.2
+      kleur: 4.1.5
+      magic-string: 0.30.21
+      mrmime: 2.0.1
+      set-cookie-parser: 3.1.2
+      sirv: 3.0.2
+      svelte: 5.56.9(@typescript-eslint/types@8.67.0)
+      vite: 8.2.1(@types/node@24.13.3)(jiti@2.7.0)
+    optionalDependencies:
+      typescript: '@typescript/typescript6@6.0.2'
+
+  '@sveltejs/load-config@0.2.3': {}
+
+  '@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0))':
+    dependencies:
+      deepmerge: 4.3.1
+      magic-string: 1.2.0
+      obug: 2.1.4
+      svelte: 5.56.9(@typescript-eslint/types@8.67.0)
+      vite: 8.2.1(@types/node@24.13.3)(jiti@2.7.0)
+      vitefu: 1.1.3(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0))
+
+  '@tailwindcss/node@4.3.3':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.24.5
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.3.3
+
+  '@tailwindcss/oxide-android-arm64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide@4.3.3':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.3.3
+      '@tailwindcss/oxide-darwin-arm64': 4.3.3
+      '@tailwindcss/oxide-darwin-x64': 4.3.3
+      '@tailwindcss/oxide-freebsd-x64': 4.3.3
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.3
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.3
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.3
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.3
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.3
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.3
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.3
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.3
+
+  '@tailwindcss/vite@4.3.3(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0))':
+    dependencies:
+      '@tailwindcss/node': 4.3.3
+      '@tailwindcss/oxide': 4.3.3
+      tailwindcss: 4.3.3
+      vite: 8.2.1(@types/node@24.13.3)(jiti@2.7.0)
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
+
+  '@types/cookie@0.6.0': {}
 
   '@types/deep-eql@4.0.2': {}
 
@@ -1781,6 +2302,8 @@ snapshots:
   '@types/node@24.13.3':
     dependencies:
       undici-types: 7.18.2
+
+  '@types/trusted-types@2.0.7': {}
 
   '@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(@typescript/typescript6@6.0.2)(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0))(@typescript/typescript6@6.0.2)(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
@@ -1946,13 +2469,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.1.10(vite@8.2.1(@types/node@24.13.3)(jiti@2.6.1))':
+  '@vitest/mocker@4.1.10(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.2.1(@types/node@24.13.3)(jiti@2.6.1)
+      vite: 8.2.1(@types/node@24.13.3)(jiti@2.7.0)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -2014,6 +2537,8 @@ snapshots:
 
   argue-cli@3.1.0: {}
 
+  aria-query@5.3.1: {}
+
   assertion-error@2.0.1: {}
 
   atomic-sleep@1.0.0: {}
@@ -2022,6 +2547,8 @@ snapshots:
     dependencies:
       '@fastify/error': 4.2.0
       fastq: 1.20.1
+
+  axobject-query@4.1.0: {}
 
   balanced-match@4.0.4: {}
 
@@ -2033,11 +2560,17 @@ snapshots:
 
   chai@6.2.2: {}
 
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
   cliui@9.0.1:
     dependencies:
       string-width: 7.2.0
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
+
+  clsx@2.1.1: {}
 
   conventional-changelog-angular@9.3.0:
     dependencies:
@@ -2053,6 +2586,8 @@ snapshots:
       argue-cli: 3.1.0
 
   convert-source-map@2.0.0: {}
+
+  cookie@0.6.0: {}
 
   cookie@1.1.1: {}
 
@@ -2086,11 +2621,20 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  deepmerge@4.3.1: {}
+
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
 
+  devalue@5.9.0: {}
+
   emoji-regex@10.6.0: {}
+
+  enhanced-resolve@5.24.5:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
 
   env-paths@2.2.1: {}
 
@@ -2154,6 +2698,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  esm-env@1.2.2: {}
+
   espree@11.2.0:
     dependencies:
       acorn: 8.18.0
@@ -2163,6 +2709,12 @@ snapshots:
   esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
+
+  esrap@2.3.3(@typescript-eslint/types@8.67.0):
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+    optionalDependencies:
+      '@typescript-eslint/types': 8.67.0
 
   esrecurse@4.3.0:
     dependencies:
@@ -2268,6 +2820,8 @@ snapshots:
 
   globals@17.11.0: {}
 
+  graceful-fs@4.2.11: {}
+
   has-flag@4.0.0:
     optional: true
 
@@ -2298,9 +2852,15 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-reference@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   isexe@2.0.0: {}
 
   jiti@2.6.1: {}
+
+  jiti@2.7.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -2326,6 +2886,8 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
+  kleur@4.1.5: {}
+
   levn@0.4.1:
     dependencies:
       prelude-ls: 1.2.1
@@ -2337,38 +2899,87 @@ snapshots:
       process-warning: 4.0.1
       set-cookie-parser: 2.7.2
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
   lightningcss-android-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
     optional: true
 
   lightningcss-darwin-arm64@1.33.0:
     optional: true
 
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
   lightningcss-darwin-x64@1.33.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
     optional: true
 
   lightningcss-freebsd-x64@1.33.0:
     optional: true
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
   lightningcss-linux-arm-gnueabihf@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-arm64-gnu@1.33.0:
     optional: true
 
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
   lightningcss-linux-arm64-musl@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-x64-gnu@1.33.0:
     optional: true
 
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
   lightningcss-linux-x64-musl@1.33.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
     optional: true
 
   lightningcss-win32-arm64-msvc@1.33.0:
     optional: true
 
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
   lightningcss-win32-x64-msvc@1.33.0:
     optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
 
   lightningcss@1.33.0:
     dependencies:
@@ -2388,6 +2999,8 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  locate-character@3.0.0: {}
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -2396,9 +3009,17 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magic-string@1.2.0:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   minimatch@10.2.6:
     dependencies:
       brace-expansion: 5.0.9
+
+  mri@1.2.0: {}
+
+  mrmime@2.0.1: {}
 
   ms@2.1.3: {}
 
@@ -2484,6 +3105,8 @@ snapshots:
 
   quick-format-unescaped@4.0.4: {}
 
+  readdirp@4.1.2: {}
+
   real-require@0.2.0: {}
 
   real-require@1.0.0: {}
@@ -2520,6 +3143,10 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.2.3
       '@rolldown/binding-win32-x64-msvc': 1.2.3
 
+  sade@1.8.1:
+    dependencies:
+      mri: 1.2.0
+
   safe-regex2@5.1.1:
     dependencies:
       ret: 0.5.0
@@ -2532,6 +3159,8 @@ snapshots:
 
   set-cookie-parser@2.7.2: {}
 
+  set-cookie-parser@3.1.2: {}
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -2539,6 +3168,12 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   siginfo@2.0.0: {}
+
+  sirv@3.0.2:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
 
   sonic-boom@4.2.1:
     dependencies:
@@ -2572,6 +3207,44 @@ snapshots:
       has-flag: 4.0.0
     optional: true
 
+  svelte-check@4.7.6(@typescript/typescript6@6.0.2)(picomatch@4.0.5)(svelte@5.56.9(@typescript-eslint/types@8.67.0)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      '@sveltejs/load-config': 0.2.3
+      chokidar: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.5)
+      picocolors: 1.1.1
+      sade: 1.8.1
+      svelte: 5.56.9(@typescript-eslint/types@8.67.0)
+      typescript: '@typescript/typescript6@6.0.2'
+    transitivePeerDependencies:
+      - picomatch
+
+  svelte@5.56.9(@typescript-eslint/types@8.67.0):
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@sveltejs/acorn-typescript': 1.0.13(acorn@8.18.0)
+      '@types/estree': 1.0.9
+      '@types/trusted-types': 2.0.7
+      acorn: 8.18.0
+      aria-query: 5.3.1
+      axobject-query: 4.1.0
+      clsx: 2.1.1
+      devalue: 5.9.0
+      esm-env: 1.2.2
+      esrap: 2.3.3(@typescript-eslint/types@8.67.0)
+      is-reference: 3.0.3
+      locate-character: 3.0.0
+      magic-string: 0.30.21
+      zimmerframe: 1.1.4
+    transitivePeerDependencies:
+      - '@typescript-eslint/types'
+
+  tailwindcss@4.3.3: {}
+
+  tapable@2.3.3: {}
+
   thread-stream@4.2.0:
     dependencies:
       real-require: 1.0.0
@@ -2588,6 +3261,8 @@ snapshots:
   tinyrainbow@3.1.1: {}
 
   toad-cache@3.7.4: {}
+
+  totalist@3.0.1: {}
 
   ts-api-utils@2.5.0(@typescript/typescript6@6.0.2):
     dependencies:
@@ -2639,7 +3314,7 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite@8.2.1(@types/node@24.13.3)(jiti@2.6.1):
+  vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
@@ -2649,12 +3324,16 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.13.3
       fsevents: 2.3.3
-      jiti: 2.6.1
+      jiti: 2.7.0
 
-  vitest@4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(jiti@2.6.1)):
+  vitefu@1.1.3(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0)):
+    optionalDependencies:
+      vite: 8.2.1(@types/node@24.13.3)(jiti@2.7.0)
+
+  vitest@4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@24.13.3)(jiti@2.6.1))
+      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@24.13.3)(jiti@2.7.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -2671,7 +3350,7 @@ snapshots:
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vite: 8.2.1(@types/node@24.13.3)(jiti@2.6.1)
+      vite: 8.2.1(@types/node@24.13.3)(jiti@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.13.3
@@ -2711,3 +3390,5 @@ snapshots:
       yargs-parser: 22.0.0
 
   yocto-queue@0.1.0: {}
+
+  zimmerframe@1.1.4: {}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * One `pnpm test`, two suites. The packages and plugins are plain Node code and
+ * need no configuration; `apps/web` needs the Svelte compiler and a DOM, so it
+ * brings its own config (`apps/web/vitest.config.ts`) as a second project.
+ */
+export default defineConfig({
+  test: {
+    projects: [
+      {
+        test: {
+          name: 'node',
+          include: ['{packages,plugins}/*/src/**/*.test.ts'],
+        },
+      },
+      './apps/web',
+    ],
+  },
+});


### PR DESCRIPTION
Closes #28.

Turns the `apps/web` placeholder into a real app: **Vite + SvelteKit** (Svelte 5 runes) + **Tailwind v4**, built as a **static SPA** (`adapter-static`, `ssr = false`) so `@strata/server` can serve the output from the same Docker image and the later Tauri shell can load it from disk.

## What's in it

- **Theme layer** — `src/lib/theme/tokens.css` carries the palette twice (dark + light), keyed on `data-theme` on `<html>`; `app.css` maps it onto Tailwind keys with `@theme inline`, so components only ever use semantic utilities (`bg-surface`, `text-muted`, `bg-h1`…`bg-h5` for the hotspot heat ramp). A dark / light / **system** switch persists the choice and follows the OS; an inline script in `app.html` applies it before first paint. IBM Plex Sans/Mono are self-hosted, so a self-hosted install stays offline.
- **API client** — `src/lib/api`, one module per endpoint (`/health`, `/plugins`, `/analyze`, `/cache`) over a shared request helper with a single `ApiError` shape. `@strata/sdk` is imported for **types only**, so the report contract is single-sourced while the UI still talks REST only.
- **Proof page** — renders the token set and the live server status (health, plugins directory, loaded plugins). The workbench shell and the analysis screens are the follow-ups (#29, #30, #31, #32).
- Docs/DX: `make web`, `pnpm dev:web`, updated `apps/web/{README,ARCHITECTURE}.md`, ADR-7 in `docs/ARCHITECTURE.md`, `.env.example` entries, backlog item ticked.

The dev server proxies the API paths to `:4000` rather than serving them under an `/api` prefix, so dev and production use identical relative URLs.

## Notes

- The mockup's exact token values aren't in the repo, so the palette is **derived from its description** (`--h1…--h5` ramp, IBM Plex, both themes). Expect a tuning pass once the screens land — flagged in `apps/web/ARCHITECTURE.md`.
- ESLint still skips `apps/web` (linting `.svelte` needs `eslint-plugin-svelte`); `svelte-check` is the static gate there and runs as the app's `typecheck` script, so root `pnpm typecheck` covers it.

## Verification

`pnpm -r build`, `pnpm typecheck`, `pnpm lint`, `pnpm test` all pass (272 tests, incl. new coverage for theme resolution). Ran the UI against a live `@strata/server` and screenshotted both themes — the proxy, the client and both palettes render as expected.