### PR TITLE
feat(core): persist the registered projects

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,13 @@ STRATA_API_PROXY=http://localhost:4000
 # Default: <cwd>/.strata/plugins — in the container, /app/.strata/plugins.
 STRATA_PLUGINS_DIR=.strata/plugins
 
+# --- Project registry -------------------------------------------------------
+# Where projects.db lives: the repositories registered with this workbench, and
+# a summary of the last analysis of each. Durable user data — kept out of the
+# cache database on purpose, so clearing the cache never drops it.
+# Default: <cwd>/.strata — in the container, /app/.strata (a persisted volume).
+STRATA_DATA_DIR=.strata
+
 # --- Incremental cache ------------------------------------------------------
 # Where cache.db lives. Relative paths resolve against the *working directory*,
 # so set this explicitly if you run Strata from inside the repo you analyse —

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -38,15 +38,19 @@ Anything marked *(mockup)* exists as a design and needs an implementation.
 
 ## Configuration & persistence
 
-New area — the mockup's settings screens need somewhere to write to. Nothing
-here exists yet.
+New area — the mockup's settings screens need somewhere to write to.
 
-- [ ] **P0** Project registry — persist the list of registered projects
-      (id, display name, root path, last-analysis summary). Backs the sidebar
-      switcher, *Add project*, and *Danger zone → Remove project* (drops the
-      entry only; never touches the repo on disk).
+- [x] Project registry — `projects.db` (`$STRATA_DATA_DIR`, its own database
+      beside the cache) holds id, display name, root and last-analysis summary
+      per project, behind `GET`/`POST` `/projects` and `GET`/`DELETE`
+      `/projects/:id`. A root is resolved to the repository that owns it, so one
+      repo is one entry; every `/analyze` over a registered root refreshes that
+      entry's summary; removing drops the entry only, never the repo on disk.
+      The sidebar switcher, *Add project* and *Danger zone → Remove project*
+      that render it are UI work, listed below.
 - [ ] **P0** Project-scoped config store + `GET`/`PATCH` endpoints, covering the
-      *Project settings* sections: display name, root, revision (default `HEAD`),
+      *Project settings* sections — including editing the two fields the registry
+      already holds: display name, root, revision (default `HEAD`),
       history limit, ignore globs, analyze paths, enabled language plugins,
       enabled git metrics, commit convention, architecture rules.
 - [ ] **P0** App-scoped config store + endpoints: appearance (theme, density),

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends git \
 
 COPY --from=build /out ./
 
-# The incremental cache is written at runtime as `node` — mount a volume here
-# (see compose.yml) to keep it across restarts.
+# The incremental cache and the project registry are written at runtime as
+# `node` — mount a volume here (see compose.yml) to keep them across restarts.
 # Third-party plugins are read from the same volume: drop one directory per
 # plugin into /app/.strata/plugins (see docs/PLUGINS.md).
-ENV STRATA_CACHE_DIR=/app/.strata STRATA_PLUGINS_DIR=/app/.strata/plugins
+ENV STRATA_CACHE_DIR=/app/.strata STRATA_DATA_DIR=/app/.strata \
+    STRATA_PLUGINS_DIR=/app/.strata/plugins
 RUN mkdir -p /app/.strata/plugins && chown -R node:node /app/.strata
 
 EXPOSE 4000

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,10 @@ build: ## Build every package and plugin
 .PHONY: clean
 clean: ## Remove build output and caches
 	$(PNPM) -r exec rm -rf dist .tsbuildinfo || true
-	rm -rf coverage .strata
+	rm -rf coverage
+	# Only the analysis cache: .strata also holds projects.db (the registered
+	# projects) and any third-party plugins, and neither is build output.
+	rm -f .strata/cache.db .strata/cache.db-wal .strata/cache.db-shm
 
 .PHONY: distclean
 distclean: clean ## clean + remove all node_modules

