### PR TITLE
feat(core): report run metadata from every analysis

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -18,9 +18,11 @@ Anything marked *(mockup)* exists as a design and needs an implementation.
 - [x] Orchestrator + git ingest + plugin registry
 - [x] HTTP API (`/health`, `/plugins`, `/analyze`)
 - [x] Incremental cache — SQLite, keyed on `(pluginId, blob)`; skip unchanged files
-- [ ] **P0** Analysis run metadata in the `/analyze` result — branch, resolved rev,
-      file count, duration, finished-at. The mockup header (`main · @ 4c1249e ·
-      analyzed 2 min ago · 1.82s`) and the overview stat cards read this directly.
+- [x] Analysis run metadata in the `/analyze` result — every report carries a
+      `run` block (branch, file count, duration, finished-at) beside the
+      resolved `rev`, which is what the mockup header (`main · @ 4c1249e ·
+      analyzed 2 min ago · 1.82s`) and the overview stat cards read. Rendering
+      that header is UI work, listed below.
 - [x] Third-party plugin discovery (API) — `STRATA_PLUGINS_DIR` is scanned for
       drop-in plugins alongside the built-ins; `/plugins` reports the directory,
       each plugin's source, and anything skipped. The *Settings → Plugins &

--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -47,8 +47,19 @@ export interface CacheReport {
   writes: number;
 }
 
