### PR TITLE
feat(web): add the hotspot treemap view

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -156,8 +156,10 @@ Sans/Mono.
 - [ ] **P0** Overview — six stat cards (files, top hotspot, import cycles, commits,
       dead code, plugins), top-hotspot bar list, import-cycle alert card with the
       cycle path, loaded-plugins list, commit-type strip
-- [ ] **P0** Hotspot treemap — heat legend, tiles sized by score and coloured by
-      complexity, plus the ranked table (churn / complexity / LOC / score)
+- [x] Hotspot treemap (`/hotspots`) — heat legend, squarified tiles sized by
+      score and coloured by complexity, the ranked table (churn / complexity /
+      LOC / score), and a shared selection between the two. Runs the analysis
+      from a repo-path form until the project switcher replaces it.
 - [ ] **P0** Dependency graph view (Cytoscape/d3) — local vs. package vs. cycle edge
       styles, cycle nodes highlighted, side panel with the SCC path and graph
       summary (nodes, edges, cycles, max fan-in)

--- a/apps/web/ARCHITECTURE.md
+++ b/apps/web/ARCHITECTURE.md
@@ -1,8 +1,9 @@
 # Module: `@strata/web` — Architecture (arc42)
 
 > Trimmed arc42, consistent with [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md).
-> Status: **scaffolded** — theme layer and API client in place; the workbench
-> shell and the analysis screens are still to build.
+> Status: **in progress** — theme layer, API client and the hotspot screen in
+> place; the workbench shell and the remaining analysis screens are still to
+> build.
 
 ## 1. Purpose & Goals
 
@@ -35,9 +36,15 @@ app-scoped settings screens. The face of Strata for browser/self-host use.
 | `src/lib/theme/tokens.css` | The palette, twice — dark and light, keyed on `data-theme` |
 | `src/lib/theme/*` | `mode` (types + resolution), `storage`, `apply`, `controller.svelte` (state) |
 | `src/lib/api/*` | `base` (origin), `request` (fetch + `ApiError`), one module per endpoint, `types` |
+| `src/lib/analysis/*` | The app-wide last report (`store.svelte`), the remembered repo path, and `RunForm` |
+| `src/lib/hotspots/*` | The hotspot feature end to end: `rows` (report → rows), `heat` (ramp), `layout` (squarified treemap), `format`/`path`, and the three views |
 | `src/lib/components/*` | Reusable UI pieces |
 | `src/routes/*` | SvelteKit routes; `+layout.ts` pins the app to SPA mode |
 | `src/lib/test/render.ts` | Mounts a component into a detached container for a test |
+
+A screen is a **feature folder**: its pure functions and the components that
+render them sit together (`lib/hotspots/`), because they change together. Only
+what more than one screen uses moves up into `lib/components/`.
 
 ## 5. Runtime
 
@@ -58,17 +65,28 @@ app-scoped settings screens. The face of Strata for browser/self-host use.
 | 4 | **API paths not prefixed (`/analyze`, not `/api/analyze`)** | Matches the server as it is; dev proxy mirrors the same paths, so dev and production URLs are identical |
 | 5 | **Type-only dependency on `@strata/sdk`** | The report's leaf types stay in sync with the backend without a runtime coupling |
 | 6 | **Self-hosted IBM Plex via `@fontsource`** | Keeps a self-hosted install fully offline |
+| 7 | **Squarified treemap written here, no charting library** | ~100 lines of geometry against a dependency that would ship a whole renderer; keeping it in-repo also keeps the layout pure and unit-tested, and the tiles are plain DOM so theming, focus and `aria-pressed` come for free |
+| 8 | **Heat by quantile, not by value** | Complexity is long-tailed: equal value steps paint nearly everything cold. Equal population steps keep all five ramp colours on screen, and the legend labels the ranges so nothing is hidden |
+| 9 | **Report held in one app-wide store** | An analysis is expensive; the overview, graph and commit screens read the same run rather than each triggering their own |
 
 ## 7. Quality & Risks
 
 - **Risk:** graph rendering perf on large repos. **Mitigation:** virtualise /
   cluster nodes; render server-computed summaries first.
 - **Risk:** the palette here is derived from the mockup's description rather
-  than exported from it; expect a tuning pass when the screens land.
+  than exported from it; expect a tuning pass when the screens land. The light
+  heat ramp already took one, so a single light ink clears 4.5:1 on every step.
+- **Debt:** the hotspot screen types the repo path into a form and remembers it
+  in `localStorage`. That is the project switcher's job — this goes away with it.
+- **Debt:** a treemap draws the top ~50 files; the rest of the ranking is only
+  in the table. A zoom or a directory roll-up is the fix if it starts to bite.
 - **Debt:** ESLint skips this app (`apps/web/**` is ignored at the root) —
   `svelte-check` is the only static gate until `eslint-plugin-svelte` is wired in.
 - **Tests:** `vitest` with the plain Svelte plugin and a `happy-dom`
   environment (`vitest.config.ts`), wired into the root run as a second
   project. Covered: theme resolution, storage, the appearance controller, the
-  request helper's error normalisation, and the two stateful components
-  (`ThemeSwitch`, `ServerStatus`). Components mount through `lib/test/render`.
+  request helper's error normalisation, the stateful components (`ThemeSwitch`,
+  `ServerStatus`), the hotspot pure layer (rows join, heat scale, squarify's
+  area/overlap/aspect invariants, formatting) and its three views, the analysis
+  store (including a superseded run), plus the `/hotspots` route end to end.
+  Components mount through `lib/test/render`.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -45,6 +45,8 @@ src/
   lib/
     theme/            tokens.css (both palettes) + the appearance controller
     api/              one module per endpoint over a shared request helper
+    analysis/         the last report, held app-wide, + the form that runs one
+    hotspots/         the hotspot feature: report → rows, heat, layout, views
     components/       reusable UI pieces
     test/             test helpers (component mounting)
   routes/             SvelteKit routes (SPA: `ssr = false`)
@@ -71,8 +73,13 @@ storage key on purpose, so keep the two in step.
 
 ## Status
 
-Scaffold: the theme layer, the typed API client and one page that proves both
-are wired. The app shell (left rail, header, project switcher) and the analysis
+The theme layer, the typed API client and the first analysis screen —
+**Hotspots** (`/hotspots`): a squarified treemap sized by score and coloured by
+complexity, its heat legend, and the ranked table. Until the project switcher
+lands, the repo to analyse is typed into the form on that page and remembered
+in `localStorage`.
+
+The app shell (left rail, header, project switcher) and the remaining analysis
 screens are next — see [`BACKLOG.md`](../../BACKLOG.md) and the *web-ui* issues.
 
 Where each screen's data comes from:

--- a/apps/web/src/lib/analysis/RunForm.svelte
+++ b/apps/web/src/lib/analysis/RunForm.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import { analysis } from './store.svelte';
+
+  // Until the project switcher lands, the repo to analyse is typed here and
+  // remembered in storage. The server resolves the path on its own machine.
+  analysis.init();
+  let root = $state(analysis.root);
+</script>
+
+<form
+  class="flex flex-wrap items-end gap-3"
+  onsubmit={(event) => {
+    event.preventDefault();
+    void analysis.run(root);
+  }}
+>
+  <label class="min-w-64 flex-1">
+    <span class="text-subtle mb-1 block text-xs">Repository path</span>
+    <input
+      class="border-line bg-bg text-ink placeholder:text-subtle w-full rounded-lg border px-3 py-2 font-mono text-sm"
+      type="text"
+      name="root"
+      autocomplete="off"
+      spellcheck="false"
+      placeholder="/absolute/path/to/repo"
+      bind:value={root}
+    />
+  </label>
+  <button
+    type="submit"
+    class="bg-accent text-accent-ink hover:bg-accent-strong rounded-lg px-4 py-2 text-sm font-medium transition-colors disabled:opacity-60"
+    disabled={analysis.status === 'running'}
+  >
+    {analysis.status === 'running' ? 'Analysing…' : 'Run analysis'}
+  </button>
+</form>