--- a/README.md
+++ b/README.md
@@ -79,6 +79,20 @@ curl -X DELETE localhost:4000/cache
 curl -s localhost:4000/plugins
 ```
 
+Repositories can be registered, so the workbench remembers them (and what the
+last analysis of each one found) instead of being handed a path every time:
+
+```bash
+curl -X POST localhost:4000/projects -H 'content-type: application/json' \
+  -d '{"name":"Strata","root":"/absolute/path/to/a/repo"}'
+curl -s localhost:4000/projects
+# forget a project — the repository on disk is untouched
+curl -X DELETE localhost:4000/projects/strata
+```
+
+The registry lives in `$STRATA_DATA_DIR` (default `<cwd>/.strata/projects.db`),
+its own database beside the cache: `DELETE /cache` never touches it.
+
 Third-party plugins are drop-in: one directory per plugin (with its
 `strata.plugin.json`) under `$STRATA_PLUGINS_DIR`, default
 `<cwd>/.strata/plugins`. Built-ins load first, a plugin that fails to load is

--- a/compose.yml
+++ b/compose.yml
@@ -14,9 +14,10 @@ services:
     volumes:
       # Mount a repo you want to analyse (read-only) at /repos.
       - ${STRATA_REPOS_DIR:-./repos}:/repos:ro
-      # Persist the analysis cache across restarts. Third-party plugins are
-      # read from /app/.strata/plugins, so they live in this volume too — or
-      # mount a host directory there instead (see docs/PLUGINS.md).
+      # Persist the analysis cache and the project registry across restarts.
+      # Third-party plugins are read from /app/.strata/plugins, so they live in
+      # this volume too — or mount a host directory there instead (see
+      # docs/PLUGINS.md).
       - strata-data:/app/.strata
     restart: unless-stopped
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -62,7 +62,7 @@ the analysed repo.
 |---------|-----------|----------|---------|
 | git CLI | out | process exec | history, blobs, file lists |
 | AI provider | out | HTTPS (OpenAI-compatible or native) | explanations, embeddings |
-| Web UI | in | REST/JSON | trigger analysis, render results |
+| Web UI | in | REST/JSON | register projects, trigger analysis, render results |
 | CI | in | CLI / container | headless analysis, gating |
 
 ## 4. Solution Strategy
@@ -88,8 +88,9 @@ strata/
 │   ├── core/     @strata/core    Orchestrator: git ingest, registry, pipeline
 │   │              strata.ts · types.ts · logger.ts · registry.ts ·
 │   │              manifest.ts · discover.ts · plugins-dir.ts ·
-│   │              git/ (exec, rev, files, history, churn) ·
-│   │              cache/ (types, schema, sqlite, null, open, keys, digest, …)
+│   │              git/ (exec, rev, branch, repo, files, history, churn) ·
+│   │              cache/ (types, schema, sqlite, null, open, keys, digest, …) ·
+│   │              projects/ (types, schema, sqlite, memory, open, id, …)
 │   └── server/   @strata/server  Fastify HTTP API over the core
 │                  app.ts · main.ts (entry) · registry.ts · routes/*
 ├── plugins/
@@ -191,6 +192,15 @@ publish. The Linux desktop job is still a stub — it produces no bundle until
   inside it. `STRATA_CACHE=0`, `analyze({cache: false})` or `DELETE /cache` turn
   it off or empty it. A cache that cannot be opened, read or written degrades to
   a pass-through with one warning — it never fails an analysis.
+- **Project registry** — the repositories this workbench knows about (id,
+  display name, root, last-analysis summary), behind `/projects`. A second
+  SQLite file (`$STRATA_DATA_DIR`, else `<cwd>/.strata/projects.db`), separate
+  from the cache on purpose: everything in the cache is derived and gets pruned,
+  cleared and wiped, and none of that may cost someone their list of projects.
+  Roots are stored as the git working-tree root they resolve to, so one
+  repository is one entry; every `/analyze` over a registered root refreshes
+  that entry's summary. Removing a project drops the row and nothing else — the
+  repository on disk is never touched.
 - **One responsibility per file** — implementation, types, helpers and
   alternate implementations live in separate modules; every `index.ts` is a
   barrel that only re-exports. Public import paths (`@strata/core`,
@@ -246,4 +256,5 @@ publish. The Linux desktop job is still a stub — it produces no bundle until
 | **Change coupling** | Files that tend to change in the same commits. |
 | **RepoContext** | The immutable repo view handed to plugins. |
 | **Plugin manifest** | `strata.plugin.json` describing a plugin to the registry. |
+| **Project** | A repository registered with this workbench: id, display name, root, last-analysis summary. |
 | **Vouch** | Granting a contributor's approval the power to unblock merges. |

--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -8,6 +8,10 @@ The **orchestrator**. Ingests a git repository, holds the plugin registry, build
 the immutable `RepoContext`, and drives the analysis pipeline that fans work out
 to plugins. This is the only module that knows about all four plugin kinds.
 
+It also owns what the workbench has to remember between runs: the incremental
+cache, and the **project registry** — which repositories are registered, and
+what the last analysis of each one found.
+
 ## 2. Constraints
 
 - Reads git by shelling out to the `git` binary (must be on PATH).
@@ -21,7 +25,8 @@ to plugins. This is the only module that knows about all four plugin kinds.
 - **Depends on:** `@strata/sdk` (contracts), `git` CLI.
 - **Consumed by:** `@strata/server` (and `scripts/analyze.mjs`).
 - **Public API:** `Strata.analyze(opts) → AnalysisReport`, `PluginRegistry`,
-  `discoverPlugins()` / `userPluginsDir()`, `gitUtil` helpers.
+  `discoverPlugins()` / `userPluginsDir()`, `openProjectStore()`, `gitUtil`
+  helpers.
 
 ## 4. Building Blocks
 
@@ -42,12 +47,19 @@ to plugins. This is the only module that knows about all four plugin kinds.
 | `git/files.ts` | `listFiles` — tracked files with blob shas. |
 | `git/history.ts` | `history` — structured commit records. |
 | `git/churn.ts` | `churn` — per-file change counts. |
+| `git/repo.ts` | `toplevel` — the working-tree root a path belongs to. |
 | `cache/types.ts` | `AnalysisCache`, `CacheOptions`, `CacheStats`. |
 | `cache/open.ts` | `openAnalysisCache()` — resolve location, degrade safely. |
 | `cache/sqlite.ts` | The SQLite implementation. |
 | `cache/null.ts` | The pass-through implementation. |
 | `cache/schema.ts` | Tables, pragmas, schema migration. |
 | `cache/keys.ts`, `cache/digest.ts`, `cache/json.ts`, `cache/stats.ts` | Entry keys, run-key digests, JSON round-trip, counter arithmetic. |
+| `projects/types.ts` | `Project`, `ProjectAnalysis`, `ProjectStore`, options. |
+| `projects/open.ts` | `openProjectStore()` — resolve location, degrade safely. |
+| `projects/sqlite.ts` | The persistent registry (`projects.db`). |
+| `projects/memory.ts` | The process-lifetime registry (fallback, tests). |
+| `projects/schema.ts` | Table, pragmas, schema stamp. |
+| `projects/id.ts`, `projects/input.ts`, `projects/errors.ts` | Slugged ids, normalised input, `DuplicateRootError`. |
 
 ## 5. Runtime
 
@@ -61,6 +73,10 @@ to plugins. This is the only module that knows about all four plugin kinds.
 5. Parse commits with the first `commit-convention` plugin.
 6. Merge into `AnalysisReport`, with the run's own metadata (`RunReport`:
    branch, file count, duration, finished-at) beside the resolved `rev`.
+
+`openProjectStore()` is independent of a run: it opens `projects.db` once, and
+the entries it holds are read on request (`list` / `get` / `findByRoot`) and
+written when a project is added, analysed or removed.
 
 ## 6. Decisions
 
@@ -93,6 +109,19 @@ to plugins. This is the only module that knows about all four plugin kinds.
 - **The cache never fails an analysis** — a database that cannot be opened,
   read or written degrades to a pass-through with one warning per run. A failed
   write costs a recomputation on the next run, nothing more.
+- **The registry is its own database** (`projects.db`, beside `cache.db`).
+  Everything in the cache is derived and disposable — it is pruned, cleared by
+  `DELETE /cache`, and wiped outright on a schema bump. None of that may cost
+  someone their list of projects, so the two never share a file, and a registry
+  written by a newer Strata is left alone rather than opened.
+- **The registry does not swallow its failures**, unlike the cache. Opening it
+  does degrade — to an in-memory registry and a warning, so the workbench still
+  runs — but a *write* that fails throws, because an "Add project" that reports
+  success and stores nothing loses something no rerun brings back.
+- **A project is keyed on the repository, not the path someone typed** — the
+  root is resolved to its git working-tree root (`gitUtil.toplevel`) and stored
+  absolute, so a subdirectory, a trailing slash and a symlink are one project
+  and not four. Ids are slugs assigned once, so renaming cannot break a link.
 
 ## 7. Quality & Risks
 
@@ -103,6 +132,11 @@ to plugins. This is the only module that knows about all four plugin kinds.
   SDK docs; `analyze({cache: false})` and `DELETE /cache` recover.
 - **Risk:** the cache file grows without bound. **Mitigation:** entries carry a
   last-used stamp and are pruned after 30 days on open.
+- **Risk:** the registry names a root that has since been moved or deleted.
+  **Mitigation:** the entry is checked when it is added, not forever; an
+  analysis of a vanished root fails at the git call, and the entry can be
+  removed. Re-pointing a project at a new root is the project-settings work on
+  the backlog.
 - **Risk:** `git` output parsing edge cases (root commit, renames). **Mitigation:**
   record-separator parsing; covered by analysis smoke runs.
 - **Risk:** a plugin runs **in-process, with the server's privileges** — the

--- a/packages/core/src/git/index.ts
+++ b/packages/core/src/git/index.ts
@@ -5,6 +5,7 @@
 export * from './exec.js';
 export * from './rev.js';
 export * from './branch.js';
+export * from './repo.js';
 export * from './files.js';
 export * from './history.js';
 export * from './churn.js';

--- a/packages/core/src/git/repo.test.ts
+++ b/packages/core/src/git/repo.test.ts
@@ -1,0 +1,50 @@
+import { execFile } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { realpath } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { toplevel } from './repo.js';
+
+const exec = promisify(execFile);
+
+/**
+ * Registering a project resolves the path it was given to the repository that
+ * owns it — so a subdirectory, a trailing slash and the root itself all land on
+ * one entry, and a path that is no repository at all is refused.
+ */
+
+let repo: string;
+let plain: string;
+
+beforeAll(async () => {
+  repo = await realpath(mkdtempSync(join(tmpdir(), 'strata-repo-')));
+  mkdirSync(join(repo, 'src'));
+  await exec('git', ['init', '-q'], { cwd: repo });
+
+  plain = await realpath(mkdtempSync(join(tmpdir(), 'strata-plain-')));
+}, 30_000);
+
+afterAll(() => {
+  rmSync(repo, { recursive: true, force: true });
+  rmSync(plain, { recursive: true, force: true });
+});
+
+describe('toplevel', () => {
+  it('resolves the working-tree root', async () => {
+    expect(await toplevel(repo)).toBe(repo);
+  });
+
+  it('resolves a subdirectory to the repository that owns it', async () => {
+    expect(await toplevel(join(repo, 'src'))).toBe(repo);
+  });
+
+  it('has no root for a directory outside any repository', async () => {
+    expect(await toplevel(plain)).toBeNull();
+  });
+
+  it('has no root for a path that does not exist', async () => {
+    expect(await toplevel(join(plain, 'nowhere'))).toBeNull();
+  });
+});

--- a/packages/core/src/git/repo.ts
+++ b/packages/core/src/git/repo.ts
@@ -1,0 +1,22 @@
+import { realpath } from 'node:fs/promises';
+import { git } from './exec.js';
+
+/**
+ * The working-tree root of the repository `dir` belongs to, or `null` when it
+ * belongs to none (or does not exist).
+ *
+ * Registering a project resolves the path through this rather than storing
+ * what was typed: a path that is not a repository cannot be analysed at all,
+ * and a *subdirectory* of one is worse than useless — git commands run from
+ * there still report the whole repository, so the entry would quietly analyse
+ * something other than what it names. Resolved to the repository itself,
+ * `/repo`, `/repo/src` and a symlink to either are one project.
+ */
+export async function toplevel(dir: string): Promise<string | null> {
+  try {
+    const out = await git(dir, ['rev-parse', '--show-toplevel']);
+    return await realpath(out.trim());
+  } catch {
+    return null;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,4 +34,14 @@ export {
   type CacheOptions,
   type CacheStats,
 } from './cache/index.js';
+export {
+  openProjectStore,
+  memoryProjectStore,
+  DuplicateRootError,
+  type Project,
+  type ProjectAnalysis,
+  type ProjectInput,
+  type ProjectStore,
+  type ProjectStoreOptions,
+} from './projects/index.js';
 export * as gitUtil from './git/index.js';

--- a/packages/core/src/projects/errors.ts
+++ b/packages/core/src/projects/errors.ts
@@ -1,0 +1,16 @@
+import type { Project } from './types.js';
+
+/**
+ * A root can be registered once. Two entries for one repository would give the
+ * switcher two names for the same analysis, so adding it again is refused —
+ * with the entry that already holds it, so the caller can say which.
+ */
+export class DuplicateRootError extends Error {
+  constructor(
+    readonly root: string,
+    readonly existing: Project,
+  ) {
+    super(`${root} is already registered as "${existing.name}".`);
+    this.name = 'DuplicateRootError';
+  }
+}

--- a/packages/core/src/projects/id.test.ts
+++ b/packages/core/src/projects/id.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { projectId } from './id.js';
+
+const free = () => false;
+
+/**
+ * The id is what `/projects/:id` and stored config point at, so it is assigned
+ * once: it has to be URL-safe whatever someone types as a display name, and it
+ * has to be unique even when two projects are called the same thing.
+ */
+describe('projectId', () => {
+  it('slugs a display name', () => {
+    expect(projectId('Strata', free)).toBe('strata');
+    expect(projectId('My Repo — 2026!', free)).toBe('my-repo-2026');
+    expect(projectId('  spaced  out  ', free)).toBe('spaced-out');
+  });
+
+  it('folds accents rather than dropping the letter', () => {
+    expect(projectId('Ökonomie', free)).toBe('okonomie');
+  });
+
+  it('falls back when a name slugs to nothing', () => {
+    expect(projectId('***', free)).toBe('project');
+    expect(projectId('', free)).toBe('project');
+  });
+
+  it('caps the length without leaving a trailing dash', () => {
+    const id = projectId(`${'a'.repeat(47)} tail`, free);
+
+    expect(id).toBe('a'.repeat(47));
+    expect(id.length).toBeLessThanOrEqual(48);
+  });
+
+  it('suffixes until the id is free', () => {
+    const taken = new Set(['strata', 'strata-2']);
+
+    expect(projectId('Strata', (id) => taken.has(id))).toBe('strata-3');
+  });
+});

--- a/packages/core/src/projects/id.ts
+++ b/packages/core/src/projects/id.ts
@@ -1,0 +1,37 @@
+const MAX_LENGTH = 48;
+
+/** Nothing in the display name is guaranteed to survive slugification. */
+const FALLBACK = 'project';
+
+/**
+ * A stable, URL-safe id for a project, derived from its display name: the id
+ * lands in `/projects/:id` and in stored config, so it is readable rather than
+ * a uuid — but it is assigned once and never re-derived, so renaming a project
+ * later cannot break a link.
+ *
+ * `taken` decides collisions (two projects may share a display name); the
+ * second one gets a numeric suffix.
+ */
+export function projectId(
+  name: string,
+  taken: (id: string) => boolean,
+): string {
+  const base = slug(name) || FALLBACK;
+  if (!taken(base)) return base;
+  for (let n = 2; ; n++) {
+    const candidate = `${base}-${n}`;
+    if (!taken(candidate)) return candidate;
+  }
+}
+
+function slug(name: string): string {
+  return name
+    .normalize('NFKD')
+    // Drop the combining marks NFKD split off, so "Ökonomie" slugs as "okonomie".
+    .replace(/\p{M}/gu, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, MAX_LENGTH)
+    .replace(/-+$/g, '');
+}

--- a/packages/core/src/projects/index.ts
+++ b/packages/core/src/projects/index.ts
@@ -1,0 +1,11 @@
+/**
+ * The project registry — which repositories this workbench knows about, and
+ * what the last analysis of each one found. See `types.ts` for the shape;
+ * `openProjectStore()` is the only entry point callers need.
+ */
+export * from './types.js';
+export * from './open.js';
+export * from './memory.js';
+export * from './errors.js';
+export { projectId } from './id.js';
+export { SqliteProjectStore } from './sqlite.js';

--- a/packages/core/src/projects/input.ts
+++ b/packages/core/src/projects/input.ts
@@ -1,0 +1,15 @@
+import { resolve } from 'node:path';
+import type { ProjectInput } from './types.js';
+
+/**
+ * Normalise what a caller asked to register: trim the display name, and make
+ * the root absolute so `/repo`, `/repo/` and a relative path are one entry
+ * rather than three.
+ */
+export function normalizeInput(input: ProjectInput): ProjectInput {
+  const name = input.name?.trim() ?? '';
+  const root = input.root?.trim() ?? '';
+  if (!name) throw new Error('A project needs a display name.');
+  if (!root) throw new Error('A project needs a repository root.');
+  return { name, root: resolve(root) };
+}

--- a/packages/core/src/projects/memory.ts
+++ b/packages/core/src/projects/memory.ts
@@ -1,0 +1,58 @@
+import { resolve } from 'node:path';
+import { DuplicateRootError } from './errors.js';
+import { projectId } from './id.js';
+import { normalizeInput } from './input.js';
+import type {
+  Project,
+  ProjectAnalysis,
+  ProjectInput,
+  ProjectStore,
+} from './types.js';
+
+/**
+ * A registry that lives for as long as the process does — what a workbench
+ * falls back to when the database cannot be opened (a read-only container, a
+ * file written by a newer Strata). Everything works; nothing survives a
+ * restart, and the warning at open time says so.
+ *
+ * Also the store tests and callers use when they want no file at all.
+ */
+export function memoryProjectStore(): ProjectStore {
+  const projects = new Map<string, Project>();
+
+  const findByRoot = (root: string): Project | undefined => {
+    const target = resolve(root);
+    return [...projects.values()].find((p) => p.root === target);
+  };
+
+  return {
+    path: null,
+    list: () => [...projects.values()],
+    get: (id) => projects.get(id),
+    findByRoot,
+    add(input: ProjectInput): Project {
+      const { name, root } = normalizeInput(input);
+      const existing = findByRoot(root);
+      if (existing) throw new DuplicateRootError(root, existing);
+
+      const project: Project = {
+        id: projectId(name, (candidate) => projects.has(candidate)),
+        name,
+        root,
+        addedAt: new Date().toISOString(),
+        lastAnalysis: null,
+      };
+      projects.set(project.id, project);
+      return project;
+    },
+    recordAnalysis(id: string, analysis: ProjectAnalysis): Project | undefined {
+      const project = projects.get(id);
+      if (!project) return undefined;
+      const updated = { ...project, lastAnalysis: analysis };
+      projects.set(id, updated);
+      return updated;
+    },
+    remove: (id) => projects.delete(id),
+    close: () => {},
+  };
+}

--- a/packages/core/src/projects/open.ts
+++ b/packages/core/src/projects/open.ts
@@ -1,0 +1,36 @@
+import { resolve } from 'node:path';
+import { createConsoleLogger } from '../logger.js';
+import { memoryProjectStore } from './memory.js';
+import { SqliteProjectStore } from './sqlite.js';
+import type { ProjectStore, ProjectStoreOptions } from './types.js';
+
+/** Beside `cache.db`, in the directory that is already a persisted volume. */
+const DEFAULT_DIR = '.strata';
+
+/**
+ * Open the project registry. Never throws at startup: a location that cannot
+ * be opened (read-only container, missing permissions, a file from a newer
+ * build) degrades to an in-memory registry and a warning, so the workbench
+ * still runs — it simply forgets the list when the process exits.
+ *
+ * Writes on an opened store do *not* degrade; see `sqlite.ts`.
+ */
+export function openProjectStore(
+  opts: ProjectStoreOptions = {},
+): ProjectStore {
+  const log = opts.log ?? createConsoleLogger('strata:projects');
+  const file =
+    opts.path ??
+    resolve(
+      opts.dir ?? process.env.STRATA_DATA_DIR ?? DEFAULT_DIR,
+      'projects.db',
+    );
+  try {
+    return new SqliteProjectStore(file);
+  } catch (err) {
+    log.warn(
+      `not persisted — could not open ${file}: ${(err as Error).message}`,
+    );
+    return memoryProjectStore();
+  }
+}

--- a/packages/core/src/projects/projects.test.ts
+++ b/packages/core/src/projects/projects.test.ts
@@ -1,0 +1,173 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  DuplicateRootError,
+  memoryProjectStore,
+  openProjectStore,
+  type ProjectAnalysis,
+} from './index.js';
+
+/**
+ * The registry is the one thing here nobody can recompute: a lost cache costs a
+ * rerun, a lost project costs the user their setup. So the interesting cases
+ * are the ones that would drop or duplicate an entry.
+ */
+
+const analysis: ProjectAnalysis = {
+  rev: '4c1249e',
+  branch: 'main',
+  files: 42,
+  durationMs: 1820,
+  finishedAt: '2026-08-15T10:00:00.000Z',
+};
+
+describe('project store', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'strata-projects-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('keeps registered projects across restarts', () => {
+    const store = openProjectStore({ dir });
+    const added = store.add({ name: 'Strata', root: '/repos/strata' });
+
+    expect(added).toMatchObject({
+      id: 'strata',
+      name: 'Strata',
+      root: resolve('/repos/strata'),
+      lastAnalysis: null,
+    });
+    store.close();
+
+    const reopened = openProjectStore({ dir });
+    expect(reopened.list()).toEqual([added]);
+    expect(reopened.get('strata')).toEqual(added);
+    reopened.close();
+  });
+
+  it('remembers the last analysis of a project', () => {
+    const store = openProjectStore({ dir });
+    const { id } = store.add({ name: 'Strata', root: '/repos/strata' });
+
+    expect(store.recordAnalysis(id, analysis)?.lastAnalysis).toEqual(analysis);
+    store.close();
+
+    const reopened = openProjectStore({ dir });
+    expect(reopened.get(id)?.lastAnalysis).toEqual(analysis);
+    reopened.close();
+  });
+
+  it('has nothing to record for an unknown project', () => {
+    const store = openProjectStore({ dir });
+    expect(store.recordAnalysis('nope', analysis)).toBeUndefined();
+    store.close();
+  });
+
+  it('refuses a root that is already registered, however it is spelled', () => {
+    const store = openProjectStore({ dir });
+    const first = store.add({ name: 'Strata', root: '/repos/strata' });
+
+    const err = catchError(() =>
+      store.add({ name: 'Strata again', root: '/repos/strata/' }),
+    );
+
+    expect(err).toBeInstanceOf(DuplicateRootError);
+    expect((err as DuplicateRootError).existing).toEqual(first);
+    expect(store.list()).toHaveLength(1);
+    store.close();
+  });
+
+  it('gives two projects of the same name distinct ids', () => {
+    const store = openProjectStore({ dir });
+
+    expect(store.add({ name: 'Strata', root: '/repos/a' }).id).toBe('strata');
+    expect(store.add({ name: 'Strata', root: '/repos/b' }).id).toBe('strata-2');
+    store.close();
+  });
+
+  it('finds the project registered for a root', () => {
+    const store = openProjectStore({ dir });
+    const project = store.add({ name: 'Strata', root: '/repos/strata' });
+
+    expect(store.findByRoot('/repos/strata')).toEqual(project);
+    expect(store.findByRoot('/repos/other')).toBeUndefined();
+    store.close();
+  });
+
+  it('rejects a project without a name or a root', () => {
+    const store = openProjectStore({ dir });
+
+    expect(() => store.add({ name: '  ', root: '/repos/a' })).toThrow(/name/);
+    expect(() => store.add({ name: 'Strata', root: ' ' })).toThrow(/root/);
+    store.close();
+  });
+
+  it('removes only the entry, and reports an id it did not hold', () => {
+    const store = openProjectStore({ dir });
+    store.add({ name: 'Strata', root: '/repos/strata' });
+    store.add({ name: 'Other', root: '/repos/other' });
+
+    expect(store.remove('strata')).toBe(true);
+    expect(store.remove('strata')).toBe(false);
+    expect(store.list().map((p) => p.id)).toEqual(['other']);
+    store.close();
+  });
+
+  it('lists projects in registration order', () => {
+    const store = openProjectStore({ dir });
+    store.add({ name: 'Zulu', root: '/repos/z' });
+    store.add({ name: 'Alpha', root: '/repos/a' });
+
+    expect(store.list().map((p) => p.id)).toEqual(['zulu', 'alpha']);
+    store.close();
+  });
+
+  it('falls back to memory when the database cannot be opened', () => {
+    // A directory where the file has to be: opening it as a database fails.
+    const store = openProjectStore({
+      path: dir,
+      log: { debug() {}, info() {}, warn() {}, error() {} },
+    });
+
+    expect(store.path).toBeNull();
+    expect(store.add({ name: 'Strata', root: '/repos/strata' }).id).toBe(
+      'strata',
+    );
+    store.close();
+  });
+});
+
+describe('memory project store', () => {
+  it('behaves like the persistent one, minus the file', () => {
+    const store = memoryProjectStore();
+    const project = store.add({ name: 'Strata', root: '/repos/strata' });
+
+    expect(store.path).toBeNull();
+    expect(store.list()).toEqual([project]);
+    expect(store.recordAnalysis(project.id, analysis)?.lastAnalysis).toEqual(
+      analysis,
+    );
+    expect(store.findByRoot('/repos/strata')?.id).toBe(project.id);
+    expect(() =>
+      store.add({ name: 'Twice', root: '/repos/strata' }),
+    ).toThrow(DuplicateRootError);
+    expect(store.remove(project.id)).toBe(true);
+    expect(store.list()).toEqual([]);
+  });
+});
+
+function catchError(fn: () => unknown): unknown {
+  try {
+    fn();
+    return undefined;
+  } catch (err) {
+    return err;
+  }
+}

--- a/packages/core/src/projects/schema.ts
+++ b/packages/core/src/projects/schema.ts
@@ -1,0 +1,60 @@
+import type { DatabaseSync } from 'node:sqlite';
+
+/**
+ * Bump when the table layout changes — and write the migration. Unlike the
+ * cache, this file holds data nobody can recompute, so a mismatch never wipes.
+ */
+export const SCHEMA_VERSION = 1;
+
+const TABLES = `
+CREATE TABLE IF NOT EXISTS projects (
+  id            TEXT    PRIMARY KEY,
+  name          TEXT    NOT NULL,
+  root          TEXT    NOT NULL UNIQUE,
+  added_at      TEXT    NOT NULL,
+  -- Registration order, which added_at alone cannot give: two projects added
+  -- in the same millisecond carry the same timestamp.
+  seq           INTEGER NOT NULL,
+  -- The last run's summary as JSON, or NULL until this project is analysed.
+  last_analysis TEXT
+) WITHOUT ROWID;
+`;
+
+/** Pragmas for a small, durable, occasionally-shared file. */
+export function configure(db: DatabaseSync): void {
+  db.exec('PRAGMA journal_mode = WAL');
+  // Registry writes are rare and user-initiated: durability beats throughput.
+  db.exec('PRAGMA synchronous = FULL');
+  db.exec('PRAGMA busy_timeout = 5000');
+}
+
+/**
+ * Create the tables and stamp the schema version.
+ *
+ * A file written by a *newer* Strata is left untouched and reported: opening it
+ * with this build's expectations would either fail confusingly or quietly drop
+ * columns the newer build still needs. The caller degrades to an in-memory
+ * registry, so the workbench still runs — it just does not persist.
+ */
+export function migrate(db: DatabaseSync): void {
+  db.exec(
+    'CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)',
+  );
+  const row = db
+    .prepare("SELECT value FROM meta WHERE key = 'schema_version'")
+    .get() as { value?: string } | undefined;
+  const found = Number(row?.value ?? SCHEMA_VERSION);
+
+  if (found > SCHEMA_VERSION) {
+    throw new Error(
+      `project registry is at schema ${found}, but this build understands ${SCHEMA_VERSION} — ` +
+        'it was written by a newer Strata.',
+    );
+  }
+
+  db.exec(TABLES);
+  db.prepare(
+    `INSERT INTO meta (key, value) VALUES ('schema_version', ?)
+     ON CONFLICT (key) DO UPDATE SET value = excluded.value`,
+  ).run(String(SCHEMA_VERSION));
+}

--- a/packages/core/src/projects/sqlite.ts
+++ b/packages/core/src/projects/sqlite.ts
@@ -1,0 +1,150 @@
+import { mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { DatabaseSync, type StatementSync } from 'node:sqlite';
+import { DuplicateRootError } from './errors.js';
+import { projectId } from './id.js';
+import { normalizeInput } from './input.js';
+import { configure, migrate } from './schema.js';
+import type {
+  Project,
+  ProjectAnalysis,
+  ProjectInput,
+  ProjectStore,
+} from './types.js';
+
+/** One row of `projects`, as SQLite hands it back. */
+interface Row {
+  id: string;
+  name: string;
+  root: string;
+  added_at: string;
+  seq: number;
+  last_analysis: string | null;
+}
+
+/**
+ * The persistent registry: one SQLite file, separate from `cache.db` so that
+ * emptying the cache — or a schema bump that wipes it — can never cost someone
+ * their list of projects.
+ *
+ * Failures here are *not* swallowed the way the cache swallows its own. A cache
+ * miss costs a recomputation, but an "Add project" that reports success and
+ * stores nothing loses user intent, so a write that fails throws and the API
+ * turns it into an error the user can see.
+ */
+export class SqliteProjectStore implements ProjectStore {
+  readonly path: string;
+
+  private readonly db: DatabaseSync;
+  private readonly selectAll: StatementSync;
+  private readonly selectById: StatementSync;
+  private readonly selectByRoot: StatementSync;
+  private readonly insert: StatementSync;
+  private readonly updateAnalysis: StatementSync;
+  private readonly deleteById: StatementSync;
+
+  constructor(path: string) {
+    this.path = resolve(path);
+    mkdirSync(dirname(this.path), { recursive: true });
+    this.db = new DatabaseSync(this.path);
+
+    configure(this.db);
+    migrate(this.db);
+
+    // Registration order is the switcher's order: stable, and it does not move
+    // under the reader when a project is analysed.
+    this.selectAll = this.db.prepare('SELECT * FROM projects ORDER BY seq');
+    this.selectById = this.db.prepare('SELECT * FROM projects WHERE id = ?');
+    this.selectByRoot = this.db.prepare(
+      'SELECT * FROM projects WHERE root = ?',
+    );
+    this.insert = this.db.prepare(
+      `INSERT INTO projects (id, name, root, added_at, seq, last_analysis)
+       VALUES (?, ?, ?, ?, (SELECT IFNULL(MAX(seq), 0) + 1 FROM projects), ?)`,
+    );
+    this.updateAnalysis = this.db.prepare(
+      'UPDATE projects SET last_analysis = ? WHERE id = ?',
+    );
+    this.deleteById = this.db.prepare('DELETE FROM projects WHERE id = ?');
+  }
+
+  list(): Project[] {
+    return (this.selectAll.all() as unknown as Row[]).map(toProject);
+  }
+
+  get(id: string): Project | undefined {
+    return one(this.selectById.get(id));
+  }
+
+  findByRoot(root: string): Project | undefined {
+    return one(this.selectByRoot.get(resolve(root)));
+  }
+
+  add(input: ProjectInput): Project {
+    const { name, root } = normalizeInput(input);
+    const existing = this.findByRoot(root);
+    if (existing) throw new DuplicateRootError(root, existing);
+
+    const project: Project = {
+      id: projectId(name, (candidate) => this.get(candidate) !== undefined),
+      name,
+      root,
+      addedAt: new Date().toISOString(),
+      lastAnalysis: null,
+    };
+    try {
+      this.insert.run(
+        project.id,
+        project.name,
+        project.root,
+        project.addedAt,
+        null,
+      );
+    } catch (err) {
+      // Another writer registered this root between the check and the insert.
+      const raced = this.findByRoot(root);
+      if (raced) throw new DuplicateRootError(root, raced);
+      throw err;
+    }
+    return project;
+  }
+
+  recordAnalysis(id: string, analysis: ProjectAnalysis): Project | undefined {
+    if (!this.get(id)) return undefined;
+    this.updateAnalysis.run(JSON.stringify(analysis), id);
+    return this.get(id);
+  }
+
+  remove(id: string): boolean {
+    return Number(this.deleteById.run(id).changes) > 0;
+  }
+
+  close(): void {
+    this.db.close();
+  }
+}
+
+/** One row, or nothing — `node:sqlite` types a result as a bag of columns. */
+function one(row: unknown): Project | undefined {
+  return row === undefined ? undefined : toProject(row as Row);
+}
+
+function toProject(row: Row): Project {
+  return {
+    id: row.id,
+    name: row.name,
+    root: row.root,
+    addedAt: row.added_at,
+    lastAnalysis: parseAnalysis(row.last_analysis),
+  };
+}
+
+/** A summary we cannot read is a project that has not been analysed yet. */
+function parseAnalysis(value: string | null): ProjectAnalysis | null {
+  if (value === null) return null;
+  try {
+    return JSON.parse(value) as ProjectAnalysis;
+  } catch {
+    return null;
+  }
+}

--- a/packages/core/src/projects/types.ts
+++ b/packages/core/src/projects/types.ts
@@ -1,0 +1,70 @@
+import type { Logger } from '@strata/sdk';
+import type { RunReport } from '../types.js';
+
+/**
+ * What the switcher shows about a project's last run: the run's own metadata
+ * plus the revision it ran on — the same pair `AnalysisReport` carries.
+ */
+export interface ProjectAnalysis extends RunReport {
+  rev: string;
+}
+
+/** One registered project. */
+export interface Project {
+  /** Stable slug, derived from the display name when the project is added. */
+  id: string;
+  /** What the switcher labels it. */
+  name: string;
+  /** Absolute working-tree root of the repository. */
+  root: string;
+  /** When it was registered, ISO 8601. */
+  addedAt: string;
+  /** Summary of the last analysis of this root; null until one runs. */
+  lastAnalysis: ProjectAnalysis | null;
+}
+
+/** What a caller supplies to register a project; the store derives the rest. */
+export interface ProjectInput {
+  name: string;
+  root: string;
+}
+
+export interface ProjectStoreOptions {
+  /** Database file. Overrides `dir`. */
+  path?: string;
+  /**
+   * Directory to hold `projects.db`. Defaults to `$STRATA_DATA_DIR`, else
+   * `<cwd>/.strata`.
+   */
+  dir?: string;
+  /** Where to report a store that could not be opened. */
+  log?: Logger;
+}
+
+/**
+ * The project registry: which repositories this workbench knows about. Durable
+ * user data, unlike the analysis cache — nothing here is derived, so nothing
+ * here is ever dropped to reclaim space, and `DELETE /cache` does not touch it.
+ *
+ * Every method is synchronous: the registry is a handful of rows read on
+ * request, and SQLite through `node:sqlite` is synchronous anyway.
+ */
+export interface ProjectStore {
+  /** The database file backing the store, or `null` when it is in memory. */
+  readonly path: string | null;
+  /** Every project, oldest registration first. */
+  list(): Project[];
+  get(id: string): Project | undefined;
+  /** The project registered for a working-tree root, if any. */
+  findByRoot(root: string): Project | undefined;
+  /**
+   * Register a project. Throws `DuplicateRootError` if the root is already
+   * registered, and `Error` if name or root is blank.
+   */
+  add(input: ProjectInput): Project;
+  /** Store the summary of a finished run; `undefined` if the id is unknown. */
+  recordAnalysis(id: string, analysis: ProjectAnalysis): Project | undefined;
+  /** Drop the entry. Never touches the repository on disk. */
+  remove(id: string): boolean;
+  close(): void;
+}

--- a/packages/server/ARCHITECTURE.md
+++ b/packages/server/ARCHITECTURE.md
@@ -11,7 +11,8 @@ UI and CI. Keeps transport concerns out of the core.
 
 ## 2. Constraints
 
-- Stateless request handling (state lives in the core/cache).
+- Stateless request handling (state lives in the core: the cache and the
+  project registry).
 - No business logic beyond validation + delegation to the core.
 - Must run in the container as a non-root user.
 
@@ -25,24 +26,30 @@ UI and CI. Keeps transport concerns out of the core.
 |--------|------|---------|
 | GET | `/health` | Liveness. |
 | GET | `/plugins` | What loaded, from where, and what was skipped: `{ directory, plugins, failures }` — each plugin its manifest plus a `source` (`builtin`/`user`). |
-| POST | `/analyze` | Body `{ root, rev?, historyLimit?, cache? }` → `AnalysisReport` (incl. run metadata and cache stats). |
-| DELETE | `/cache` | Empty the incremental cache. |
+| GET | `/projects` | `{ projects }` — the registry, in registration order; each entry carries its id, display name, root and last-analysis summary. |
+| POST | `/projects` | Body `{ name, root }` → the created `Project` (201). The root is resolved to the repository that owns it; 400 if it owns none, 409 if that repository is already registered. |
+| GET | `/projects/:id` | One project, or 404. |
+| DELETE | `/projects/:id` | Drop the entry (`{ removed: true }`), or 404. Never touches the repository on disk. |
+| POST | `/analyze` | Body `{ root, rev?, historyLimit?, cache? }` → `AnalysisReport` (incl. run metadata and cache stats). A run over a registered root also updates that project's last-analysis summary. |
+| DELETE | `/cache` | Empty the incremental cache. Registered projects are untouched — they live in their own database. |
 
 ## 4. Building Blocks
 
 | File | Responsibility |
 |------|----------------|
 | `index.ts` | Barrel — the package's public surface. |
-| `app.ts` | `createServer()` — registry, one `Strata`, routes, shutdown hook. |
+| `app.ts` | `createServer()` — plugin registry, one `Strata`, one project store, routes, shutdown hook. |
 | `main.ts` | Process entry point (`node dist/main.js`). |
 | `registry.ts` | `buildRegistry()` — load the built-ins, then the user plugins directory. |
-| `routes/health.ts` … `routes/cache.ts` | One module per endpoint. |
+| `routes/health.ts` … `routes/projects.ts` | One module per endpoint. |
+| `routes/http-error.ts` | `httpError(status, message)` — a thrown error Fastify serialises in its own error shape. |
 | `routes/index.ts` | `registerRoutes()` + the `RouteContext` they share. |
 
 ## 5. Runtime
 
-Request → validate body → `Strata.analyze()` → JSON report. Plugin discovery
-happens once at startup.
+Request → validate body → `Strata.analyze()` → JSON report, plus a write to the
+project registry when the analysed root is registered. Plugin discovery happens
+once at startup, as does opening the registry.
 
 ## 6. Decisions
 
@@ -54,13 +61,25 @@ happens once at startup.
 - **A plugin that will not load never fails startup** — it is reported on
   `GET /plugins` instead, which is what the plugins settings screen reads.
 - **One long-lived `Strata`**, so the cache is opened once and closed with the
-  server (`onClose`), not per request.
+  server (`onClose`), not per request. The project store is opened and closed
+  the same way.
+- **`/analyze` refreshes the registry itself** — the switcher shows how long ago
+  each project was analysed, and a run over a registered root is that fact,
+  whoever asked for it. No `projectId` in the request body, so a CI run and a
+  click through the UI keep the same entry current. A registry that will not
+  take the update is logged, never raised: the caller already paid for the
+  report.
+- **Registering a project resolves the path through git**, so a path that is no
+  repository is a 400 at *Add project* rather than a failure at the first
+  analysis, and a subdirectory registers the repository that owns it instead of
+  a second entry for a project that is already there.
 
 ## 7. Quality & Risks
 
 - **Risk:** `root` points anywhere on disk, and the API is unauthenticated —
   `DELETE /cache` is reachable by anyone who can reach the port (cost: a
-  recomputation). **Mitigation:** the API assumes a trusted network and
+  recomputation), and so is `DELETE /projects/:id` (cost: a registry entry, and
+  nothing on disk). **Mitigation:** the API assumes a trusted network and
   deployments mount repos read-only under a fixed prefix; path allow-listing and
   auth are on the backlog. Do not expose the port publicly.
 - **Risk:** malformed request bodies. **Mitigation:** `/analyze` carries a JSON

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -1,21 +1,26 @@
 import Fastify, { type FastifyInstance } from 'fastify';
-import { Strata } from '@strata/core';
+import { openProjectStore, Strata } from '@strata/core';
 import { buildRegistry } from './registry.js';
 import { registerRoutes } from './routes/index.js';
 
 /**
  * Build the HTTP app: discover plugins once, hold one `Strata` (so the
- * incremental cache is opened once and closed with the server), register routes.
+ * incremental cache is opened once and closed with the server) and one project
+ * registry, register routes.
  */
 export async function createServer(): Promise<FastifyInstance> {
   const app = Fastify({ logger: true });
   const registry = await buildRegistry();
   const strata = new Strata(registry);
+  const projects = openProjectStore();
 
-  registerRoutes(app, { strata, registry });
+  registerRoutes(app, { strata, registry, projects });
 
-  // Flush and close the cache with the server.
-  app.addHook('onClose', async () => strata.close());
+  // Flush and close the cache and the registry with the server.
+  app.addHook('onClose', async () => {
+    strata.close();
+    projects.close();
+  });
 
   return app;
 }

--- a/packages/server/src/routes/analyze.test.ts
+++ b/packages/server/src/routes/analyze.test.ts
@@ -1,0 +1,106 @@
+import Fastify, { type FastifyInstance } from 'fastify';
+import {
+  memoryProjectStore,
+  type AnalysisReport,
+  type PluginRegistry,
+  type ProjectStore,
+  type Strata,
+} from '@strata/core';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { analyzeRoute } from './analyze.js';
+
+/**
+ * `/analyze` is a thin delegation, with one thing of its own: a run over a
+ * registered root refreshes what the switcher shows about that project — and a
+ * registry that will not take the update must not cost the caller the report.
+ */
+
+const report = {
+  rev: '4c1249e',
+  run: {
+    branch: 'main',
+    files: 42,
+    durationMs: 1820,
+    finishedAt: '2026-08-15T10:00:00.000Z',
+  },
+  languages: {},
+  metrics: [],
+  commits: [],
+  cache: {
+    enabled: false,
+    hits: 0,
+    misses: 0,
+    runHits: 0,
+    runMisses: 0,
+    writes: 0,
+  },
+} satisfies AnalysisReport;
+
+const strata = { analyze: async () => report } as unknown as Strata;
+
+let projects: ProjectStore;
+let app: FastifyInstance;
+
+function build(store: ProjectStore): FastifyInstance {
+  const instance = Fastify();
+  analyzeRoute(instance, {
+    strata,
+    projects: store,
+    registry: {} as PluginRegistry,
+  });
+  return instance;
+}
+
+async function analyze(root: string) {
+  return await app.inject({
+    method: 'POST',
+    url: '/analyze',
+    payload: { root },
+  });
+}
+
+beforeEach(() => {
+  projects = memoryProjectStore();
+  app = build(projects);
+});
+
+afterEach(async () => {
+  await app.close();
+});
+
+describe('POST /analyze', () => {
+  it('records the run against the project registered for that root', async () => {
+    const project = projects.add({ name: 'Strata', root: '/repos/strata' });
+
+    const response = await analyze('/repos/strata');
+
+    expect(response.json()).toEqual(report);
+    expect(projects.get(project.id)?.lastAnalysis).toEqual({
+      rev: report.rev,
+      ...report.run,
+    });
+  });
+
+  it('analyses a root nobody registered without recording anything', async () => {
+    const response = await analyze('/repos/unregistered');
+
+    expect(response.statusCode).toBe(200);
+    expect(projects.list()).toEqual([]);
+  });
+
+  it('still returns the report when the registry refuses the update', async () => {
+    const broken: ProjectStore = {
+      ...projects,
+      findByRoot: () => {
+        throw new Error('database is locked');
+      },
+    };
+    await app.close();
+    app = build(broken);
+
+    const response = await analyze('/repos/strata');
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual(report);
+  });
+});

--- a/packages/server/src/routes/analyze.ts
+++ b/packages/server/src/routes/analyze.ts
@@ -29,6 +29,25 @@ const schema = {
 export function analyzeRoute(app: FastifyInstance, ctx: RouteContext): void {
   app.post<{ Body: AnalyzeBody }>('/analyze', { schema }, async (req) => {
     const { root, rev, historyLimit, cache } = req.body;
-    return ctx.strata.analyze({ root, rev, historyLimit, cache });
+    const report = await ctx.strata.analyze({ root, rev, historyLimit, cache });
+
+    // The switcher shows how long ago each project was analysed, so every run
+    // over a registered root updates it — whoever asked for the run.
+    try {
+      const project = ctx.projects.findByRoot(root);
+      if (project) {
+        ctx.projects.recordAnalysis(project.id, {
+          rev: report.rev,
+          ...report.run,
+        });
+      }
+    } catch (err) {
+      // A registry that cannot be written is worth a line in the log; it is not
+      // worth failing an analysis the caller already paid for.
+      req.log.warn(
+        `could not record the run against the project registry: ${(err as Error).message}`,
+      );
+    }
+    return report;
   });
 }

--- a/packages/server/src/routes/context.ts
+++ b/packages/server/src/routes/context.ts
@@ -1,7 +1,8 @@
-import type { PluginRegistry, Strata } from '@strata/core';
+import type { PluginRegistry, ProjectStore, Strata } from '@strata/core';
 
 /** What every route needs from the app it is registered on. */
 export interface RouteContext {
   strata: Strata;
   registry: PluginRegistry;
+  projects: ProjectStore;
 }

--- a/packages/server/src/routes/http-error.ts
+++ b/packages/server/src/routes/http-error.ts
@@ -1,0 +1,11 @@
+/**
+ * An error Fastify will serialise with a status of our choosing, in the same
+ * `{ statusCode, error, message }` shape its own validation errors use — so a
+ * client has one error shape to render, whoever produced it.
+ */
+export function httpError(
+  statusCode: number,
+  message: string,
+): Error & { statusCode: number } {
+  return Object.assign(new Error(message), { statusCode });
+}

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -3,6 +3,7 @@ import { analyzeRoute } from './analyze.js';
 import { cacheRoute } from './cache.js';
 import { healthRoute } from './health.js';
 import { pluginsRoute } from './plugins.js';
+import { projectsRoute } from './projects.js';
 import type { RouteContext } from './context.js';
 
 export type { RouteContext } from './context.js';
@@ -11,6 +12,7 @@ export type { RouteContext } from './context.js';
 export function registerRoutes(app: FastifyInstance, ctx: RouteContext): void {
   healthRoute(app);
   pluginsRoute(app, ctx);
+  projectsRoute(app, ctx);
   analyzeRoute(app, ctx);
   cacheRoute(app, ctx);
 }

--- a/packages/server/src/routes/projects.test.ts
+++ b/packages/server/src/routes/projects.test.ts
@@ -1,0 +1,168 @@
+import { execFile } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { realpath } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import Fastify, { type FastifyInstance } from 'fastify';
+import {
+  memoryProjectStore,
+  type PluginRegistry,
+  type ProjectStore,
+  type Strata,
+} from '@strata/core';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { projectsRoute } from './projects.js';
+
+const exec = promisify(execFile);
+
+/**
+ * The registry endpoints behind the sidebar switcher. They run against a real
+ * repository, because *Add project* resolves the path it is given through git
+ * — that resolution is the part worth testing.
+ */
+
+let repo: string;
+let plain: string;
+let projects: ProjectStore;
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  repo = await realpath(mkdtempSync(join(tmpdir(), 'strata-projects-api-')));
+  mkdirSync(join(repo, 'src'));
+  await exec('git', ['init', '-q'], { cwd: repo });
+  plain = await realpath(mkdtempSync(join(tmpdir(), 'strata-plain-api-')));
+}, 30_000);
+
+afterAll(async () => {
+  await app.close();
+  rmSync(repo, { recursive: true, force: true });
+  rmSync(plain, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  await app?.close();
+  projects = memoryProjectStore();
+  app = Fastify();
+  projectsRoute(app, {
+    projects,
+    strata: {} as Strata,
+    registry: {} as PluginRegistry,
+  });
+});
+
+async function add(body: Record<string, unknown>) {
+  return await app.inject({ method: 'POST', url: '/projects', payload: body });
+}
+
+describe('GET /projects', () => {
+  it('lists what is registered', async () => {
+    await add({ name: 'Strata', root: repo });
+
+    const response = await app.inject({ url: '/projects' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      projects: [
+        expect.objectContaining({ id: 'strata', name: 'Strata', root: repo }),
+      ],
+    });
+  });
+
+  it('starts empty', async () => {
+    expect((await app.inject({ url: '/projects' })).json()).toEqual({
+      projects: [],
+    });
+  });
+});
+
+describe('POST /projects', () => {
+  it('registers a repository and answers 201', async () => {
+    const response = await add({ name: 'Strata', root: repo });
+
+    expect(response.statusCode).toBe(201);
+    expect(response.json()).toMatchObject({
+      id: 'strata',
+      name: 'Strata',
+      root: repo,
+      lastAnalysis: null,
+    });
+  });
+
+  it('registers the repository a subdirectory belongs to', async () => {
+    const response = await add({ name: 'Strata', root: join(repo, 'src') });
+
+    expect(response.json()).toMatchObject({ root: repo });
+  });
+
+  it('refuses a path that is not in a repository', async () => {
+    const response = await add({ name: 'Nope', root: plain });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json().message).toContain('not inside a git repository');
+    expect(projects.list()).toEqual([]);
+  });
+
+  it('refuses a root that is already registered', async () => {
+    await add({ name: 'Strata', root: repo });
+
+    const response = await add({ name: 'Strata again', root: repo });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json().message).toContain('already registered');
+    expect(projects.list()).toHaveLength(1);
+  });
+
+  it('rejects a body that is incomplete or blank', async () => {
+    expect((await add({ root: repo })).statusCode).toBe(400);
+    expect((await add({ name: 'Strata' })).statusCode).toBe(400);
+    expect((await add({ name: '', root: repo })).statusCode).toBe(400);
+  });
+
+  it('does not let the caller choose the id', async () => {
+    // Fastify strips what the schema does not declare, so `id` never arrives.
+    const response = await add({ name: 'Strata', root: repo, id: 'mine' });
+
+    expect(response.json().id).toBe('strata');
+  });
+});
+
+describe('GET /projects/:id', () => {
+  it('answers with the project, or 404 for an id nobody registered', async () => {
+    await add({ name: 'Strata', root: repo });
+
+    const known = await app.inject({ url: '/projects/strata' });
+    expect(known.json()).toMatchObject({ id: 'strata', root: repo });
+
+    const missing = await app.inject({ url: '/projects/ghost' });
+    expect(missing.statusCode).toBe(404);
+  });
+});
+
+describe('DELETE /projects/:id', () => {
+  it('drops the entry — and nothing else', async () => {
+    await add({ name: 'Strata', root: repo });
+
+    const response = await app.inject({
+      method: 'DELETE',
+      url: '/projects/strata',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ removed: true });
+    expect(projects.list()).toEqual([]);
+    // The repository itself is untouched: it is still a git working tree.
+    await expect(
+      exec('git', ['rev-parse', '--is-inside-work-tree'], { cwd: repo }),
+    ).resolves.toMatchObject({ stdout: 'true\n' });
+  });
+
+  it('answers 404 for an id it did not hold', async () => {
+    const response = await app.inject({
+      method: 'DELETE',
+      url: '/projects/ghost',
+    });
+
+    expect(response.statusCode).toBe(404);
+  });
+});

--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -1,0 +1,92 @@
+import type { FastifyInstance } from 'fastify';
+import { DuplicateRootError, gitUtil, type Project } from '@strata/core';
+import type { RouteContext } from './context.js';
+import { httpError } from './http-error.js';
+
+interface AddBody {
+  name: string;
+  root: string;
+}
+
+interface IdParams {
+  id: string;
+}
+
+const addSchema = {
+  body: {
+    type: 'object',
+    required: ['name', 'root'],
+    additionalProperties: false,
+    properties: {
+      name: { type: 'string', minLength: 1, maxLength: 100 },
+      root: { type: 'string', minLength: 1 },
+    },
+  },
+};
+
+const idSchema = {
+  params: {
+    type: 'object',
+    required: ['id'],
+    additionalProperties: false,
+    properties: { id: { type: 'string', minLength: 1 } },
+  },
+};
+
+/**
+ * The project registry: what the sidebar switcher lists, what *Add project*
+ * writes, and what *Danger zone → Remove project* drops. Removing an entry is
+ * a registry operation only — the repository on disk is never touched.
+ */
+export function projectsRoute(app: FastifyInstance, ctx: RouteContext): void {
+  app.get('/projects', async () => ({ projects: ctx.projects.list() }));
+
+  app.get<{ Params: IdParams }>(
+    '/projects/:id',
+    { schema: idSchema },
+    async (req) => found(ctx.projects.get(req.params.id), req.params.id),
+  );
+
+  app.post<{ Body: AddBody }>(
+    '/projects',
+    { schema: addSchema },
+    async (req, reply) => {
+      // Store the repository, not the path that was typed: a subdirectory
+      // analyses the whole repo anyway, so it would register a second entry
+      // for a project that is already there.
+      const root = await gitUtil.toplevel(req.body.root);
+      if (root === null) {
+        throw httpError(
+          400,
+          `${req.body.root} is not inside a git repository.`,
+        );
+      }
+      try {
+        const project = ctx.projects.add({ name: req.body.name, root });
+        reply.code(201);
+        return project;
+      } catch (err) {
+        if (err instanceof DuplicateRootError) {
+          throw httpError(409, err.message);
+        }
+        throw err;
+      }
+    },
+  );
+
+  app.delete<{ Params: IdParams }>(
+    '/projects/:id',
+    { schema: idSchema },
+    async (req) => {
+      if (!ctx.projects.remove(req.params.id)) {
+        throw httpError(404, `No project "${req.params.id}".`);
+      }
+      return { removed: true };
+    },
+  );
+}
+
+function found(project: Project | undefined, id: string): Project {
+  if (!project) throw httpError(404, `No project "${id}".`);
+  return project;
+}


### PR DESCRIPTION
## What

Persists the list of registered projects — id, display name, root path and a
summary of the last analysis — and puts it behind the API:

| Method | Path | |
|---|---|---|
| GET | `/projects` | the registry, in registration order |
| POST | `/projects` | `{ name, root }` → the created project (201) |
| GET | `/projects/:id` | one project, or 404 |
| DELETE | `/projects/:id` | drop the entry, or 404 |

- **Its own database** (`projects.db`, `$STRATA_DATA_DIR`), beside `cache.db`.
  Everything in the cache is derived and gets pruned, cleared by `DELETE /cache`
  and wiped on a schema bump — none of that may cost someone their project list.
- **A root is stored as the repository that owns it** (`gitUtil.toplevel`), so
  `/repo`, `/repo/src`, a trailing slash and a symlink are one project. A path
  that is no repository is a 400 at *Add project* rather than a failure at the
  first analysis; a repository already registered is a 409.
- **`/analyze` refreshes the summary itself** for a registered root, whoever
  asked for the run — no `projectId` in the request body, so a CI run and a click
  through the UI keep the same entry current. A registry that will not take the
  update is logged, never raised.
- **Opening never fails startup** — an unwritable location, or a file written by
  a newer Strata, degrades to an in-memory registry with a warning. Writes on an
  opened store *do* throw: unlike a cache miss, an "Add project" that reports
  success and stores nothing loses something no rerun brings back.
- `make clean` no longer `rm -rf`s `.strata` — it drops only the cache files, now
  that durable data lives there too.

Not in scope, and left to the next backlog item (project-scoped config +
`PATCH`): renaming a project and re-pointing its root. The switcher UI that
renders all this is its own P0 item.

## Why

Closes #57 — the sidebar switcher, *Add project* and *Danger zone → Remove
project* need somewhere to write to, and nothing in *Configuration &
persistence* existed yet.

## Type of change

- [x] feat / fix / perf / refactor
- [x] docs / test / build / ci / chore

## Checklist

- [x] `pnpm build && pnpm test && pnpm lint` pass locally (332 tests)
- [x] Added/updated tests where it made sense — the store (persistence across
      restarts, duplicate roots, id collisions, removal, memory fallback), the id
      slugs, `toplevel`, and the two route modules via `app.inject` (the first
      server tests in the repo)
- [x] Docs updated — both module `ARCHITECTURE.md`s, `docs/ARCHITECTURE.md`,
      README, `.env.example` (`STRATA_DATA_DIR`), Dockerfile/compose, BACKLOG

Also smoke-tested against a running server: registering `…/strata/packages`
stored the repo root, a re-add returned 409, `/tmp` returned 400, an `/analyze`
run populated `lastAnalysis`, and `DELETE` emptied the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)