+/** What one run did — what the header line and the overview stat cards read. */
+export interface RunReport {
+  /** Branch the analysed revision names; null for a detached HEAD, sha or tag. */
+  branch: string | null;
+  files: number;
+  durationMs: number;
+  /** When the run finished, ISO 8601. */
+  finishedAt: string;
+}
+
 export interface AnalysisReport {
   rev: string;
+  run: RunReport;
   languages: Record<string, LanguageAnalysis>;
   metrics: MetricSeries[];
   commits: ParsedCommit[];

--- a/apps/web/src/lib/graph/merge.test.ts
+++ b/apps/web/src/lib/graph/merge.test.ts
@@ -7,6 +7,12 @@ function reportWith(
 ): AnalysisReport {
   return {
     rev: 'abc',
+    run: {
+      branch: 'main',
+      files: 0,
+      durationMs: 1,
+      finishedAt: '2026-01-01T00:00:00.000Z',
+    },
     languages,
     metrics: [],
     commits: [],

--- a/apps/web/src/lib/hotspots/rows.test.ts
+++ b/apps/web/src/lib/hotspots/rows.test.ts
@@ -5,6 +5,12 @@ import { hotspotRows } from './rows';
 function report(partial: Partial<AnalysisReport> = {}): AnalysisReport {
   return {
     rev: 'abc123',
+    run: {
+      branch: 'main',
+      files: 0,
+      durationMs: 1,
+      finishedAt: '2026-01-01T00:00:00.000Z',
+    },
     languages: {},
     metrics: [],
     commits: [],

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -136,8 +136,8 @@ builds a `RepoContext` and fans work out.
 
 ### Analyse a repository
 
-1. `Strata.analyze({root, rev})` resolves `rev` → sha and lists tracked files
-   (each with its blob sha).
+1. `Strata.analyze({root, rev})` resolves `rev` → sha and branch, and lists
+   tracked files (each with its blob sha).
 2. Files are routed to `language` plugins by extension.
 3. Commit history is streamed; `git-metric` plugins compute their series.
 4. The active `commit-convention` plugin parses each commit.
@@ -147,7 +147,10 @@ Steps 2 and 3 go through the cache. The core skips any plugin whose inputs
 digest to a stored result — that part needs no cooperation. Per-file reuse
 inside a plugin that does run is opt-in: only plugins that route their per-file
 work through `ctx.cache.file()` skip unchanged blobs; one that ignores the
-helper recomputes everything. The report carries the run's cache counters.
+helper recomputes everything. The report carries the run's cache counters, and
+its `run` block carries what the run itself did — branch, file count, duration
+and finished-at, which is what the workbench header and the overview stat cards
+render.
 
 ### Grant merge trust (governance runtime)
 

--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -29,7 +29,7 @@ to plugins. This is the only module that knows about all four plugin kinds.
 |------|----------------|
 | `index.ts` | Barrel — the package's public surface, no logic. |
 | `strata.ts` | The `Strata` orchestrator. |
-| `types.ts` | `AnalyzeOptions`, `StrataOptions`, `AnalysisReport`, `CacheReport`. |
+| `types.ts` | `AnalyzeOptions`, `StrataOptions`, `AnalysisReport`, `RunReport`, `CacheReport`. |
 | `logger.ts` | `createConsoleLogger(scope)` — what `RepoContext.log` gets. |
 | `registry.ts` | `PluginRegistry` — load plugins, contain load failures, `byKind()` / `loadedByKind()`. |
 | `manifest.ts` | `readManifest()` / `resolveEntry()` — validate a `strata.plugin.json` and its entry path. |
@@ -38,6 +38,7 @@ to plugins. This is the only module that knows about all four plugin kinds.
 | `plugins-dir.ts` | `userPluginsDir()` — where drop-in plugins live (`STRATA_PLUGINS_DIR`). |
 | `git/exec.ts` | Run a read-only git command. |
 | `git/rev.ts` | `resolveRev` — revision → sha. |
+| `git/branch.ts` | `branchAt` — the branch a revision names, if any. |
 | `git/files.ts` | `listFiles` — tracked files with blob shas. |
 | `git/history.ts` | `history` — structured commit records. |
 | `git/churn.ts` | `churn` — per-file change counts. |
@@ -51,13 +52,15 @@ to plugins. This is the only module that knows about all four plugin kinds.
 ## 5. Runtime
 
 `analyze()`:
-1. `resolveRev` → sha; `listFiles` → `RepoFile[]` (blob-keyed).
+1. `resolveRev` → sha; `branchAt` → branch (or none); `listFiles` → `RepoFile[]`
+   (blob-keyed).
 2. Build `RepoContext`, one `cache` scope per plugin.
 3. Route files to `language` plugins by extension — skipping any plugin whose
    input digest already has a stored result.
 4. Stream `history`; run `git-metric` plugins (same skip).
 5. Parse commits with the first `commit-convention` plugin.
-6. Merge into `AnalysisReport`.
+6. Merge into `AnalysisReport`, with the run's own metadata (`RunReport`:
+   branch, file count, duration, finished-at) beside the resolved `rev`.
 
 ## 6. Decisions
 
@@ -72,6 +75,11 @@ to plugins. This is the only module that knows about all four plugin kinds.
   `registry.failures()` rather than thrown: a broken third-party plugin must
   cost only itself, not the process.
 - **First-registered commit convention wins** (single active convention).
+- **The run times itself** — duration covers everything the caller waited for,
+  cache open included, and `finishedAt` is stamped where the run ends. A client
+  measuring its own round-trip would be measuring the network too. A revision
+  that names no branch (detached HEAD, sha, tag) reports `null` rather than
+  inventing one.
 - **Blob sha on every file**, so the cache keys on content, not on paths or
   timestamps.
 - **Two cache levels** — a plugin whose entire input digest is unchanged is

--- a/packages/core/src/git/branch.test.ts
+++ b/packages/core/src/git/branch.test.ts
@@ -1,0 +1,65 @@
+import { execFile } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { branchAt } from './branch.js';
+
+const exec = promisify(execFile);
+
+/**
+ * A revision is only sometimes a branch. The run header shows one when there is
+ * one and stays quiet otherwise, so what does *not* resolve to a branch matters
+ * as much as what does.
+ */
+
+let repo: string;
+let sha: string;
+
+async function git(args: string[]): Promise<string> {
+  const { stdout } = await exec('git', args, {
+    cwd: repo,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'Strata Test',
+      GIT_AUTHOR_EMAIL: 'test@example.com',
+      GIT_COMMITTER_NAME: 'Strata Test',
+      GIT_COMMITTER_EMAIL: 'test@example.com',
+    },
+  });
+  return stdout.trim();
+}
+
+beforeAll(async () => {
+  repo = mkdtempSync(join(tmpdir(), 'strata-branch-'));
+  await git(['init', '-q', '-b', 'main']);
+  await git(['commit', '-q', '--allow-empty', '-m', 'feat: initial']);
+  await git(['tag', 'v1']);
+  await git(['branch', 'feature/x']);
+  sha = await git(['rev-parse', 'HEAD']);
+}, 30_000);
+
+afterAll(() => {
+  rmSync(repo, { recursive: true, force: true });
+});
+
+describe('branchAt', () => {
+  it('names the checked-out branch by default', async () => {
+    expect(await branchAt(repo)).toBe('main');
+  });
+
+  it('names a branch the caller asked for', async () => {
+    expect(await branchAt(repo, 'feature/x')).toBe('feature/x');
+  });
+
+  it('has no branch for a raw sha or a tag', async () => {
+    expect(await branchAt(repo, sha)).toBeNull();
+    expect(await branchAt(repo, 'v1')).toBeNull();
+  });
+
+  it('has no branch on a detached HEAD', async () => {
+    await git(['checkout', '-q', '--detach', 'HEAD']);
+    expect(await branchAt(repo)).toBeNull();
+  });
+});

--- a/packages/core/src/git/branch.ts
+++ b/packages/core/src/git/branch.ts
@@ -1,0 +1,20 @@
+import { git } from './exec.js';
+
+const HEADS = 'refs/heads/';
+
+/**
+ * The branch `rev` names, or null when it names none. A detached HEAD, a raw
+ * sha, a tag and a remote-tracking ref all analyse fine — they simply have no
+ * local branch to show in the run header.
+ */
+export async function branchAt(
+  root: string,
+  rev = 'HEAD',
+): Promise<string | null> {
+  // `--symbolic-full-name` prints the full ref a revision resolves to: a branch
+  // as `refs/heads/<name>`, a detached HEAD as `HEAD`, a raw sha as nothing.
+  const ref = (
+    await git(root, ['rev-parse', '--symbolic-full-name', rev])
+  ).trim();
+  return ref.startsWith(HEADS) ? ref.slice(HEADS.length) : null;
+}

--- a/packages/core/src/git/index.ts
+++ b/packages/core/src/git/index.ts
@@ -4,6 +4,7 @@
  */
 export * from './exec.js';
 export * from './rev.js';
+export * from './branch.js';
 export * from './files.js';
 export * from './history.js';
 export * from './churn.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,6 +24,7 @@ export type {
   AnalysisReport,
   AnalyzeOptions,
   CacheReport,
+  RunReport,
   StrataOptions,
 } from './types.js';
 export {

--- a/packages/core/src/run.test.ts
+++ b/packages/core/src/run.test.ts
@@ -1,0 +1,76 @@
+import { execFile } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { PluginRegistry } from './registry.js';
+import { Strata } from './strata.js';
+
+const exec = promisify(execFile);
+
+/**
+ * Run metadata: what the analysis *did*, as opposed to what it found. The
+ * workbench header (`main · @ 4c1249e · analyzed 2 min ago · 1.82s`) and the
+ * overview stat cards read nothing but this, so it comes back from every run —
+ * no plugin needs to be registered for it.
+ */
+
+let repo: string;
+let strata: Strata;
+
+async function git(args: string[]): Promise<void> {
+  await exec('git', args, {
+    cwd: repo,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'Strata Test',
+      GIT_AUTHOR_EMAIL: 'test@example.com',
+      GIT_COMMITTER_NAME: 'Strata Test',
+      GIT_COMMITTER_EMAIL: 'test@example.com',
+    },
+  });
+}
+
+beforeAll(async () => {
+  repo = mkdtempSync(join(tmpdir(), 'strata-run-'));
+  await git(['init', '-q', '-b', 'main']);
+  writeFileSync(join(repo, 'a.ts'), 'export const a = 1;\n');
+  writeFileSync(join(repo, 'b.ts'), 'export const b = 2;\n');
+  await git(['add', '-A']);
+  await git(['commit', '-m', 'feat: initial']);
+
+  strata = new Strata(new PluginRegistry(), { cache: false });
+}, 30_000);
+
+afterAll(() => {
+  strata.close();
+  rmSync(repo, { recursive: true, force: true });
+});
+
+describe('run metadata', () => {
+  it('reports the branch, the file count and how long the run took', async () => {
+    const before = Date.now();
+    const report = await strata.analyze({ root: repo });
+
+    expect(report.run.branch).toBe('main');
+    expect(report.run.files).toBe(2);
+    expect(report.run.durationMs).toBeGreaterThanOrEqual(0);
+    expect(Date.parse(report.run.finishedAt)).toBeGreaterThanOrEqual(before);
+  });
+
+  it('resolves the revision the caller asked for', async () => {
+    const report = await strata.analyze({ root: repo, rev: 'main' });
+
+    expect(report.run.branch).toBe('main');
+    expect(report.rev).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  it('has no branch when a revision names none', async () => {
+    const { rev } = await strata.analyze({ root: repo });
+    const report = await strata.analyze({ root: repo, rev });
+
+    expect(report.run.branch).toBeNull();
+    expect(report.rev).toBe(rev);
+  });
+});

--- a/packages/core/src/strata.ts
+++ b/packages/core/src/strata.ts
@@ -8,7 +8,7 @@ import {
   openAnalysisCache,
   type AnalysisCache,
 } from './cache/index.js';
-import { git, history, listFiles, resolveRev } from './git/index.js';
+import { branchAt, git, history, listFiles, resolveRev } from './git/index.js';
 import { consoleLogger } from './logger.js';
 import type { PluginRegistry } from './registry.js';
 import type { AnalysisReport, AnalyzeOptions, StrataOptions } from './types.js';
@@ -28,11 +28,14 @@ export class Strata {
   ) {}
 
   async analyze(opts: AnalyzeOptions): Promise<AnalysisReport> {
+    // The run clock covers everything the caller waited for, cache open included.
+    const startedAt = performance.now();
     const cache = opts.cache === false ? nullCache() : this.openCache();
     warnIfCacheInsideRepo(cache.path, opts.root);
     // Counters live as long as the cache does; report this run's delta.
     const before = cache.stats();
     const rev = await resolveRev(opts.root, opts.rev);
+    const branch = await branchAt(opts.root, opts.rev);
     const files = await listFiles(opts.root, rev);
     const ctx: Omit<RepoContext, 'cache'> = {
       root: opts.root,
@@ -118,6 +121,12 @@ export class Strata {
     cache.flush();
     return {
       rev,
+      run: {
+        branch,
+        files: files.length,
+        durationMs: Math.round(performance.now() - startedAt),
+        finishedAt: new Date().toISOString(),
+      },
       languages,
       metrics,
       commits,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -24,8 +24,25 @@ export interface CacheReport extends CacheStats {
   path?: string;
 }
 
+/**
+ * What one run did, rather than what it found — the header line
+ * (`main · @ 4c1249e · analyzed 2 min ago · 1.82s`) and the overview stat cards
+ * read this. The resolved sha is `AnalysisReport.rev`, not repeated here.
+ */
+export interface RunReport {
+  /** Branch the analysed revision names; null for a detached HEAD, sha or tag. */
+  branch: string | null;
+  /** Tracked files at that revision. */
+  files: number;
+  /** Wall-clock time of the whole run, in milliseconds. */
+  durationMs: number;
+  /** When the run finished, ISO 8601. */
+  finishedAt: string;
+}
+
 export interface AnalysisReport {
   rev: string;
+  run: RunReport;
   languages: Record<string, LanguageAnalysis>;
   metrics: MetricSeries[];
   commits: ParsedCommit[];

--- a/packages/server/ARCHITECTURE.md
+++ b/packages/server/ARCHITECTURE.md
@@ -25,7 +25,7 @@ UI and CI. Keeps transport concerns out of the core.
 |--------|------|---------|
 | GET | `/health` | Liveness. |
 | GET | `/plugins` | What loaded, from where, and what was skipped: `{ directory, plugins, failures }` — each plugin its manifest plus a `source` (`builtin`/`user`). |
-| POST | `/analyze` | Body `{ root, rev?, historyLimit?, cache? }` → `AnalysisReport` (incl. cache stats). |
+| POST | `/analyze` | Body `{ root, rev?, historyLimit?, cache? }` → `AnalysisReport` (incl. run metadata and cache stats). |
 | DELETE | `/cache` | Empty the incremental cache. |
 
 ## 4. Building Blocks

--- a/scripts/lib/report.mjs
+++ b/scripts/lib/report.mjs
@@ -2,7 +2,12 @@
 
 /** Print the whole report: hotspots, coupling, commits, cache, per-language graphs. */
 export function printReport(report, target) {
-  console.log(`\nStrata — ${target} @ ${report.rev.slice(0, 8)}\n`);
+  const { branch, files, durationMs } = report.run;
+  const at = `${branch ? `${branch} ` : ''}@ ${report.rev.slice(0, 8)}`;
+  console.log(
+    `\nStrata — ${target} — ${at} · ${files} files · ` +
+      `${(durationMs / 1000).toFixed(2)}s\n`,
+  );
   printHotspots(report);
   printCoupling(report);
   printCommits(report);


### PR DESCRIPTION
Closes #56.

`/analyze` now returns what the run *did*, not only what it found. Every `AnalysisReport` carries a `run` block beside the resolved `rev`:

```json
{
  "rev": "a053c3fd1b43c541b9309c7916aeb6e3a7d2dc53",
  "run": {
    "branch": "main",
    "files": 281,
    "durationMs": 1537,
    "finishedAt": "2026-08-15T13:10:55.727Z"
  }
}
```

That is exactly what the mockup header (`main · @ 4c1249e · analyzed 2 min ago · 1.82s`) and the overview stat cards read. Rendering them is UI work and stays on the backlog.

## Notes

- **`branchAt(root, rev)`** (`git/branch.ts`) resolves a revision's full ref with `git rev-parse --symbolic-full-name`. A detached HEAD, a raw sha, a tag and a remote-tracking ref all analyse fine and report `branch: null` rather than an invented name.
- **The run times itself.** The clock starts before the cache opens, so the duration covers everything the caller waited for; a client measuring its own round-trip would be measuring the network too.
- **The sha is not duplicated** — `report.rev` stays where it is, so there is one place for it to be right.
- Scope is the five fields the issue lists. No `commits` count: `report.commits.length` already covers it.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm test` (298 tests / 56 files) pass.
- New tests: `git/branch.test.ts` covers attached HEAD, a named branch, a sha, a tag and a detached HEAD; `run.test.ts` proves the metadata comes back from a real repo with no plugins registered at all.
- Checked live over HTTP against this repo (the JSON above) and through `node scripts/analyze.mjs`, whose header now reads `Strata — /path — main @ a053c3fd · 281 files · 0.04s`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)