--- a/apps/web/src/lib/analysis/index.ts
+++ b/apps/web/src/lib/analysis/index.ts
@@ -1,0 +1,2 @@
+export { analysis, type AnalysisStatus } from './store.svelte';
+export { readStoredRoot, ROOT_STORAGE_KEY, storeRoot } from './root-storage';

--- a/apps/web/src/lib/analysis/root-storage.ts
+++ b/apps/web/src/lib/analysis/root-storage.ts
@@ -1,0 +1,24 @@
+/**
+ * The repo the workbench last analysed. A stop-gap: once the project switcher
+ * lands, the registered projects replace this single remembered path.
+ */
+export const ROOT_STORAGE_KEY = 'strata:root';
+
+/** `null` when nothing is stored, or storage is unavailable. */
+export function readStoredRoot(): string | null {
+  try {
+    const stored = localStorage.getItem(ROOT_STORAGE_KEY);
+    return stored && stored.trim() ? stored : null;
+  } catch {
+    // Private mode / storage disabled: the field simply starts empty.
+    return null;
+  }
+}
+
+export function storeRoot(root: string): void {
+  try {
+    localStorage.setItem(ROOT_STORAGE_KEY, root);
+  } catch {
+    // Not remembering the path must not fail the analysis.
+  }
+}

--- a/apps/web/src/lib/analysis/store.svelte.ts
+++ b/apps/web/src/lib/analysis/store.svelte.ts
@@ -1,0 +1,75 @@
+import { analyze, ApiError, type AnalysisReport } from '$lib/api';
+import { readStoredRoot, storeRoot } from './root-storage';
+
+export type AnalysisStatus = 'idle' | 'running' | 'ready' | 'error';
+
+/**
+ * The last analysis, held for the whole app: one run feeds the treemap today
+ * and the overview, graph and commit screens as they land, so re-entering a
+ * view must not re-run the pipeline.
+ *
+ * One instance, exported below — there is one workbench per window.
+ */
+class AnalysisStore {
+  #status = $state<AnalysisStatus>('idle');
+  #report = $state<AnalysisReport | null>(null);
+  #error = $state('');
+  #root = $state('');
+  /** Lets a superseded run drop its result instead of overwriting a newer one. */
+  #run = 0;
+
+  get status(): AnalysisStatus {
+    return this.#status;
+  }
+
+  get report(): AnalysisReport | null {
+    return this.#report;
+  }
+
+  get error(): string {
+    return this.#error;
+  }
+
+  /** The path the form edits; seeded from storage by `init()`. */
+  get root(): string {
+    return this.#root;
+  }
+
+  set root(value: string) {
+    this.#root = value;
+  }
+
+  /** Adopt the remembered repo path. Safe to call from any view that mounts. */
+  init(): void {
+    if (!this.#root) this.#root = readStoredRoot() ?? '';
+  }
+
+  async run(root = this.#root): Promise<void> {
+    const trimmed = root.trim();
+    if (!trimmed) {
+      this.#status = 'error';
+      this.#error = 'Enter the absolute path of a repository to analyse.';
+      return;
+    }
+
+    const run = ++this.#run;
+    this.#root = trimmed;
+    this.#status = 'running';
+    this.#error = '';
+    storeRoot(trimmed);
+
+    try {
+      const report = await analyze({ root: trimmed });
+      if (run !== this.#run) return;
+      this.#report = report;
+      this.#status = 'ready';
+    } catch (err) {
+      if (run !== this.#run) return;
+      this.#error =
+        err instanceof ApiError ? err.message : 'Unexpected client error.';
+      this.#status = 'error';
+    }
+  }
+}
+
+export const analysis = new AnalysisStore();

--- a/apps/web/src/lib/analysis/store.test.ts
+++ b/apps/web/src/lib/analysis/store.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { analysis } from './store.svelte';
+import { ROOT_STORAGE_KEY } from './root-storage';
+
+const report = {
+  rev: 'abc123',
+  languages: {},
+  metrics: [],
+  commits: [],
+  cache: {
+    enabled: false,
+    hits: 0,
+    misses: 0,
+    runHits: 0,
+    runMisses: 0,
+    writes: 0,
+  },
+};
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('analysis store', () => {
+  it('runs the analysis and remembers the repo path', async () => {
+    const fetchMock = vi.fn(async () => Response.json(report));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await analysis.run('  /repo/strata  ');
+
+    expect(analysis.status).toBe('ready');
+    expect(analysis.report?.rev).toBe('abc123');
+    expect(analysis.root).toBe('/repo/strata');
+    expect(localStorage.getItem(ROOT_STORAGE_KEY)).toBe('/repo/strata');
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    expect(JSON.parse(String(init.body))).toEqual({ root: '/repo/strata' });
+  });
+
+  it('surfaces a failed run without dropping the last good report', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => Response.json({ message: 'not a repository' }, { status: 400 })),
+    );
+
+    await analysis.run('/not/a/repo');
+
+    expect(analysis.status).toBe('error');
+    expect(analysis.error).toBe('not a repository');
+    // The store is the app's single instance: the report the previous run
+    // loaded has to stay on screen behind the error.
+    expect(analysis.report?.rev).toBe('abc123');
+  });
+
+  it('refuses an empty path instead of calling the server', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await analysis.run('   ');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(analysis.status).toBe('error');
+    expect(analysis.error).toContain('absolute path');
+  });
+
+  it('lets the newest run win when two overlap', async () => {
+    // The slow run resolves last; its result must not replace the newer one.
+    const slow = Response.json({ ...report, rev: 'slow' });
+    const fast = Response.json({ ...report, rev: 'fast' });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, init: RequestInit) => {
+        const body = JSON.parse(String(init.body)) as { root: string };
+        if (body.root !== '/slow') return fast;
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        return slow;
+      }),
+    );
+
+    const first = analysis.run('/slow');
+    const second = analysis.run('/fast');
+    await Promise.all([first, second]);
+
+    expect(analysis.report?.rev).toBe('fast');
+    expect(analysis.status).toBe('ready');
+  });
+});

--- a/apps/web/src/lib/hotspots/HeatLegend.svelte
+++ b/apps/web/src/lib/hotspots/HeatLegend.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import { compactNumber } from './format';
+  import { heatBands, heatColor, type HeatScale } from './heat';
+
+  interface Props {
+    scale: HeatScale;
+    /** What the ramp encodes; the tiles' size is labelled separately. */
+    label?: string;
+  }
+
+  let { scale, label = 'Complexity' }: Props = $props();
+
+  let bands = $derived(heatBands(scale));
+</script>
+
+<div class="flex flex-wrap items-center gap-x-4 gap-y-2">
+  <span class="text-subtle text-xs">{label}</span>
+  <ul class="flex items-stretch">
+    {#each bands as band (band.level)}
+      <li class="flex flex-col items-center gap-1">
+        <span
+          class="border-bg/60 block h-3 w-12 border-r first:rounded-l-sm last:rounded-r-sm last:border-r-0"
+          style="background: {heatColor(band.level)};"
+          aria-hidden="true"
+        ></span>
+        <span class="text-subtle font-mono text-[10px]">
+          {compactNumber(band.to)}
+        </span>
+      </li>
+    {/each}
+  </ul>
+  <span class="text-subtle text-xs">
+    cold {compactNumber(scale.min)} → hot {compactNumber(scale.max)}
+  </span>
+</div>

--- a/apps/web/src/lib/hotspots/RankedTable.svelte
+++ b/apps/web/src/lib/hotspots/RankedTable.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+  import { compactNumber } from './format';
+  import { heatColor, heatLevel, type HeatScale } from './heat';
+  import { dirName, fileName } from './path';
+  import type { HotspotRow } from './rows';
+
+  interface Props {
+    rows: HotspotRow[];
+    scale: HeatScale;
+    /** Rows rendered; the tail of a long ranking is noise. */
+    limit?: number;
+    selected?: string | null;
+    onselect?: (path: string) => void;
+  }
+
+  let { rows, scale, limit = 100, selected = null, onselect }: Props = $props();
+
+  let shown = $derived(rows.slice(0, limit));
+</script>
+
+<div class="overflow-x-auto">
+  <table class="w-full text-sm">
+    <caption class="sr-only">
+      Files ranked by hotspot score: churn × complexity
+    </caption>
+    <thead>
+      <tr class="border-line text-subtle border-b text-xs">
+        <th scope="col" class="w-10 py-2 pr-3 text-right font-medium">#</th>
+        <th scope="col" class="py-2 pr-3 text-left font-medium">File</th>
+        <th scope="col" class="w-20 py-2 pr-3 text-right font-medium">Churn</th>
+        <th scope="col" class="w-24 py-2 pr-3 text-right font-medium">
+          Complexity
+        </th>
+        <th scope="col" class="w-20 py-2 pr-3 text-right font-medium">LOC</th>
+        <th scope="col" class="w-20 py-2 text-right font-medium">Score</th>
+      </tr>
+    </thead>
+    <tbody>
+      {#each shown as row, index (row.path)}
+        <tr
+          class="border-line hover:bg-elevated border-b last:border-b-0
+                 {selected === row.path ? 'bg-accent-soft' : ''}"
+        >
+          <td class="text-subtle py-2 pr-3 text-right font-mono text-xs">
+            {index + 1}
+          </td>
+          <td class="max-w-0 py-2 pr-3">
+            <!-- The name is the control: a clickable <tr> would be neither
+                 focusable nor announced. -->
+            <button
+              type="button"
+              class="flex w-full items-center gap-2 text-left"
+              aria-pressed={selected === row.path}
+              onclick={() => onselect?.(row.path)}
+            >
+              <span
+                class="size-2.5 shrink-0 rounded-xs"
+                style="background: {heatColor(heatLevel(scale, row.complexity))};"
+                aria-hidden="true"
+              ></span>
+              <span class="truncate font-mono text-xs" title={row.path}>
+                <span class="text-subtle">{dirName(row.path)}</span
+                ><span class="text-ink">{fileName(row.path)}</span>
+              </span>
+            </button>
+          </td>
+          <td class="text-muted py-2 pr-3 text-right font-mono text-xs">
+            {row.churn}
+          </td>
+          <td class="text-muted py-2 pr-3 text-right font-mono text-xs">
+            {compactNumber(row.complexity)}
+          </td>
+          <td class="text-muted py-2 pr-3 text-right font-mono text-xs">
+            {row.loc === null ? '—' : compactNumber(row.loc)}
+          </td>
+          <td class="py-2 text-right font-mono text-xs font-medium">
+            {compactNumber(row.score)}
+          </td>
+        </tr>
+      {/each}
+    </tbody>
+  </table>
+</div>
+
+{#if rows.length > shown.length}
+  <p class="text-subtle mt-3 text-xs">
+    {shown.length} of {rows.length} scored files.
+  </p>
+{/if}

--- a/apps/web/src/lib/hotspots/RankedTable.test.ts
+++ b/apps/web/src/lib/hotspots/RankedTable.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render } from '$lib/test/render';
+import { heatScale } from './heat';
+import RankedTable from './RankedTable.svelte';
+import type { HotspotRow } from './rows';
+
+const rows: HotspotRow[] = [
+  { path: 'src/big.ts', score: 12_400, churn: 62, complexity: 200, loc: 940 },
+  { path: 'src/mid.ts', score: 300, churn: 10, complexity: 30, loc: null },
+];
+
+const scale = heatScale(rows.map((row) => row.complexity));
+
+let ui: ReturnType<typeof render>;
+
+afterEach(() => ui?.destroy());
+
+describe('RankedTable', () => {
+  it('ranks the rows and shows every factor of the score', () => {
+    ui = render(RankedTable, { rows, scale });
+
+    const cells = [...ui.container.querySelectorAll('tbody tr')].map((row) =>
+      [...row.querySelectorAll('td')].map((cell) => cell.textContent?.trim()),
+    );
+
+    expect(cells[0]).toEqual(['1', 'src/big.ts', '62', '200', '940', '12k']);
+    // No language plugin claimed the file, so there is no line count to show.
+    expect(cells[1]).toEqual(['2', 'src/mid.ts', '10', '30', '—', '300']);
+  });
+
+  it('selects a file from its name', () => {
+    const onselect = vi.fn();
+    ui = render(RankedTable, { rows, scale, selected: 'src/mid.ts', onselect });
+
+    const buttons = [
+      ...ui.container.querySelectorAll<HTMLButtonElement>('tbody button'),
+    ];
+    buttons[0]!.click();
+
+    expect(onselect).toHaveBeenCalledWith('src/big.ts');
+    expect(buttons[1]!.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('trims a long ranking and counts what it left out', () => {
+    ui = render(RankedTable, { rows, scale, limit: 1 });
+
+    expect(ui.container.querySelectorAll('tbody tr')).toHaveLength(1);
+    expect(ui.container.textContent).toContain('1 of 2 scored files');
+  });
+});

--- a/apps/web/src/lib/hotspots/Treemap.svelte
+++ b/apps/web/src/lib/hotspots/Treemap.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+  import { compactNumber } from './format';
+  import { heatColor, heatInk, heatLevel, type HeatScale } from './heat';
+  import { fileName } from './path';
+  import { squarify } from './layout';
+  import type { HotspotRow } from './rows';
+
+  interface Props {
+    rows: HotspotRow[];
+    scale: HeatScale;
+    /** How many of the top files get a tile; the rest would be sub-pixel. */
+    limit?: number;
+    selected?: string | null;
+    onselect?: (path: string) => void;
+  }
+
+  let { rows, scale, limit = 48, selected = null, onselect }: Props = $props();
+
+  // The box is 16:9, so the layout gets the same ratio and every tile can be
+  // positioned in percentages — no measuring, no resize observer.
+  const BOX_WIDTH = 16;
+  const BOX_HEIGHT = 9;
+
+  let shown = $derived(rows.slice(0, limit));
+  let tiles = $derived(
+    squarify(shown, (row) => row.score, BOX_WIDTH, BOX_HEIGHT),
+  );
+
+  const percent = (value: number, of: number) => `${(value / of) * 100}%`;
+
+  /** Below this the label would be clipped to a letter or two — drop it. */
+  const fits = (width: number, height: number) =>
+    width / BOX_WIDTH > 0.075 && height / BOX_HEIGHT > 0.09;
+</script>
+
+{#if tiles.length === 0}
+  <p class="text-muted text-sm">No file scored above zero in this window.</p>
+{:else}
+  <div
+    class="border-line bg-bg relative aspect-[16/9] w-full overflow-hidden rounded-lg border"
+  >
+    {#each tiles as tile (tile.item.path)}
+      {@const row = tile.item}
+      {@const level = heatLevel(scale, row.complexity)}
+      <button
+        type="button"
+        class="absolute overflow-hidden p-1.5 text-left transition-[filter] outline-none
+               hover:brightness-115 focus-visible:z-10 focus-visible:brightness-115
+               {selected === row.path
+          ? 'ring-ink z-10 ring-2 ring-inset'
+          : 'ring-bg/60 ring-1 ring-inset'}"
+        style="left: {percent(tile.x, BOX_WIDTH)};
+               top: {percent(tile.y, BOX_HEIGHT)};
+               width: {percent(tile.width, BOX_WIDTH)};
+               height: {percent(tile.height, BOX_HEIGHT)};
+               background: {heatColor(level)};
+               color: {heatInk(level)};"
+        aria-pressed={selected === row.path}
+        title="{row.path} — score {compactNumber(row.score)}, {row.churn} commits, complexity {compactNumber(
+          row.complexity,
+        )}"
+        onclick={() => onselect?.(row.path)}
+      >
+        {#if fits(tile.width, tile.height)}
+          <span class="block truncate text-[11px] leading-tight font-medium">
+            {fileName(row.path)}
+          </span>
+          <span class="block truncate font-mono text-[10px] opacity-80">
+            {compactNumber(row.score)}
+          </span>
+        {/if}
+      </button>
+    {/each}
+  </div>
+
+  {#if rows.length > shown.length}
+    <p class="text-subtle mt-2 text-xs">
+      Showing the top {shown.length} of {rows.length} scored files.
+    </p>
+  {/if}
+{/if}

--- a/apps/web/src/lib/hotspots/Treemap.test.ts
+++ b/apps/web/src/lib/hotspots/Treemap.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render } from '$lib/test/render';
+import { heatScale } from './heat';
+import type { HotspotRow } from './rows';
+import Treemap from './Treemap.svelte';
+
+const rows: HotspotRow[] = [
+  { path: 'src/big.ts', score: 900, churn: 9, complexity: 100, loc: 400 },
+  { path: 'src/mid.ts', score: 300, churn: 10, complexity: 30, loc: 120 },
+  { path: 'src/small.ts', score: 100, churn: 5, complexity: 20, loc: 60 },
+];
+
+const scale = heatScale(rows.map((row) => row.complexity));
+
+let ui: ReturnType<typeof render>;
+
+afterEach(() => ui?.destroy());
+
+describe('Treemap', () => {
+  it('gives the hottest file the largest tile', () => {
+    ui = render(Treemap, { rows, scale });
+
+    const tiles = [...ui.container.querySelectorAll('button')];
+    expect(tiles).toHaveLength(3);
+
+    const areaOf = (tile: Element) => {
+      const style = tile.getAttribute('style') ?? '';
+      const width = Number(/width: ([\d.]+)%/.exec(style)?.[1]);
+      const height = Number(/height: ([\d.]+)%/.exec(style)?.[1]);
+      return width * height;
+    };
+
+    expect(areaOf(tiles[0]!)).toBeGreaterThan(areaOf(tiles[1]!));
+    expect(areaOf(tiles[1]!)).toBeGreaterThan(areaOf(tiles[2]!));
+    expect(tiles[0]!.getAttribute('title')).toContain('src/big.ts');
+  });
+
+  it('colours by complexity, not by score', () => {
+    ui = render(Treemap, { rows, scale });
+
+    const [hottest, middle] = [...ui.container.querySelectorAll('button')];
+    expect(hottest!.getAttribute('style')).toContain(
+      'background: var(--strata-h5)',
+    );
+    expect(middle!.getAttribute('style')).toContain(
+      'background: var(--strata-h3)',
+    );
+  });
+
+  it('reports the clicked path and marks it selected', () => {
+    const onselect = vi.fn();
+    ui = render(Treemap, { rows, scale, selected: 'src/mid.ts', onselect });
+
+    const tiles = [...ui.container.querySelectorAll('button')];
+    tiles[0]!.click();
+
+    expect(onselect).toHaveBeenCalledWith('src/big.ts');
+    expect(tiles[1]!.getAttribute('aria-pressed')).toBe('true');
+    expect(tiles[0]!.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('caps the tiles and says how many files were left out', () => {
+    ui = render(Treemap, { rows, scale, limit: 2 });
+
+    expect(ui.container.querySelectorAll('button')).toHaveLength(2);
+    expect(ui.container.textContent).toContain('top 2 of 3');
+  });
+
+  it('says so when nothing scored', () => {
+    ui = render(Treemap, { rows: [], scale: heatScale([]) });
+    expect(ui.container.textContent).toContain('No file scored above zero');
+  });
+});

--- a/apps/web/src/lib/hotspots/format.test.ts
+++ b/apps/web/src/lib/hotspots/format.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { compactNumber } from './format';
+
+describe('compactNumber', () => {
+  it('rounds small values and abbreviates large ones', () => {
+    expect(compactNumber(0)).toBe('0');
+    expect(compactNumber(12.4)).toBe('12');
+    expect(compactNumber(999)).toBe('999');
+    expect(compactNumber(1240)).toBe('1.2k');
+    expect(compactNumber(12_400)).toBe('12k');
+    expect(compactNumber(3_400_000)).toBe('3.4M');
+    expect(compactNumber(2_000_000_000)).toBe('2.0B');
+  });
+
+  it('marks a value it cannot show', () => {
+    expect(compactNumber(Number.NaN)).toBe('—');
+  });
+});

--- a/apps/web/src/lib/hotspots/format.ts
+++ b/apps/web/src/lib/hotspots/format.ts
@@ -1,0 +1,24 @@
+/**
+ * Hotspot scores run from single digits into the millions on a large repo. The
+ * table has to stay scannable at both ends, so anything past a thousand is
+ * abbreviated and only the leading digits are kept.
+ */
+export function compactNumber(value: number): string {
+  if (!Number.isFinite(value)) return '—';
+  const rounded = Math.round(value);
+  if (Math.abs(rounded) < 1000) return String(rounded);
+
+  const units = [
+    { limit: 1e9, suffix: 'B' },
+    { limit: 1e6, suffix: 'M' },
+    { limit: 1e3, suffix: 'k' },
+  ];
+  for (const { limit, suffix } of units) {
+    if (Math.abs(rounded) >= limit) {
+      const scaled = rounded / limit;
+      const digits = Math.abs(scaled) < 10 ? 1 : 0;
+      return `${scaled.toFixed(digits)}${suffix}`;
+    }
+  }
+  return String(rounded);
+}

--- a/apps/web/src/lib/hotspots/heat.test.ts
+++ b/apps/web/src/lib/hotspots/heat.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { heatBands, heatColor, heatInk, heatLevel, heatScale } from './heat';
+
+describe('heatScale', () => {
+  it('spreads a skewed set across all five levels', () => {
+    // One file dwarfs the rest: equal-value steps would paint nine of ten cold.
+    const values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 5000];
+    const scale = heatScale(values);
+
+    const levels = values.map((value) => heatLevel(scale, value));
+    expect(new Set(levels)).toEqual(new Set([1, 2, 3, 4, 5]));
+    expect(heatLevel(scale, 5000)).toBe(5);
+    expect(heatLevel(scale, 1)).toBe(1);
+  });
+
+  it('keeps the observed range for the legend', () => {
+    const scale = heatScale([4, 1, 9]);
+    expect(scale.min).toBe(1);
+    expect(scale.max).toBe(9);
+  });
+
+  it('survives an empty set', () => {
+    const scale = heatScale([]);
+    expect(scale).toEqual({ min: 0, max: 0, breaks: [0, 0, 0, 0] });
+    expect(heatLevel(scale, 0)).toBe(1);
+    expect(heatLevel(scale, 12)).toBe(5);
+  });
+
+  it('puts every value on one level when they are all equal', () => {
+    const scale = heatScale([7, 7, 7]);
+    expect(heatLevel(scale, 7)).toBe(1);
+  });
+});
+
+describe('heatBands', () => {
+  it('chains the ranges from min to max', () => {
+    const bands = heatBands(heatScale([0, 10, 20, 30, 40, 50]));
+
+    expect(bands).toHaveLength(5);
+    expect(bands[0]!.from).toBe(0);
+    expect(bands[4]!.to).toBe(50);
+    for (let i = 1; i < bands.length; i += 1) {
+      expect(bands[i]!.from).toBe(bands[i - 1]!.to);
+    }
+  });
+});
+
+describe('heat tokens', () => {
+  it('names the palette variable for a level', () => {
+    expect(heatColor(3)).toBe('var(--strata-h3)');
+    expect(heatInk(3)).toBe('var(--strata-h3-ink)');
+  });
+});

--- a/apps/web/src/lib/hotspots/heat.ts
+++ b/apps/web/src/lib/hotspots/heat.ts
@@ -1,0 +1,88 @@
+/**
+ * The heat ramp: five steps from cold (`h1`) to hot (`h5`), the tokens the
+ * palette reserves for exactly this. Tiles are *coloured* by complexity while
+ * they are *sized* by score, so the two factors of a hotspot stay readable
+ * apart: a big pale tile churns a lot, a small red one is dense but quiet.
+ */
+
+export const HEAT_LEVELS = [1, 2, 3, 4, 5] as const;
+
+export type HeatLevel = (typeof HEAT_LEVELS)[number];
+
+export interface HeatScale {
+  min: number;
+  max: number;
+  /** Upper bound of levels 1–4; level 5 is everything above the last. */
+  breaks: readonly [number, number, number, number];
+}
+
+/**
+ * Quantile breaks over the values in the current view.
+ *
+ * Complexity is heavily skewed — a handful of files dwarf the rest — so equal
+ * *value* steps would paint almost everything cold. Equal *population* steps
+ * keep all five colours on screen and make the ramp read as a ranking, which
+ * is what the legend then labels.
+ */
+export function heatScale(values: readonly number[]): HeatScale {
+  const sorted = [...values].filter(Number.isFinite).sort((a, b) => a - b);
+  if (sorted.length === 0) return { min: 0, max: 0, breaks: [0, 0, 0, 0] };
+
+  return {
+    min: sorted[0]!,
+    max: sorted[sorted.length - 1]!,
+    breaks: [
+      quantile(sorted, 0.2),
+      quantile(sorted, 0.4),
+      quantile(sorted, 0.6),
+      quantile(sorted, 0.8),
+    ],
+  };
+}
+
+export function heatLevel(scale: HeatScale, value: number): HeatLevel {
+  if (value <= scale.breaks[0]) return 1;
+  if (value <= scale.breaks[1]) return 2;
+  if (value <= scale.breaks[2]) return 3;
+  if (value <= scale.breaks[3]) return 4;
+  return 5;
+}
+
+export interface HeatBand {
+  level: HeatLevel;
+  from: number;
+  to: number;
+}
+
+/**
+ * The legend's five rows: the value range each colour stands for. Repeated
+ * breaks (few distinct values) collapse into empty bands, which the legend
+ * renders as-is — an honest "nothing lands here".
+ */
+export function heatBands(scale: HeatScale): HeatBand[] {
+  const bounds = [scale.min, ...scale.breaks, scale.max];
+  return HEAT_LEVELS.map((level) => ({
+    level,
+    from: bounds[level - 1]!,
+    to: bounds[level]!,
+  }));
+}
+
+/** Tile background for a level — the palette token, resolved per theme. */
+export function heatColor(level: HeatLevel): string {
+  return `var(--strata-h${level})`;
+}
+
+/** Text colour that holds contrast on `heatColor(level)` in both themes. */
+export function heatInk(level: HeatLevel): string {
+  return `var(--strata-h${level}-ink)`;
+}
+
+/** Linear-interpolated quantile over an ascending array. */
+function quantile(sorted: readonly number[], q: number): number {
+  const pos = (sorted.length - 1) * q;
+  const low = Math.floor(pos);
+  const high = Math.ceil(pos);
+  if (low === high) return sorted[low]!;
+  return sorted[low]! + (sorted[high]! - sorted[low]!) * (pos - low);
+}

--- a/apps/web/src/lib/hotspots/index.ts
+++ b/apps/web/src/lib/hotspots/index.ts
@@ -1,0 +1,15 @@
+export { compactNumber } from './format';
+export {
+  heatBands,
+  heatColor,
+  heatInk,
+  heatLevel,
+  heatScale,
+  HEAT_LEVELS,
+  type HeatBand,
+  type HeatLevel,
+  type HeatScale,
+} from './heat';
+export { dirName, fileName } from './path';
+export { hotspotRows, HOTSPOT_SERIES_ID, type HotspotRow } from './rows';
+export { squarify, type TreemapTile } from './layout';

--- a/apps/web/src/lib/hotspots/layout.test.ts
+++ b/apps/web/src/lib/hotspots/layout.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { squarify, type TreemapTile } from './layout';
+
+interface Item {
+  id: string;
+  weight: number;
+}
+
+const weightOf = (item: Item) => item.weight;
+const area = (tile: TreemapTile<Item>) => tile.width * tile.height;
+
+function overlaps(a: TreemapTile<Item>, b: TreemapTile<Item>): boolean {
+  const epsilon = 1e-9;
+  return (
+    a.x + a.width - epsilon > b.x &&
+    b.x + b.width - epsilon > a.x &&
+    a.y + a.height - epsilon > b.y &&
+    b.y + b.height - epsilon > a.y
+  );
+}
+
+describe('squarify', () => {
+  const items: Item[] = [
+    { id: 'a', weight: 6 },
+    { id: 'b', weight: 6 },
+    { id: 'c', weight: 4 },
+    { id: 'd', weight: 3 },
+    { id: 'e', weight: 2 },
+    { id: 'f', weight: 2 },
+    { id: 'g', weight: 1 },
+  ];
+
+  it('gives each tile an area proportional to its weight', () => {
+    const tiles = squarify(items, weightOf, 6, 4);
+    const total = items.reduce((sum, item) => sum + item.weight, 0);
+
+    for (const tile of tiles) {
+      expect(area(tile)).toBeCloseTo((tile.item.weight / total) * 24, 6);
+    }
+  });
+
+  it('fills the box without overlapping', () => {
+    const tiles = squarify(items, weightOf, 6, 4);
+
+    expect(tiles.reduce((sum, tile) => sum + area(tile), 0)).toBeCloseTo(24, 6);
+    for (const tile of tiles) {
+      expect(tile.x).toBeGreaterThanOrEqual(-1e-9);
+      expect(tile.y).toBeGreaterThanOrEqual(-1e-9);
+      expect(tile.x + tile.width).toBeLessThanOrEqual(6 + 1e-9);
+      expect(tile.y + tile.height).toBeLessThanOrEqual(4 + 1e-9);
+    }
+    for (let i = 0; i < tiles.length; i += 1) {
+      for (let j = i + 1; j < tiles.length; j += 1) {
+        expect(overlaps(tiles[i]!, tiles[j]!)).toBe(false);
+      }
+    }
+  });
+
+  it('keeps tiles close to square rather than slivered', () => {
+    const tiles = squarify(items, weightOf, 6, 4);
+
+    for (const tile of tiles) {
+      const ratio =
+        Math.max(tile.width, tile.height) / Math.min(tile.width, tile.height);
+      expect(ratio).toBeLessThan(3);
+    }
+  });
+
+  it('orders tiles largest first, whatever order it was given', () => {
+    const weights = squarify([...items].reverse(), weightOf, 6, 4).map(
+      (tile) => tile.item.weight,
+    );
+    expect(weights).toEqual([...weights].sort((a, b) => b - a));
+    expect(weights[0]).toBe(6);
+  });
+
+  it('drops weights that cannot claim area', () => {
+    const tiles = squarify(
+      [
+        { id: 'a', weight: 5 },
+        { id: 'zero', weight: 0 },
+        { id: 'nan', weight: Number.NaN },
+      ],
+      weightOf,
+      4,
+      4,
+    );
+
+    expect(tiles.map((tile) => tile.item.id)).toEqual(['a']);
+    expect(area(tiles[0]!)).toBeCloseTo(16, 6);
+  });
+
+  it('has nothing to lay out in an empty or collapsed box', () => {
+    expect(squarify([], weightOf, 4, 4)).toEqual([]);
+    expect(squarify(items, weightOf, 0, 4)).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/hotspots/layout.ts
+++ b/apps/web/src/lib/hotspots/layout.ts
@@ -1,0 +1,123 @@
+/**
+ * Squarified treemap layout (Bruls, Huizing & van Wijk, 2000).
+ *
+ * Items are packed into rows along the shorter side of the space that is left,
+ * a row being closed as soon as adding one more tile would make its worst
+ * aspect ratio worse. The result is tiles close to square, which is what makes
+ * a treemap comparable by eye: area reads as area, not as a thin sliver.
+ *
+ * The layout is pure geometry in whatever units the caller passes — the view
+ * hands it the box's aspect ratio and positions the tiles in percentages, so
+ * nothing here has to know about pixels or resizing.
+ */
+
+export interface TreemapTile<T> {
+  item: T;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Lay `items` out in a `width × height` box, ordered largest weight first.
+ * Items without a positive, finite weight take no area and are dropped.
+ */
+export function squarify<T>(
+  items: readonly T[],
+  weightOf: (item: T) => number,
+  width: number,
+  height: number,
+): TreemapTile<T>[] {
+  if (width <= 0 || height <= 0) return [];
+
+  const weighted = items
+    .map((item) => ({ item, weight: weightOf(item) }))
+    .filter((entry) => Number.isFinite(entry.weight) && entry.weight > 0)
+    .sort((a, b) => b.weight - a.weight);
+
+  const total = weighted.reduce((sum, entry) => sum + entry.weight, 0);
+  if (total === 0) return [];
+
+  // Weights become areas up front, so the row maths is plain geometry.
+  const scale = (width * height) / total;
+  const areas = weighted.map((entry) => entry.weight * scale);
+
+  const tiles: TreemapTile<T>[] = [];
+  const free: Box = { x: 0, y: 0, width, height };
+  let row: number[] = [];
+  let start = 0;
+
+  for (const area of areas) {
+    const side = Math.min(free.width, free.height);
+    if (row.length > 0 && worst([...row, area], side) > worst(row, side)) {
+      placeRow(row, free, tiles, weighted, start);
+      start += row.length;
+      row = [];
+    }
+    row.push(area);
+  }
+  placeRow(row, free, tiles, weighted, start);
+
+  return tiles;
+}
+
+interface Box {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Fill one row along the shorter side of `free`, then shrink `free` by the
+ * band the row consumed.
+ */
+function placeRow<T>(
+  row: readonly number[],
+  free: Box,
+  tiles: TreemapTile<T>[],
+  weighted: readonly { item: T }[],
+  start: number,
+): void {
+  if (row.length === 0) return;
+
+  const total = row.reduce((sum, area) => sum + area, 0);
+  const horizontal = free.width <= free.height;
+  const side = horizontal ? free.width : free.height;
+  const thickness = total / side;
+
+  let offset = horizontal ? free.x : free.y;
+  row.forEach((area, index) => {
+    const length = area / thickness;
+    tiles.push({
+      item: weighted[start + index]!.item,
+      x: horizontal ? offset : free.x,
+      y: horizontal ? free.y : offset,
+      width: horizontal ? length : thickness,
+      height: horizontal ? thickness : length,
+    });
+    offset += length;
+  });
+
+  if (horizontal) {
+    free.y += thickness;
+    free.height -= thickness;
+  } else {
+    free.x += thickness;
+    free.width -= thickness;
+  }
+}
+
+/** Worst (largest) aspect ratio in a row laid along `side`. */
+function worst(row: readonly number[], side: number): number {
+  const total = row.reduce((sum, area) => sum + area, 0);
+  const max = Math.max(...row);
+  const min = Math.min(...row);
+  const totalSquared = total * total;
+  const sideSquared = side * side;
+  return Math.max(
+    (sideSquared * max) / totalSquared,
+    totalSquared / (sideSquared * min),
+  );
+}

--- a/apps/web/src/lib/hotspots/path.test.ts
+++ b/apps/web/src/lib/hotspots/path.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { dirName, fileName } from './path';
+
+describe('path', () => {
+  it('splits a repo path into directory and name', () => {
+    expect(dirName('packages/core/src/strata.ts')).toBe('packages/core/src/');
+    expect(fileName('packages/core/src/strata.ts')).toBe('strata.ts');
+  });
+
+  it('treats a root-level file as having no directory', () => {
+    expect(dirName('README.md')).toBe('');
+    expect(fileName('README.md')).toBe('README.md');
+  });
+});

--- a/apps/web/src/lib/hotspots/path.ts
+++ b/apps/web/src/lib/hotspots/path.ts
@@ -1,0 +1,16 @@
+/**
+ * Repo paths are always POSIX-style (git hands them over that way), so a
+ * split on `/` is all the view needs to show a file name apart from its
+ * directory.
+ */
+
+export function fileName(path: string): string {
+  const cut = path.lastIndexOf('/');
+  return cut === -1 ? path : path.slice(cut + 1);
+}
+
+/** The directory, with a trailing slash — empty for a file at the repo root. */
+export function dirName(path: string): string {
+  const cut = path.lastIndexOf('/');
+  return cut === -1 ? '' : path.slice(0, cut + 1);
+}

--- a/apps/web/src/lib/hotspots/rows.test.ts
+++ b/apps/web/src/lib/hotspots/rows.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import type { AnalysisReport } from '$lib/api';
+import { hotspotRows } from './rows';
+
+function report(partial: Partial<AnalysisReport> = {}): AnalysisReport {
+  return {
+    rev: 'abc123',
+    languages: {},
+    metrics: [],
+    commits: [],
+    cache: {
+      enabled: false,
+      hits: 0,
+      misses: 0,
+      runHits: 0,
+      runMisses: 0,
+      writes: 0,
+    },
+    ...partial,
+  };
+}
+
+const hotspots = {
+  id: 'hotspots',
+  label: 'Hotspots (churn × complexity)',
+  points: [
+    { subject: 'src/a.ts', value: 300, meta: { churn: 10, complexity: 30 } },
+    { subject: 'src/b.ts', value: 900, meta: { churn: 9, complexity: 100 } },
+  ],
+};
+
+describe('hotspotRows', () => {
+  it('joins the metric with the language plugins line counts', () => {
+    const rows = hotspotRows(
+      report({
+        metrics: [hotspots],
+        languages: {
+          typescript: {
+            graph: { nodes: [], edges: [], cycles: [] },
+            deadCode: [],
+            metrics: [{ path: 'src/a.ts', loc: 120 }],
+          },
+        },
+      }),
+    );
+
+    expect(rows).toEqual([
+      { path: 'src/b.ts', score: 900, churn: 9, complexity: 100, loc: null },
+      { path: 'src/a.ts', score: 300, churn: 10, complexity: 30, loc: 120 },
+    ]);
+  });
+
+  it('is empty when no plugin published the series', () => {
+    expect(hotspotRows(report({ metrics: [{ id: 'other', label: 'x', points: [] }] })))
+      .toEqual([]);
+  });
+
+  it('drops unscored files and reads missing meta as zero', () => {
+    const rows = hotspotRows(
+      report({
+        metrics: [
+          {
+            id: 'hotspots',
+            label: 'Hotspots',
+            points: [
+              { subject: 'src/zero.ts', value: 0, meta: { churn: 1 } },
+              { subject: 'src/bare.ts', value: 5 },
+            ],
+          },
+        ],
+      }),
+    );
+
+    expect(rows).toEqual([
+      { path: 'src/bare.ts', score: 5, churn: 0, complexity: 0, loc: null },
+    ]);
+  });
+});

--- a/apps/web/src/lib/hotspots/rows.ts
+++ b/apps/web/src/lib/hotspots/rows.ts
@@ -1,0 +1,61 @@
+import type { AnalysisReport } from '$lib/api';
+
+/** The id the `git-hotspots` plugin publishes its series under. */
+export const HOTSPOT_SERIES_ID = 'hotspots';
+
+/** One file in the hotspot view: what the treemap sizes and the table ranks. */
+export interface HotspotRow {
+  path: string;
+  /** churn × complexity, straight from the metric. */
+  score: number;
+  /** Commits that touched the file inside the analysed history window. */
+  churn: number;
+  complexity: number;
+  /** From the language plugins; `null` for a file no language claimed. */
+  loc: number | null;
+}
+
+/**
+ * Fold a report into the rows both panels read.
+ *
+ * The hotspot series carries the score and its two factors; lines of code come
+ * from whichever language plugin analysed the file, so the two are joined here
+ * rather than in a component. Files with no score are not hotspots and drop out.
+ */
+export function hotspotRows(report: AnalysisReport): HotspotRow[] {
+  const series = report.metrics.find((s) => s.id === HOTSPOT_SERIES_ID);
+  if (!series) return [];
+
+  const loc = locByPath(report);
+  return series.points
+    .map((point) => ({
+      path: point.subject,
+      score: point.value,
+      churn: metaNumber(point.meta, 'churn'),
+      complexity: metaNumber(point.meta, 'complexity'),
+      loc: loc.get(point.subject) ?? null,
+    }))
+    .filter((row) => row.score > 0)
+    .sort((a, b) => b.score - a.score);
+}
+
+/** Every language's `metrics`, flattened to `path → loc`. */
+function locByPath(report: AnalysisReport): Map<string, number> {
+  const loc = new Map<string, number>();
+  for (const language of Object.values(report.languages)) {
+    for (const metric of language.metrics) loc.set(metric.path, metric.loc);
+  }
+  return loc;
+}
+
+/**
+ * `meta` is `Record<string, number | string>` by contract, and a plugin other
+ * than `git-hotspots` may fill it differently — anything unusable reads as 0.
+ */
+function metaNumber(
+  meta: Record<string, number | string> | undefined,
+  key: string,
+): number {
+  const value = Number(meta?.[key]);
+  return Number.isFinite(value) ? value : 0;
+}

--- a/apps/web/src/lib/theme/tokens.css
+++ b/apps/web/src/lib/theme/tokens.css
@@ -10,6 +10,10 @@
  *   surfaces  bg → surface → elevated, separated by `line`
  *   text      ink → muted → subtle
  *   heat      h1 (cold) → h5 (hot), used by the hotspot treemap and legends
+ *
+ * Each heat step carries its own `-ink`: the ramp crosses from dark blue to
+ * light amber, so a single label colour cannot hold contrast across it. The
+ * inks below are the side (light or dark) that clears 4.5:1 on that step.
  */
 
 :root,
@@ -41,6 +45,13 @@
   --strata-h4: #e07a3f;
   --strata-h5: #d94a3d;
 
+  /* Only the cold end is dark enough to carry light text here. */
+  --strata-h1-ink: #eaf1f7;
+  --strata-h2-ink: #0b0e14;
+  --strata-h3-ink: #0b0e14;
+  --strata-h4-ink: #0b0e14;
+  --strata-h5-ink: #0b0e14;
+
   --strata-shadow: 0 1px 2px rgb(0 0 0 / 0.4), 0 8px 24px rgb(0 0 0 / 0.28);
 }
 
@@ -67,12 +78,19 @@
   --strata-danger: #cf222e;
 
   /* Darkened a step from the dark ramp: the same hues need more weight to
-     hold contrast against a white surface. */
+     hold contrast against a white surface — and enough weight that one light
+     ink works across the whole ramp, which keeps treemap labels consistent. */
   --strata-h1: #2a6488;
-  --strata-h2: #2f8a76;
-  --strata-h3: #a8760f;
-  --strata-h4: #c25e28;
+  --strata-h2: #237a67;
+  --strata-h3: #8f6300;
+  --strata-h4: #a94f1e;
   --strata-h5: #b3312a;
+
+  --strata-h1-ink: #ffffff;
+  --strata-h2-ink: #ffffff;
+  --strata-h3-ink: #ffffff;
+  --strata-h4-ink: #ffffff;
+  --strata-h5-ink: #ffffff;
 
   --strata-shadow: 0 1px 2px rgb(16 21 29 / 0.06), 0 8px 24px rgb(16 21 29 / 0.08);
 }

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -15,8 +15,16 @@
     <div>
       <h1 class="text-2xl font-semibold">Strata</h1>
       <p class="text-muted mt-1 text-sm">
-        Frontend scaffold — theme layer and API client in place. The workbench
-        shell and the analysis screens come next.
+        Frontend scaffold — theme layer, API client and the first analysis
+        screen in place. The workbench shell comes next.
+      </p>
+      <p class="mt-3 text-sm">
+        <a
+          class="text-accent underline-offset-4 hover:underline"
+          href="/hotspots"
+        >
+          Hotspots →
+        </a>
       </p>
     </div>
     <ThemeSwitch />

--- a/apps/web/src/routes/hotspots/+page.svelte
+++ b/apps/web/src/routes/hotspots/+page.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+  import { analysis } from '$lib/analysis';
+  import RunForm from '$lib/analysis/RunForm.svelte';
+  import Card from '$lib/components/Card.svelte';
+  import ThemeSwitch from '$lib/components/ThemeSwitch.svelte';
+  import HeatLegend from '$lib/hotspots/HeatLegend.svelte';
+  import RankedTable from '$lib/hotspots/RankedTable.svelte';
+  import Treemap from '$lib/hotspots/Treemap.svelte';
+  import { compactNumber, heatScale, hotspotRows } from '$lib/hotspots';
+
+  let report = $derived(analysis.report);
+  let rows = $derived(report ? hotspotRows(report) : []);
+  // The ramp is fitted to what is on screen, so it stays informative on a repo
+  // whose complexity spans two orders of magnitude and on one that does not.
+  let scale = $derived(heatScale(rows.map((row) => row.complexity)));
+
+  let selected = $state<string | null>(null);
+  let detail = $derived(rows.find((row) => row.path === selected) ?? null);
+
+  function select(path: string): void {
+    selected = selected === path ? null : path;
+  }
+
+  // A new report invalidates whatever tile was highlighted.
+  $effect(() => {
+    void report;
+    selected = null;
+  });
+</script>
+
+<svelte:head>
+  <title>Hotspots · Strata</title>
+</svelte:head>
+
+<main class="mx-auto max-w-6xl px-6 py-12">
+  <header class="mb-8 flex flex-wrap items-end justify-between gap-4">
+    <div>
+      <p class="text-subtle text-xs">
+        <a class="hover:text-ink underline-offset-4 hover:underline" href="/">
+          Strata
+        </a>
+        <span aria-hidden="true">/</span> Hotspots
+      </p>
+      <h1 class="mt-1 text-2xl font-semibold">Hotspots</h1>
+      <p class="text-muted mt-1 text-sm">
+        Churn × complexity: files that change often <em>and</em> are dense are
+        where maintenance cost concentrates. Tiles are sized by score and
+        coloured by complexity.
+      </p>
+    </div>
+    <ThemeSwitch />
+  </header>
+
+  <div class="mb-6">
+    <Card title="Analysis" hint={report ? `rev ${report.rev.slice(0, 8)}` : ''}>
+      <RunForm />
+      {#if analysis.status === 'error'}
+        <p class="text-danger mt-3 text-sm">{analysis.error}</p>
+      {/if}
+    </Card>
+  </div>
+
+  {#if analysis.status === 'idle'}
+    <p class="text-muted text-sm">
+      Point Strata at a repository above to see its hotspots.
+    </p>
+  {:else if analysis.status === 'running' && !report}
+    <p class="text-muted text-sm">Running the pipeline…</p>
+  {:else if report && rows.length === 0}
+    <p class="text-muted text-sm">
+      No hotspot scores in this report — the <code class="font-mono"
+        >git-hotspots</code
+      > plugin found no file that changed inside the analysed history window.
+    </p>
+  {:else if report}
+    <div class="grid gap-6 lg:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
+      <Card title="Treemap" hint="{rows.length} scored files">
+        <div class="mb-4">
+          <HeatLegend {scale} />
+        </div>
+        <Treemap {rows} {scale} {selected} onselect={select} />
+
+        {#if detail}
+          <dl
+            class="border-line mt-4 grid grid-cols-2 gap-x-6 gap-y-2 border-t pt-4 text-sm sm:grid-cols-4"
+          >
+            <div class="col-span-2 sm:col-span-4">
+              <dt class="text-subtle text-xs">Selected</dt>
+              <dd class="truncate font-mono text-xs" title={detail.path}>
+                {detail.path}
+              </dd>
+            </div>
+            <div>
+              <dt class="text-subtle text-xs">Churn</dt>
+              <dd class="font-mono">{detail.churn}</dd>
+            </div>
+            <div>
+              <dt class="text-subtle text-xs">Complexity</dt>
+              <dd class="font-mono">{compactNumber(detail.complexity)}</dd>
+            </div>
+            <div>
+              <dt class="text-subtle text-xs">LOC</dt>
+              <dd class="font-mono">
+                {detail.loc === null ? '—' : compactNumber(detail.loc)}
+              </dd>
+            </div>
+            <div>
+              <dt class="text-subtle text-xs">Score</dt>
+              <dd class="font-mono">{compactNumber(detail.score)}</dd>
+            </div>
+          </dl>
+        {/if}
+      </Card>
+
+      <Card title="Ranked" hint="churn · complexity · LOC · score">
+        <RankedTable {rows} {scale} {selected} onselect={select} />
+      </Card>
+    </div>
+  {/if}
+</main>

--- a/apps/web/src/routes/hotspots/page.test.ts
+++ b/apps/web/src/routes/hotspots/page.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render } from '$lib/test/render';
+import Page from './+page.svelte';
+
+/**
+ * The screen end to end: a run against the API, the report folded into tiles
+ * and rows, and one selection shared by both panels.
+ *
+ * The analysis store is the app's single instance, so it survives between the
+ * tests below — each run therefore carries its own `rev`, and a test waits for
+ * that `rev` on screen before touching anything.
+ */
+
+function reportWith(rev: string) {
+  return {
+    rev,
+    languages: {
+      typescript: {
+        graph: { nodes: [], edges: [], cycles: [] },
+        deadCode: [],
+        metrics: [{ path: 'src/big.ts', loc: 940 }],
+      },
+    },
+    metrics: [
+      {
+        id: 'hotspots',
+        label: 'Hotspots (churn × complexity)',
+        points: [
+          {
+            subject: 'src/big.ts',
+            value: 900,
+            meta: { churn: 9, complexity: 100 },
+          },
+          {
+            subject: 'src/mid.ts',
+            value: 300,
+            meta: { churn: 10, complexity: 30 },
+          },
+        ],
+      },
+    ],
+    commits: [],
+    cache: {
+      enabled: false,
+      hits: 0,
+      misses: 0,
+      runHits: 0,
+      runMisses: 0,
+      writes: 0,
+    },
+  };
+}
+
+/** Run the analysis from the form, as a user would. */
+function submit(container: HTMLElement, root: string): void {
+  const input = container.querySelector<HTMLInputElement>(
+    'input[name="root"]',
+  )!;
+  input.value = root;
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+  container
+    .querySelector('form')!
+    .dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+}
+
+const tiles = (container: HTMLElement) =>
+  container.querySelectorAll<HTMLButtonElement>('button[title]');
+
+let ui: ReturnType<typeof render>;
+
+afterEach(() => {
+  ui?.destroy();
+  vi.unstubAllGlobals();
+  localStorage.clear();
+});
+
+describe('hotspots page', () => {
+  it('asks for a repository before anything has run', () => {
+    ui = render(Page);
+    expect(ui.container.textContent).toContain('Point Strata at a repository');
+  });
+
+  it('renders the treemap and the ranked table from one run', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => Response.json(reportWith('11111111aaaa'))),
+    );
+
+    ui = render(Page);
+    submit(ui.container, '/repo/strata');
+
+    await vi.waitFor(() => {
+      expect(ui.container.textContent).toContain('rev 11111111');
+    });
+
+    expect(tiles(ui.container)).toHaveLength(2);
+    expect(ui.container.querySelectorAll('tbody tr')).toHaveLength(2);
+    expect(ui.container.textContent).toContain('2 scored files');
+    // Only the file a language plugin measured has a line count.
+    expect(ui.container.textContent).toContain('940');
+  });
+
+  it('shows the details of the tile that was clicked', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => Response.json(reportWith('22222222bbbb'))),
+    );
+
+    ui = render(Page);
+    submit(ui.container, '/repo/strata');
+
+    await vi.waitFor(() => {
+      expect(ui.container.textContent).toContain('rev 22222222');
+    });
+
+    [...tiles(ui.container)]
+      .find((tile) => tile.title.includes('src/mid.ts'))!
+      .click();
+
+    await vi.waitFor(() => {
+      expect(ui.container.querySelector('dl')?.textContent).toContain(
+        'src/mid.ts',
+      );
+    });
+    // The ranked table follows the same selection.
+    expect(
+      ui.container.querySelector('tbody [aria-pressed="true"]')?.textContent,
+    ).toContain('src/mid.ts');
+  });
+
+  it('surfaces a failed run', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        Response.json({ message: 'not a repository' }, { status: 400 }),
+      ),
+    );
+
+    ui = render(Page);
+    submit(ui.container, '/nope');
+
+    await vi.waitFor(() => {
+      expect(ui.container.textContent).toContain('not a repository');
+    });
+  });
+});


### PR DESCRIPTION
## What

The first analysis screen, at `/hotspots`:

- **Squarified treemap** — tiles sized by hotspot score, coloured by complexity, so the two factors of the score stay readable apart (a big pale tile churns a lot; a small red one is dense but quiet). Written here rather than pulled in: ~100 lines of geometry (Bruls/Huizing/van Wijk) against a dependency that ships a whole renderer. Tiles are plain DOM buttons, so theming, focus and `aria-pressed` come for free.
- **Heat legend** — five ramp steps on **quantile** breaks with their value ranges. Complexity is long-tailed; equal *value* steps would paint nearly everything cold, equal *population* steps keep all five colours on screen.
- **Ranked table** — churn / complexity / LOC / score. LOC is joined on from `languages[*].metrics`; a file no language plugin claimed shows `—`.
- Tile and table share one selection, and a new report clears it.

Supporting pieces:

- `lib/analysis/` — the last report held app-wide (the overview, graph and commit screens will read the same run instead of each triggering their own), with a superseded run dropping its result rather than overwriting a newer one. A repo-path form stands in until the project switcher lands; flagged as debt in the module ARCHITECTURE.
- Each heat step gains an `-ink` token and the light ramp is darkened a step, so one ink clears 4.5:1 on every step — the tuning pass the scaffold PR said to expect.

Layout follows one-responsibility-per-file, as a feature folder: `rows` (report → rows), `heat`, `layout` (squarify), `format`/`path`, and the three views next to them.

## Why

Backlog *Analysis screens → Hotspot treemap* (P0). Refs #29.

## Type of change

- [x] feat / fix / perf / refactor
- [x] docs / test / build / ci / chore

## Checklist

- [x] `pnpm build && pnpm test && pnpm lint` pass locally (plus `svelte-check`, clean)
- [x] Added/updated tests where it made sense
- [x] Docs updated (README / docs/) if behaviour changed

## Verification

62 web tests (196 repo-wide) pass: the pure layer (rows join, heat scale, squarify's area/overlap/aspect invariants, formatting), the three views, the analysis store, and the `/hotspots` route end to end.

Also run against this repo's own report (216 scored files) to check the layer on real data: worst tile aspect ratio **1.56**, the five heat levels evenly populated (48/39/43/43/43), LOC resolved for 140 of 216 files (the rest Markdown/YAML).

## Known, out of scope

- `pnpm-lock.yaml` is the top hotspot and dominates the treemap — that is #13 (ignore globs for metrics).
- The treemap draws the top ~50 files; the rest of the ranking is in the table only. A zoom or directory roll-up is the fix if it bites.