### PR TITLE
feat(core): configure what an analysis of a project does

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -48,11 +48,20 @@ New area — the mockup's settings screens need somewhere to write to.
       entry's summary; removing drops the entry only, never the repo on disk.
       The sidebar switcher, *Add project* and *Danger zone → Remove project*
       that render it are UI work, listed below.
-- [ ] **P0** Project-scoped config store + `GET`/`PATCH` endpoints, covering the
-      *Project settings* sections — including editing the two fields the registry
-      already holds: display name, root, revision (default `HEAD`),
-      history limit, ignore globs, analyze paths, enabled language plugins,
-      enabled git metrics, commit convention, architecture rules.
+- [x] Project-scoped config store + endpoints — `GET`/`PATCH`
+      `/projects/:id/config` holds revision (default `HEAD`), history limit,
+      ignore globs, analyze paths, enabled language plugins, enabled git
+      metrics, commit convention and architecture rules; `PATCH /projects/:id`
+      renames a project or re-points its root. Settings are stored sparsely and
+      defaulted on read, and a plugin id nobody loaded is refused. `/analyze`
+      over a registered root takes `rev` and `historyLimit` from here (an
+      explicit request field still wins) — the remaining fields are stored and
+      served but not yet honoured by the pipeline, which is the item below.
+- [ ] **P0** Honour the rest of a project's config in the pipeline — ignore
+      globs and analyze paths in the file routing, the enabled-plugin lists in
+      `Strata.analyze`, and the chosen commit convention instead of
+      first-registered-wins. (Architecture rules need the rule engine under
+      *Architecture fitness*.)
 - [ ] **P0** App-scoped config store + endpoints: appearance (theme, density),
       plugins directory, third-party plugin loading, cache on/off + clear,
       CI gate thresholds, AI provider instances.
@@ -109,8 +118,10 @@ New area — the mockup's settings screens need somewhere to write to.
 
 ## Architecture fitness
 
-- [ ] **P1** Rule engine — declare allowed/forbidden dependencies ("`ui` may not import `db`"),
-      persisted per project and edited in *Project settings → Architecture rules*
+- [ ] **P1** Rule engine — declare allowed/forbidden dependencies ("`ui` may not import `db`").
+      The rules are persisted per project already (`/projects/:id/config`,
+      `{from, to, enforced}`); what is missing is the check that reads them and
+      the *Project settings → Architecture rules* screen that edits them.
 - [ ] **P1** Boundary/layer violation report + CI gate
 - [ ] **P2** Violations surfaced on the dependency graph (highlight the offending edge)
 - [ ] **P2** Fitness-function trends over time

--- a/README.md
+++ b/README.md
@@ -90,6 +90,21 @@ curl -s localhost:4000/projects
 curl -X DELETE localhost:4000/projects/strata
 ```
 
+Each project carries its own settings — revision, history window, ignore globs
+and analyze paths, which plugins run, the commit convention, architecture
+rules. `PATCH` merges, so send only what changed:
+
+```bash
+curl -s localhost:4000/projects/strata/config
+curl -X PATCH localhost:4000/projects/strata/config \
+  -H 'content-type: application/json' \
+  -d '{"rev":"main","historyLimit":500,"ignore":["**/dist/**"]}'
+```
+
+An analysis of a registered root uses those settings as its defaults, so
+`POST /analyze {"root":"…"}` runs what *Project settings* says; a request that
+names `rev` or `historyLimit` itself still wins.
+
 The registry lives in `$STRATA_DATA_DIR` (default `<cwd>/.strata/projects.db`),
 its own database beside the cache: `DELETE /cache` never touches it.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -90,7 +90,8 @@ strata/
 │   │              manifest.ts · discover.ts · plugins-dir.ts ·
 │   │              git/ (exec, rev, branch, repo, files, history, churn) ·
 │   │              cache/ (types, schema, sqlite, null, open, keys, digest, …) ·
-│   │              projects/ (types, schema, sqlite, memory, open, id, …)
+│   │              projects/ (types, schema, sqlite, memory, open, id, …) ·
+│   │              config/ (types, defaults, patch, errors)
 │   └── server/   @strata/server  Fastify HTTP API over the core
 │                  app.ts · main.ts (entry) · registry.ts · routes/*
 ├── plugins/
@@ -201,6 +202,14 @@ publish. The Linux desktop job is still a stub — it produces no bundle until
   repository is one entry; every `/analyze` over a registered root refreshes
   that entry's summary. Removing a project drops the row and nothing else — the
   repository on disk is never touched.
+- **Project configuration** — what an analysis of a project does (revision,
+  history window, ignore globs and analyze paths, which language/metric plugins
+  run, the commit convention, architecture rules), behind
+  `/projects/:id/config`. Stored sparsely beside the registry entry and merged
+  with the defaults on read, so an unset field follows the default rather than a
+  copy of it. `/analyze` takes these as its defaults and lets an explicit
+  request field win. Identity — display name and root — stays on the registry
+  entry, which is the only place that can keep a root unique.
 - **One responsibility per file** — implementation, types, helpers and
   alternate implementations live in separate modules; every `index.ts` is a
   barrel that only re-exports. Public import paths (`@strata/core`,

--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -9,8 +9,9 @@ the immutable `RepoContext`, and drives the analysis pipeline that fans work out
 to plugins. This is the only module that knows about all four plugin kinds.
 
 It also owns what the workbench has to remember between runs: the incremental
-cache, and the **project registry** — which repositories are registered, and
-what the last analysis of each one found.
+cache, the **project registry** — which repositories are registered, and what
+the last analysis of each one found — and each project's **configuration**,
+what an analysis of it is supposed to do.
 
 ## 2. Constraints
 
@@ -60,6 +61,10 @@ what the last analysis of each one found.
 | `projects/memory.ts` | The process-lifetime registry (fallback, tests). |
 | `projects/schema.ts` | Table, pragmas, schema stamp. |
 | `projects/id.ts`, `projects/input.ts`, `projects/errors.ts` | Slugged ids, normalised input, `DuplicateRootError`. |
+| `config/types.ts` | `ProjectConfig`, `ProjectConfigPatch`, `ArchitectureRule`. |
+| `config/defaults.ts` | `DEFAULT_PROJECT_CONFIG` + `withDefaults()` — fill a stored config out. |
+| `config/patch.ts` | `applyPatch()` — merge, normalise, refuse what cannot be stored. |
+| `config/errors.ts` | `InvalidConfigError`. |
 
 ## 5. Runtime
 
@@ -75,8 +80,15 @@ what the last analysis of each one found.
    branch, file count, duration, finished-at) beside the resolved `rev`.
 
 `openProjectStore()` is independent of a run: it opens `projects.db` once, and
-the entries it holds are read on request (`list` / `get` / `findByRoot`) and
-written when a project is added, analysed or removed.
+the entries it holds are read on request (`list` / `get` / `findByRoot` /
+`config`) and written when a project is added, renamed, re-pointed, configured,
+analysed or removed.
+
+A project's config is stored **sparsely** — only the fields someone set — and
+`withDefaults()` fills it out on the way to a caller. `setConfig()` merges a
+patch through `applyPatch()`, which normalises (trims, drops blank rows,
+collapses duplicates) and throws `InvalidConfigError` on a value that cannot
+mean anything.
 
 ## 6. Decisions
 
@@ -122,6 +134,15 @@ written when a project is added, analysed or removed.
   root is resolved to its git working-tree root (`gitUtil.toplevel`) and stored
   absolute, so a subdirectory, a trailing slash and a symlink are one project
   and not four. Ids are slugs assigned once, so renaming cannot break a link.
+- **Config is stored sparsely and defaulted on read**, rather than written out
+  in full when a project is registered. A default that moves in a later release
+  then reaches every project that never overrode it, and "never set" stays
+  distinguishable from "set to today's default".
+- **Identity and configuration are separate** — display name and root live on
+  the registry entry (the root has to stay unique across projects, which only
+  the registry can promise); everything about what an analysis *does* lives in
+  the config. Deleting a project deletes both, so an id handed out again never
+  inherits the last holder's settings.
 
 ## 7. Quality & Risks
 
@@ -133,10 +154,14 @@ written when a project is added, analysed or removed.
 - **Risk:** the cache file grows without bound. **Mitigation:** entries carry a
   last-used stamp and are pruned after 30 days on open.
 - **Risk:** the registry names a root that has since been moved or deleted.
-  **Mitigation:** the entry is checked when it is added, not forever; an
-  analysis of a vanished root fails at the git call, and the entry can be
-  removed. Re-pointing a project at a new root is the project-settings work on
-  the backlog.
+  **Mitigation:** the entry is checked when it is added and whenever it is
+  re-pointed, not forever; an analysis of a vanished root fails at the git call,
+  and the project can be pointed at the new path (`update`) or removed.
+- **Risk:** a stored config names a plugin that is no longer installed, or a
+  revision that no longer exists. **Mitigation:** the API checks plugin ids
+  against the registry as they are written; a stale one survives only until the
+  next edit of that field, and an unknown revision fails the run it is used in
+  rather than the settings screen.
 - **Risk:** `git` output parsing edge cases (root commit, renames). **Mitigation:**
   record-separator parsing; covered by analysis smoke runs.
 - **Risk:** a plugin runs **in-process, with the server's privileges** — the

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyPatch,
+  DEFAULT_PROJECT_CONFIG,
+  InvalidConfigError,
+  withDefaults,
+  type ProjectConfig,
+} from './index.js';
+
+/**
+ * Config is stored sparsely and filled out on read, so the two halves have to
+ * agree: what a patch keeps, what it replaces, and what it refuses to store at
+ * all — a settings screen posting an empty row must not create a rule nobody
+ * can read back.
+ */
+
+describe('withDefaults', () => {
+  it('fills an empty config out to the pre-configuration behaviour', () => {
+    expect(withDefaults({})).toEqual({
+      rev: 'HEAD',
+      historyLimit: null,
+      ignore: [],
+      paths: [],
+      languages: null,
+      metrics: null,
+      convention: null,
+      rules: [],
+    });
+  });
+
+  it('keeps what was set and defaults the rest', () => {
+    expect(withDefaults({ rev: 'main', historyLimit: 500 })).toMatchObject({
+      rev: 'main',
+      historyLimit: 500,
+      ignore: [],
+    });
+  });
+
+  it('copies out, so a caller cannot mutate the defaults', () => {
+    withDefaults({}).ignore.push('**/dist/**');
+
+    expect(DEFAULT_PROJECT_CONFIG.ignore).toEqual([]);
+  });
+});
+
+describe('applyPatch', () => {
+  const stored: Partial<ProjectConfig> = {
+    rev: 'main',
+    ignore: ['**/dist/**'],
+  };
+
+  it('merges by field and leaves the rest alone', () => {
+    expect(applyPatch(stored, { historyLimit: 500 })).toEqual({
+      rev: 'main',
+      ignore: ['**/dist/**'],
+      historyLimit: 500,
+    });
+  });
+
+  it('replaces an array whole rather than adding to it', () => {
+    expect(applyPatch(stored, { ignore: ['**/*.lock'] })).toMatchObject({
+      ignore: ['**/*.lock'],
+    });
+  });
+
+  it('trims, drops blank entries and collapses duplicates', () => {
+    expect(
+      applyPatch({}, { ignore: [' **/dist/** ', '', '  ', '**/dist/**'] }),
+    ).toEqual({ ignore: ['**/dist/**'] });
+  });
+
+  it('takes null for "no cap" and "every registered plugin"', () => {
+    expect(
+      applyPatch(
+        { historyLimit: 500, languages: ['strata-language-typescript'] },
+        { historyLimit: null, languages: null, convention: null },
+      ),
+    ).toEqual({ historyLimit: null, languages: null, convention: null });
+  });
+
+  it('keeps rules, defaulting a new one to report-only', () => {
+    const patched = applyPatch(
+      {},
+      {
+        rules: [
+          { from: ' src/ui/** ', to: 'src/db/**', enforced: true },
+          { from: 'src/api/**', to: 'src/ui/**' } as never,
+        ],
+      },
+    );
+
+    expect(patched.rules).toEqual([
+      { from: 'src/ui/**', to: 'src/db/**', enforced: true },
+      { from: 'src/api/**', to: 'src/ui/**', enforced: false },
+    ]);
+  });
+
+  it('refuses a value that cannot mean anything', () => {
+    expect(() => applyPatch({}, { rev: '   ' })).toThrow(InvalidConfigError);
+    expect(() => applyPatch({}, { historyLimit: 0 })).toThrow(
+      InvalidConfigError,
+    );
+    expect(() => applyPatch({}, { historyLimit: 2.5 })).toThrow(
+      InvalidConfigError,
+    );
+    expect(() => applyPatch({}, { languages: [' '] })).toThrow(
+      InvalidConfigError,
+    );
+    expect(() =>
+      applyPatch({}, { rules: [{ from: 'src/**', to: '', enforced: true }] }),
+    ).toThrow(InvalidConfigError);
+  });
+
+  it('does not touch what it was given', () => {
+    const before = { ...stored };
+
+    applyPatch(stored, { rev: 'develop' });
+
+    expect(stored).toEqual(before);
+  });
+});

--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -1,0 +1,36 @@
+import type { ProjectConfig } from './types.js';
+
+/**
+ * What a project analyses before anyone configures it: the checked-out
+ * revision, the whole history, the whole repository, every registered plugin.
+ * Exactly the behaviour `POST /analyze {root}` had before there was a config.
+ */
+export const DEFAULT_PROJECT_CONFIG: ProjectConfig = {
+  rev: 'HEAD',
+  historyLimit: null,
+  ignore: [],
+  paths: [],
+  languages: null,
+  metrics: null,
+  convention: null,
+  rules: [],
+};
+
+/**
+ * Fill a stored (sparse) config out to a whole one. Arrays are copied, so a
+ * caller cannot mutate the defaults through the value it gets back.
+ */
+export function withDefaults(stored: Partial<ProjectConfig>): ProjectConfig {
+  return {
+    rev: stored.rev ?? DEFAULT_PROJECT_CONFIG.rev,
+    historyLimit: stored.historyLimit ?? DEFAULT_PROJECT_CONFIG.historyLimit,
+    ignore: [...(stored.ignore ?? DEFAULT_PROJECT_CONFIG.ignore)],
+    paths: [...(stored.paths ?? DEFAULT_PROJECT_CONFIG.paths)],
+    languages: stored.languages ? [...stored.languages] : null,
+    metrics: stored.metrics ? [...stored.metrics] : null,
+    convention: stored.convention ?? DEFAULT_PROJECT_CONFIG.convention,
+    rules: (stored.rules ?? DEFAULT_PROJECT_CONFIG.rules).map((r) => ({
+      ...r,
+    })),
+  };
+}

--- a/packages/core/src/config/errors.ts
+++ b/packages/core/src/config/errors.ts
@@ -1,0 +1,10 @@
+/**
+ * A patch that cannot be stored as written. Separate from any other failure so
+ * the HTTP layer can answer 400 with the reason, rather than 500 with none.
+ */
+export class InvalidConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidConfigError';
+  }
+}

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Project-scoped configuration — what the *Project settings* screens edit and
+ * what an analysis of a project reads. Stored sparsely by the project store
+ * (see `projects/`), merged with `DEFAULT_PROJECT_CONFIG` on the way out.
+ */
+export * from './types.js';
+export * from './defaults.js';
+export * from './patch.js';
+export * from './errors.js';

--- a/packages/core/src/config/patch.ts
+++ b/packages/core/src/config/patch.ts
@@ -1,0 +1,86 @@
+import { InvalidConfigError } from './errors.js';
+import type {
+  ArchitectureRule,
+  ProjectConfig,
+  ProjectConfigPatch,
+} from './types.js';
+
+/**
+ * Merge a patch into a stored config and hand back the new stored value —
+ * still sparse, so untouched fields keep following the defaults.
+ *
+ * Everything is normalised on the way in (trimmed, blanks dropped, duplicates
+ * collapsed) and refused when it cannot mean anything: a settings screen that
+ * posts an empty glob row should not turn into a rule nobody can read back.
+ */
+export function applyPatch(
+  stored: Partial<ProjectConfig>,
+  patch: ProjectConfigPatch,
+): Partial<ProjectConfig> {
+  const next: Partial<ProjectConfig> = { ...stored };
+
+  if (patch.rev !== undefined) next.rev = required(patch.rev, 'revision');
+  if (patch.historyLimit !== undefined) {
+    next.historyLimit = historyLimit(patch.historyLimit);
+  }
+  if (patch.ignore !== undefined) next.ignore = list(patch.ignore);
+  if (patch.paths !== undefined) next.paths = list(patch.paths);
+  if (patch.languages !== undefined) {
+    next.languages = ids(patch.languages, 'language plugin');
+  }
+  if (patch.metrics !== undefined) {
+    next.metrics = ids(patch.metrics, 'git metric plugin');
+  }
+  if (patch.convention !== undefined) {
+    next.convention = patch.convention === null
+      ? null
+      : required(patch.convention, 'commit convention');
+  }
+  if (patch.rules !== undefined) next.rules = patch.rules.map(rule);
+
+  return next;
+}
+
+function required(value: string, field: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) throw new InvalidConfigError(`The ${field} cannot be blank.`);
+  return trimmed;
+}
+
+function historyLimit(value: number | null): number | null {
+  if (value === null) return null;
+  if (!Number.isInteger(value) || value < 1) {
+    throw new InvalidConfigError(
+      'The history limit must be a whole number of commits, at least 1 — ' +
+        'use null for the whole history.',
+    );
+  }
+  return value;
+}
+
+/** Blank entries are what an empty row in an editable chip list looks like. */
+function list(values: string[]): string[] {
+  return unique(values.map((v) => v.trim()).filter(Boolean));
+}
+
+function ids(values: string[] | null, field: string): string[] | null {
+  if (values === null) return null;
+  return unique(values.map((v) => required(v, field)));
+}
+
+function unique(values: string[]): string[] {
+  const seen = new Set<string>();
+  return values.filter((v) => {
+    if (seen.has(v)) return false;
+    seen.add(v);
+    return true;
+  });
+}
+
+function rule(value: ArchitectureRule): ArchitectureRule {
+  return {
+    from: required(value.from, 'rule source'),
+    to: required(value.to, 'rule target'),
+    enforced: value.enforced ?? false,
+  };
+}

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -1,0 +1,55 @@
+/** One architecture fitness rule: `from` may not import `to`. */
+export interface ArchitectureRule {
+  /** Path glob the rule constrains, e.g. `src/ui/**`. */
+  from: string;
+  /** Path glob it may not reach, e.g. `src/db/**`. */
+  to: string;
+  /**
+   * Enforced rules are meant to fail a CI gate; the rest only report. A new
+   * rule reports until it is marked enforced — turning a build red is a
+   * decision, not a side effect of writing the rule down.
+   */
+  enforced: boolean;
+}
+
+/**
+ * Everything the *Project settings* screens configure about one project's
+ * analyses. Identity (id, display name, root) belongs to the registry entry
+ * itself, not here: this is what an analysis of that repository *does*.
+ *
+ * Stored sparsely — only what was explicitly set — and merged with the
+ * defaults on read, so a default that changes in a later release reaches every
+ * project that never overrode it.
+ */
+export interface ProjectConfig {
+  /** Revision to analyse. `HEAD` by default. */
+  rev: string;
+  /** Cap on the history window, in commits; `null` for the whole history. */
+  historyLimit: number | null;
+  /** Globs excluded from the analysis. */
+  ignore: string[];
+  /** Repo-relative paths to analyse; empty means the whole repository. */
+  paths: string[];
+  /**
+   * Ids of the `language` plugins that may run, or `null` for every registered
+   * one. An explicit list is an allow-list: a plugin installed later is not in
+   * it until it is added.
+   */
+  languages: string[] | null;
+  /** Ids of the `git-metric` plugins that may run, or `null` for all of them. */
+  metrics: string[] | null;
+  /**
+   * Id of the `commit-convention` plugin to parse commits with, or `null` to
+   * take the first registered one (what the core does today).
+   */
+  convention: string | null;
+  /** Architecture rules to check. */
+  rules: ArchitectureRule[];
+}
+
+/**
+ * A partial update. Every field is replaced whole — an array field is the new
+ * list, not an addition to the old one — so an editor that renders the current
+ * config can send back exactly what it shows.
+ */
+export type ProjectConfigPatch = Partial<ProjectConfig>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,5 +43,14 @@ export {
   type ProjectInput,
   type ProjectStore,
   type ProjectStoreOptions,
+  type ProjectUpdate,
 } from './projects/index.js';
+export {
+  DEFAULT_PROJECT_CONFIG,
+  withDefaults,
+  InvalidConfigError,
+  type ArchitectureRule,
+  type ProjectConfig,
+  type ProjectConfigPatch,
+} from './config/index.js';
 export * as gitUtil from './git/index.js';

--- a/packages/core/src/projects/input.ts
+++ b/packages/core/src/projects/input.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'node:path';
-import type { ProjectInput } from './types.js';
+import type { Project, ProjectInput, ProjectUpdate } from './types.js';
 
 /**
  * Normalise what a caller asked to register: trim the display name, and make
@@ -12,4 +12,19 @@ export function normalizeInput(input: ProjectInput): ProjectInput {
   if (!name) throw new Error('A project needs a display name.');
   if (!root) throw new Error('A project needs a repository root.');
   return { name, root: resolve(root) };
+}
+
+/**
+ * The same rules for a change to an existing project: a field left out keeps
+ * what the project already has, and one that is present has to mean something
+ * — `{"name": "  "}` is a mistake, not a request to clear the name.
+ */
+export function normalizeUpdate(
+  current: Project,
+  changes: ProjectUpdate,
+): ProjectInput {
+  return normalizeInput({
+    name: changes.name ?? current.name,
+    root: changes.root ?? current.root,
+  });
 }

--- a/packages/core/src/projects/memory.ts
+++ b/packages/core/src/projects/memory.ts
@@ -1,12 +1,19 @@
 import { resolve } from 'node:path';
+import {
+  applyPatch,
+  withDefaults,
+  type ProjectConfig,
+  type ProjectConfigPatch,
+} from '../config/index.js';
 import { DuplicateRootError } from './errors.js';
 import { projectId } from './id.js';
-import { normalizeInput } from './input.js';
+import { normalizeInput, normalizeUpdate } from './input.js';
 import type {
   Project,
   ProjectAnalysis,
   ProjectInput,
   ProjectStore,
+  ProjectUpdate,
 } from './types.js';
 
 /**
@@ -19,6 +26,7 @@ import type {
  */
 export function memoryProjectStore(): ProjectStore {
   const projects = new Map<string, Project>();
+  const configs = new Map<string, Partial<ProjectConfig>>();
 
   const findByRoot = (root: string): Project | undefined => {
     const target = resolve(root);
@@ -45,6 +53,20 @@ export function memoryProjectStore(): ProjectStore {
       projects.set(project.id, project);
       return project;
     },
+    update(id: string, changes: ProjectUpdate): Project | undefined {
+      const current = projects.get(id);
+      if (!current) return undefined;
+
+      const { name, root } = normalizeUpdate(current, changes);
+      const holder = findByRoot(root);
+      if (holder && holder.id !== id) {
+        throw new DuplicateRootError(root, holder);
+      }
+
+      const updated = { ...current, name, root };
+      projects.set(id, updated);
+      return updated;
+    },
     recordAnalysis(id: string, analysis: ProjectAnalysis): Project | undefined {
       const project = projects.get(id);
       if (!project) return undefined;
@@ -52,7 +74,23 @@ export function memoryProjectStore(): ProjectStore {
       projects.set(id, updated);
       return updated;
     },
-    remove: (id) => projects.delete(id),
+    config(id: string): ProjectConfig | undefined {
+      if (!projects.has(id)) return undefined;
+      return withDefaults(configs.get(id) ?? {});
+    },
+    setConfig(
+      id: string,
+      patch: ProjectConfigPatch,
+    ): ProjectConfig | undefined {
+      if (!projects.has(id)) return undefined;
+      const stored = applyPatch(configs.get(id) ?? {}, patch);
+      configs.set(id, stored);
+      return withDefaults(stored);
+    },
+    remove(id) {
+      configs.delete(id);
+      return projects.delete(id);
+    },
     close: () => {},
   };
 }

--- a/packages/core/src/projects/projects.test.ts
+++ b/packages/core/src/projects/projects.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { DEFAULT_PROJECT_CONFIG } from '../config/index.js';
 import {
   DuplicateRootError,
   memoryProjectStore,
@@ -120,6 +121,83 @@ describe('project store', () => {
     store.close();
   });
 
+  it('renames and re-points a project without changing its id', () => {
+    const store = openProjectStore({ dir });
+    const { id } = store.add({ name: 'Strata', root: '/repos/strata' });
+
+    const renamed = store.update(id, { name: 'The workbench' });
+    expect(renamed).toMatchObject({
+      id: 'strata',
+      name: 'The workbench',
+      root: resolve('/repos/strata'),
+    });
+
+    const moved = store.update(id, { root: '/repos/moved' });
+    expect(moved?.root).toBe(resolve('/repos/moved'));
+    expect(store.findByRoot('/repos/moved')?.id).toBe(id);
+    expect(store.findByRoot('/repos/strata')).toBeUndefined();
+    store.close();
+  });
+
+  it('will not move a project onto a root another one holds', () => {
+    const store = openProjectStore({ dir });
+    store.add({ name: 'Strata', root: '/repos/strata' });
+    const other = store.add({ name: 'Other', root: '/repos/other' });
+
+    expect(() => store.update(other.id, { root: '/repos/strata' })).toThrow(
+      DuplicateRootError,
+    );
+    // Its own root is not a clash with itself.
+    expect(store.update(other.id, { root: '/repos/other' })?.id).toBe(other.id);
+    expect(store.update('ghost', { name: 'Nobody' })).toBeUndefined();
+    store.close();
+  });
+
+  it('keeps the settings that were set, and defaults the rest', () => {
+    const store = openProjectStore({ dir });
+    const { id } = store.add({ name: 'Strata', root: '/repos/strata' });
+
+    expect(store.config(id)).toEqual(DEFAULT_PROJECT_CONFIG);
+
+    const saved = store.setConfig(id, { rev: 'main', historyLimit: 500 });
+    expect(saved).toMatchObject({ rev: 'main', historyLimit: 500, paths: [] });
+    store.close();
+
+    const reopened = openProjectStore({ dir });
+    expect(reopened.config(id)).toMatchObject({
+      rev: 'main',
+      historyLimit: 500,
+    });
+    // A later patch merges into what is stored rather than replacing it.
+    expect(reopened.setConfig(id, { paths: ['src'] })).toMatchObject({
+      rev: 'main',
+      historyLimit: 500,
+      paths: ['src'],
+    });
+    reopened.close();
+  });
+
+  it('has no settings for a project it does not hold', () => {
+    const store = openProjectStore({ dir });
+
+    expect(store.config('ghost')).toBeUndefined();
+    expect(store.setConfig('ghost', { rev: 'main' })).toBeUndefined();
+    store.close();
+  });
+
+  it('drops the settings with the project, so a reused id starts clean', () => {
+    const store = openProjectStore({ dir });
+    const { id } = store.add({ name: 'Strata', root: '/repos/strata' });
+    store.setConfig(id, { rev: 'main' });
+
+    store.remove(id);
+    const again = store.add({ name: 'Strata', root: '/repos/strata' });
+
+    expect(again.id).toBe(id);
+    expect(store.config(id)).toEqual(DEFAULT_PROJECT_CONFIG);
+    store.close();
+  });
+
   it('lists projects in registration order', () => {
     const store = openProjectStore({ dir });
     store.add({ name: 'Zulu', root: '/repos/z' });
@@ -158,8 +236,17 @@ describe('memory project store', () => {
     expect(() =>
       store.add({ name: 'Twice', root: '/repos/strata' }),
     ).toThrow(DuplicateRootError);
+    expect(store.update(project.id, { name: 'Renamed' })).toMatchObject({
+      id: project.id,
+      name: 'Renamed',
+    });
+    expect(store.config(project.id)).toEqual(DEFAULT_PROJECT_CONFIG);
+    expect(store.setConfig(project.id, { rev: 'main' })).toMatchObject({
+      rev: 'main',
+    });
     expect(store.remove(project.id)).toBe(true);
     expect(store.list()).toEqual([]);
+    expect(store.config(project.id)).toBeUndefined();
   });
 });
 

--- a/packages/core/src/projects/schema.ts
+++ b/packages/core/src/projects/schema.ts
@@ -4,7 +4,7 @@ import type { DatabaseSync } from 'node:sqlite';
  * Bump when the table layout changes — and write the migration. Unlike the
  * cache, this file holds data nobody can recompute, so a mismatch never wipes.
  */
-export const SCHEMA_VERSION = 1;
+export const SCHEMA_VERSION = 2;
 
 const TABLES = `
 CREATE TABLE IF NOT EXISTS projects (
@@ -18,6 +18,14 @@ CREATE TABLE IF NOT EXISTS projects (
   -- The last run's summary as JSON, or NULL until this project is analysed.
   last_analysis TEXT
 ) WITHOUT ROWID;
+
+-- Schema 2. One row per configured project, holding only the settings that
+-- were explicitly set: defaults are applied on read, so a default that moves
+-- in a later release reaches every project that never overrode it.
+CREATE TABLE IF NOT EXISTS project_config (
+  project_id TEXT PRIMARY KEY,
+  value      TEXT NOT NULL
+) WITHOUT ROWID;
 `;
 
 /** Pragmas for a small, durable, occasionally-shared file. */
@@ -30,6 +38,10 @@ export function configure(db: DatabaseSync): void {
 
 /**
  * Create the tables and stamp the schema version.
+ *
+ * Every version so far only *adds* tables, so an older file needs nothing but
+ * the `CREATE TABLE IF NOT EXISTS` run and a new stamp; a version that changes
+ * an existing table has to bring its own `ALTER`s here.
  *
  * A file written by a *newer* Strata is left untouched and reported: opening it
  * with this build's expectations would either fail confusingly or quietly drop

--- a/packages/core/src/projects/sqlite.ts
+++ b/packages/core/src/projects/sqlite.ts
@@ -1,15 +1,22 @@
 import { mkdirSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { DatabaseSync, type StatementSync } from 'node:sqlite';
+import {
+  applyPatch,
+  withDefaults,
+  type ProjectConfig,
+  type ProjectConfigPatch,
+} from '../config/index.js';
 import { DuplicateRootError } from './errors.js';
 import { projectId } from './id.js';
-import { normalizeInput } from './input.js';
+import { normalizeInput, normalizeUpdate } from './input.js';
 import { configure, migrate } from './schema.js';
 import type {
   Project,
   ProjectAnalysis,
   ProjectInput,
   ProjectStore,
+  ProjectUpdate,
 } from './types.js';
 
 /** One row of `projects`, as SQLite hands it back. */
@@ -40,8 +47,12 @@ export class SqliteProjectStore implements ProjectStore {
   private readonly selectById: StatementSync;
   private readonly selectByRoot: StatementSync;
   private readonly insert: StatementSync;
+  private readonly updateIdentity: StatementSync;
   private readonly updateAnalysis: StatementSync;
   private readonly deleteById: StatementSync;
+  private readonly selectConfig: StatementSync;
+  private readonly upsertConfig: StatementSync;
+  private readonly deleteConfig: StatementSync;
 
   constructor(path: string) {
     this.path = resolve(path);
@@ -62,10 +73,23 @@ export class SqliteProjectStore implements ProjectStore {
       `INSERT INTO projects (id, name, root, added_at, seq, last_analysis)
        VALUES (?, ?, ?, ?, (SELECT IFNULL(MAX(seq), 0) + 1 FROM projects), ?)`,
     );
+    this.updateIdentity = this.db.prepare(
+      'UPDATE projects SET name = ?, root = ? WHERE id = ?',
+    );
     this.updateAnalysis = this.db.prepare(
       'UPDATE projects SET last_analysis = ? WHERE id = ?',
     );
     this.deleteById = this.db.prepare('DELETE FROM projects WHERE id = ?');
+    this.selectConfig = this.db.prepare(
+      'SELECT value FROM project_config WHERE project_id = ?',
+    );
+    this.upsertConfig = this.db.prepare(
+      `INSERT INTO project_config (project_id, value) VALUES (?, ?)
+       ON CONFLICT (project_id) DO UPDATE SET value = excluded.value`,
+    );
+    this.deleteConfig = this.db.prepare(
+      'DELETE FROM project_config WHERE project_id = ?',
+    );
   }
 
   list(): Project[] {
@@ -109,14 +133,62 @@ export class SqliteProjectStore implements ProjectStore {
     return project;
   }
 
+  update(id: string, changes: ProjectUpdate): Project | undefined {
+    const current = this.get(id);
+    if (!current) return undefined;
+
+    const { name, root } = normalizeUpdate(current, changes);
+    const holder = this.findByRoot(root);
+    if (holder && holder.id !== id) throw new DuplicateRootError(root, holder);
+
+    this.updateIdentity.run(name, root, id);
+    return this.get(id);
+  }
+
   recordAnalysis(id: string, analysis: ProjectAnalysis): Project | undefined {
     if (!this.get(id)) return undefined;
     this.updateAnalysis.run(JSON.stringify(analysis), id);
     return this.get(id);
   }
 
+  config(id: string): ProjectConfig | undefined {
+    if (!this.get(id)) return undefined;
+    return withDefaults(this.storedConfig(id));
+  }
+
+  setConfig(id: string, patch: ProjectConfigPatch): ProjectConfig | undefined {
+    if (!this.get(id)) return undefined;
+    const stored = applyPatch(this.storedConfig(id), patch);
+    this.upsertConfig.run(id, JSON.stringify(stored));
+    return withDefaults(stored);
+  }
+
   remove(id: string): boolean {
-    return Number(this.deleteById.run(id).changes) > 0;
+    // The settings go with the project: an id can be handed out again, and
+    // reusing one must not resurrect the last holder's configuration.
+    this.db.exec('BEGIN IMMEDIATE');
+    try {
+      const removed = Number(this.deleteById.run(id).changes) > 0;
+      this.deleteConfig.run(id);
+      this.db.exec('COMMIT');
+      return removed;
+    } catch (err) {
+      this.db.exec('ROLLBACK');
+      throw err;
+    }
+  }
+
+  /** Only what was explicitly set; the defaults are applied on the way out. */
+  private storedConfig(id: string): Partial<ProjectConfig> {
+    const row = this.selectConfig.get(id) as { value: string } | undefined;
+    if (row === undefined) return {};
+    try {
+      return JSON.parse(row.value) as Partial<ProjectConfig>;
+    } catch {
+      // Unreadable settings fall back to the defaults rather than failing the
+      // screen that reads them; the next PATCH overwrites the bad row.
+      return {};
+    }
   }
 
   close(): void {

--- a/packages/core/src/projects/types.ts
+++ b/packages/core/src/projects/types.ts
@@ -1,4 +1,5 @@
 import type { Logger } from '@strata/sdk';
+import type { ProjectConfig, ProjectConfigPatch } from '../config/index.js';
 import type { RunReport } from '../types.js';
 
 /**
@@ -27,6 +28,16 @@ export interface Project {
 export interface ProjectInput {
   name: string;
   root: string;
+}
+
+/**
+ * What can be changed about a registered project *after* it is registered —
+ * its identity, not its settings. The id is not in here: it is what links to
+ * this project point at, and a rename must not break them.
+ */
+export interface ProjectUpdate {
+  name?: string;
+  root?: string;
 }
 
 export interface ProjectStoreOptions {
@@ -62,9 +73,27 @@ export interface ProjectStore {
    * registered, and `Error` if name or root is blank.
    */
   add(input: ProjectInput): Project;
+  /**
+   * Rename a project or point it at another root; `undefined` if the id is
+   * unknown. Throws `DuplicateRootError` if another project holds the new root.
+   */
+  update(id: string, changes: ProjectUpdate): Project | undefined;
   /** Store the summary of a finished run; `undefined` if the id is unknown. */
   recordAnalysis(id: string, analysis: ProjectAnalysis): Project | undefined;
-  /** Drop the entry. Never touches the repository on disk. */
+  /**
+   * This project's settings, filled out with the defaults; `undefined` if the
+   * id is unknown.
+   */
+  config(id: string): ProjectConfig | undefined;
+  /**
+   * Merge a patch into this project's settings and return the result;
+   * `undefined` if the id is unknown. Throws `InvalidConfigError` on a value
+   * that cannot be stored as written.
+   */
+  setConfig(id: string, patch: ProjectConfigPatch): ProjectConfig | undefined;
+  /**
+   * Drop the entry and its settings. Never touches the repository on disk.
+   */
   remove(id: string): boolean;
   close(): void;
 }

--- a/packages/server/ARCHITECTURE.md
+++ b/packages/server/ARCHITECTURE.md
@@ -29,8 +29,11 @@ UI and CI. Keeps transport concerns out of the core.
 | GET | `/projects` | `{ projects }` — the registry, in registration order; each entry carries its id, display name, root and last-analysis summary. |
 | POST | `/projects` | Body `{ name, root }` → the created `Project` (201). The root is resolved to the repository that owns it; 400 if it owns none, 409 if that repository is already registered. |
 | GET | `/projects/:id` | One project, or 404. |
-| DELETE | `/projects/:id` | Drop the entry (`{ removed: true }`), or 404. Never touches the repository on disk. |
-| POST | `/analyze` | Body `{ root, rev?, historyLimit?, cache? }` → `AnalysisReport` (incl. run metadata and cache stats). A run over a registered root also updates that project's last-analysis summary. |
+| PATCH | `/projects/:id` | Body `{ name?, root? }` → the updated `Project`. Identity only; same root resolution and 409 as `POST`. |
+| DELETE | `/projects/:id` | Drop the entry and its config (`{ removed: true }`), or 404. Never touches the repository on disk. |
+| GET | `/projects/:id/config` | That project's settings, filled out with the defaults. |
+| PATCH | `/projects/:id/config` | Body: any of `rev`, `historyLimit`, `ignore`, `paths`, `languages`, `metrics`, `convention`, `rules` → the whole config. Merges by field; an array replaces. 400 on a value that cannot be stored or a plugin id nobody loaded. |
+| POST | `/analyze` | Body `{ root, rev?, historyLimit?, cache? }` → `AnalysisReport` (incl. run metadata and cache stats). Over a registered root, the project's config supplies the defaults and the run updates its last-analysis summary. |
 | DELETE | `/cache` | Empty the incremental cache. Registered projects are untouched — they live in their own database. |
 
 ## 4. Building Blocks
@@ -41,8 +44,10 @@ UI and CI. Keeps transport concerns out of the core.
 | `app.ts` | `createServer()` — plugin registry, one `Strata`, one project store, routes, shutdown hook. |
 | `main.ts` | Process entry point (`node dist/main.js`). |
 | `registry.ts` | `buildRegistry()` — load the built-ins, then the user plugins directory. |
-| `routes/health.ts` … `routes/projects.ts` | One module per endpoint. |
+| `routes/health.ts` … `routes/project-config.ts` | One module per endpoint. |
 | `routes/http-error.ts` | `httpError(status, message)` — a thrown error Fastify serialises in its own error shape. |
+| `routes/patch.ts` | `requirePatch()` — refuse a PATCH that changes nothing. |
+| `routes/plugin-ids.ts` | `requireKnownPlugins()` — refuse settings naming a plugin nobody loaded. |
 | `routes/index.ts` | `registerRoutes()` + the `RouteContext` they share. |
 
 ## 5. Runtime
@@ -69,6 +74,17 @@ once at startup, as does opening the registry.
   click through the UI keep the same entry current. A registry that will not
   take the update is logged, never raised: the caller already paid for the
   report.
+- **A project's config is the default for a run over it**, not a constraint on
+  it: `/analyze` fills in `rev` and `historyLimit` from the settings and lets an
+  explicit request field win, so *Re-analyze* follows *Project settings* while a
+  CI job asking for a revision still gets that revision.
+- **Settings are two resources, split by who can promise what** — `/projects/:id`
+  owns identity (the root has to stay unique across projects), `/projects/:id/config`
+  owns what an analysis does. One PATCH each, merging by field.
+- **Plugin selections are checked against the registry as they are written** —
+  the screens only offer loaded plugins, so an id that is not one is a typo or a
+  stale client, and stored silently it would look like a plugin that is switched
+  on but never runs.
 - **Registering a project resolves the path through git**, so a path that is no
   repository is a 400 at *Add project* rather than a failure at the first
   analysis, and a subdirectory registers the repository that owns it instead of

--- a/packages/server/src/routes/analyze.test.ts
+++ b/packages/server/src/routes/analyze.test.ts
@@ -2,6 +2,7 @@ import Fastify, { type FastifyInstance } from 'fastify';
 import {
   memoryProjectStore,
   type AnalysisReport,
+  type AnalyzeOptions,
   type PluginRegistry,
   type ProjectStore,
   type Strata,
@@ -36,7 +37,15 @@ const report = {
   },
 } satisfies AnalysisReport;
 
-const strata = { analyze: async () => report } as unknown as Strata;
+/** What the route asked the core for, so the defaults can be asserted. */
+let requested: AnalyzeOptions | undefined;
+
+const strata = {
+  analyze: async (opts: AnalyzeOptions) => {
+    requested = opts;
+    return report;
+  },
+} as unknown as Strata;
 
 let projects: ProjectStore;
 let app: FastifyInstance;
@@ -51,15 +60,16 @@ function build(store: ProjectStore): FastifyInstance {
   return instance;
 }
 
-async function analyze(root: string) {
+async function analyze(root: string, body: Record<string, unknown> = {}) {
   return await app.inject({
     method: 'POST',
     url: '/analyze',
-    payload: { root },
+    payload: { root, ...body },
   });
 }
 
 beforeEach(() => {
+  requested = undefined;
   projects = memoryProjectStore();
   app = build(projects);
 });
@@ -79,6 +89,34 @@ describe('POST /analyze', () => {
       rev: report.rev,
       ...report.run,
     });
+  });
+
+  it('runs a registered project the way its settings say', async () => {
+    const { id } = projects.add({ name: 'Strata', root: '/repos/strata' });
+    projects.setConfig(id, { rev: 'develop', historyLimit: 500 });
+
+    await analyze('/repos/strata');
+
+    expect(requested).toMatchObject({ rev: 'develop', historyLimit: 500 });
+  });
+
+  it('lets the request override what the settings say', async () => {
+    const { id } = projects.add({ name: 'Strata', root: '/repos/strata' });
+    projects.setConfig(id, { rev: 'develop', historyLimit: 500 });
+
+    await analyze('/repos/strata', { rev: 'v1.0.0', historyLimit: 10 });
+
+    expect(requested).toMatchObject({ rev: 'v1.0.0', historyLimit: 10 });
+  });
+
+  it('leaves the core its own defaults for an unconfigured project', async () => {
+    projects.add({ name: 'Strata', root: '/repos/strata' });
+
+    await analyze('/repos/strata');
+
+    // `HEAD` and no cap are what the core does anyway; a null limit must not
+    // reach it as a number.
+    expect(requested).toMatchObject({ rev: 'HEAD', historyLimit: undefined });
   });
 
   it('analyses a root nobody registered without recording anything', async () => {

--- a/packages/server/src/routes/analyze.ts
+++ b/packages/server/src/routes/analyze.ts
@@ -1,4 +1,5 @@
 import type { FastifyInstance } from 'fastify';
+import type { Project, ProjectConfig } from '@strata/core';
 import type { RouteContext } from './context.js';
 
 interface AnalyzeBody {
@@ -29,25 +30,54 @@ const schema = {
 export function analyzeRoute(app: FastifyInstance, ctx: RouteContext): void {
   app.post<{ Body: AnalyzeBody }>('/analyze', { schema }, async (req) => {
     const { root, rev, historyLimit, cache } = req.body;
-    const report = await ctx.strata.analyze({ root, rev, historyLimit, cache });
+
+    // A registered project's settings are the defaults for a run over it, so
+    // clicking *Re-analyze* honours what *Project settings* says. What the
+    // request states wins: a CI job asking for a specific revision means it.
+    const { project, config } = registered(ctx, root, req.log);
+    const report = await ctx.strata.analyze({
+      root,
+      rev: rev ?? config?.rev,
+      historyLimit: historyLimit ?? config?.historyLimit ?? undefined,
+      cache,
+    });
 
     // The switcher shows how long ago each project was analysed, so every run
     // over a registered root updates it — whoever asked for the run.
-    try {
-      const project = ctx.projects.findByRoot(root);
-      if (project) {
+    if (project) {
+      try {
         ctx.projects.recordAnalysis(project.id, {
           rev: report.rev,
           ...report.run,
         });
+      } catch (err) {
+        // A registry that cannot be written is worth a line in the log; it is
+        // not worth failing an analysis the caller already paid for.
+        req.log.warn(
+          `could not record the run against the project registry: ${(err as Error).message}`,
+        );
       }
-    } catch (err) {
-      // A registry that cannot be written is worth a line in the log; it is not
-      // worth failing an analysis the caller already paid for.
-      req.log.warn(
-        `could not record the run against the project registry: ${(err as Error).message}`,
-      );
     }
     return report;
   });
+}
+
+/**
+ * The project registered for this root and its settings, if there is one. A
+ * registry that cannot be read costs the run its defaults and its summary —
+ * never the run itself.
+ */
+function registered(
+  ctx: RouteContext,
+  root: string,
+  log: { warn(message: string): void },
+): { project?: Project; config?: ProjectConfig } {
+  try {
+    const project = ctx.projects.findByRoot(root);
+    if (!project) return {};
+    return { project, config: ctx.projects.config(project.id) };
+  } catch (err) {
+    log.warn(`could not read the project registry: ${(err as Error).message}`);
+    return {};
+  }
 }

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -3,6 +3,7 @@ import { analyzeRoute } from './analyze.js';
 import { cacheRoute } from './cache.js';
 import { healthRoute } from './health.js';
 import { pluginsRoute } from './plugins.js';
+import { projectConfigRoute } from './project-config.js';
 import { projectsRoute } from './projects.js';
 import type { RouteContext } from './context.js';
 
@@ -13,6 +14,7 @@ export function registerRoutes(app: FastifyInstance, ctx: RouteContext): void {
   healthRoute(app);
   pluginsRoute(app, ctx);
   projectsRoute(app, ctx);
+  projectConfigRoute(app, ctx);
   analyzeRoute(app, ctx);
   cacheRoute(app, ctx);
 }

--- a/packages/server/src/routes/patch.ts
+++ b/packages/server/src/routes/patch.ts
@@ -1,0 +1,16 @@
+import { httpError } from './http-error.js';
+
+/**
+ * Refuse a PATCH that changes nothing.
+ *
+ * This is a runtime check rather than a `minProperties` schema keyword because
+ * Fastify strips fields the schema does not declare *after* validating: a body
+ * of nothing but misspelled keys passes `minProperties` and then arrives here
+ * empty, which would otherwise read as a successful update of nothing.
+ */
+export function requirePatch<T extends object>(body: T, what: string): T {
+  if (Object.keys(body).length === 0) {
+    throw httpError(400, `Name at least one ${what} to change.`);
+  }
+  return body;
+}

--- a/packages/server/src/routes/plugin-ids.ts
+++ b/packages/server/src/routes/plugin-ids.ts
@@ -1,0 +1,38 @@
+import type { PluginRegistry } from '@strata/core';
+import type { PluginKind } from '@strata/sdk';
+import { httpError } from './http-error.js';
+
+/**
+ * Refuse a settings write that names a plugin this workbench has not loaded.
+ * The screens only ever offer registered plugins, so a name that is not one is
+ * a typo or a stale client — and stored silently it would look like a plugin
+ * that is switched on but never runs.
+ *
+ * `null` (meaning "every registered plugin of this kind") is not a selection
+ * and passes through.
+ */
+export function requireKnownPlugins(
+  registry: PluginRegistry,
+  kind: PluginKind,
+  ids: string[] | string | null | undefined,
+): void {
+  if (ids === null || ids === undefined) return;
+
+  const known = registry.loadedByKind(kind).map((l) => l.manifest.id);
+  const unknown = (Array.isArray(ids) ? ids : [ids]).filter(
+    (id) => !known.includes(id),
+  );
+  if (unknown.length === 0) return;
+
+  throw httpError(
+    400,
+    `Unknown ${kind} plugin: ${unknown.map(quote).join(', ')}. ` +
+      (known.length
+        ? `Registered: ${known.map(quote).join(', ')}.`
+        : `This workbench has no ${kind} plugin loaded.`),
+  );
+}
+
+function quote(id: string): string {
+  return `"${id}"`;
+}

--- a/packages/server/src/routes/project-config.test.ts
+++ b/packages/server/src/routes/project-config.test.ts
@@ -1,0 +1,183 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import Fastify, { type FastifyInstance } from 'fastify';
+import {
+  memoryProjectStore,
+  PluginRegistry,
+  type ProjectStore,
+  type Strata,
+} from '@strata/core';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import { projectConfigRoute } from './project-config.js';
+
+/**
+ * The *Project settings* screens read and write through here. A PATCH merges,
+ * so what a screen leaves out survives; what it names has to exist, so a
+ * plugin toggle cannot store an id that will never run.
+ */
+
+const LANGUAGE_ID = 'test-language';
+
+let projects: ProjectStore;
+let app: FastifyInstance;
+let id: string;
+let pluginDir: string;
+let registry: PluginRegistry;
+
+/** One real registered plugin, so "known" and "unknown" are both testable. */
+beforeAll(async () => {
+  pluginDir = mkdtempSync(join(tmpdir(), 'strata-config-plugin-'));
+  mkdirSync(join(pluginDir, 'dist'), { recursive: true });
+  writeFileSync(
+    join(pluginDir, 'dist/index.mjs'),
+    "export default { kind: 'language', extensions: ['ts'], analyze: async () => ({}) };\n",
+  );
+  writeFileSync(
+    join(pluginDir, 'strata.plugin.json'),
+    JSON.stringify({
+      id: LANGUAGE_ID,
+      name: 'Test language',
+      kind: 'language',
+      version: '1.0.0',
+      sdk: '0.1.0',
+      main: './dist/index.mjs',
+    }),
+  );
+
+  registry = new PluginRegistry({
+    debug() {},
+    info() {},
+    warn() {},
+    error() {},
+  });
+  await registry.loadFrom(join(pluginDir, 'strata.plugin.json'));
+}, 30_000);
+
+afterAll(() => {
+  rmSync(pluginDir, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  projects = memoryProjectStore();
+  id = projects.add({ name: 'Strata', root: '/repos/strata' }).id;
+  app = Fastify();
+  projectConfigRoute(app, { projects, registry, strata: {} as Strata });
+});
+
+afterEach(async () => {
+  await app.close();
+});
+
+function get(project = id) {
+  return app.inject({ url: `/projects/${project}/config` });
+}
+
+async function patch(body: unknown, project = id) {
+  return await app.inject({
+    method: 'PATCH',
+    url: `/projects/${project}/config`,
+    payload: body as Record<string, unknown>,
+  });
+}
+
+describe('GET /projects/:id/config', () => {
+  it('answers with the defaults before anything is configured', async () => {
+    const response = await get();
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      rev: 'HEAD',
+      historyLimit: null,
+      ignore: [],
+      paths: [],
+      languages: null,
+      metrics: null,
+      convention: null,
+      rules: [],
+    });
+  });
+
+  it('answers 404 for a project nobody registered', async () => {
+    expect((await get('ghost')).statusCode).toBe(404);
+  });
+});
+
+describe('PATCH /projects/:id/config', () => {
+  it('merges into what is stored and answers with the whole config', async () => {
+    await patch({ rev: 'main', historyLimit: 500 });
+
+    const response = await patch({ ignore: ['**/dist/**'] });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      rev: 'main',
+      historyLimit: 500,
+      ignore: ['**/dist/**'],
+    });
+    expect((await get()).json()).toMatchObject({ rev: 'main' });
+  });
+
+  it('takes null for "no cap" and "every registered plugin"', async () => {
+    await patch({ historyLimit: 500 });
+
+    const response = await patch({ historyLimit: null, languages: null });
+
+    expect(response.json()).toMatchObject({
+      historyLimit: null,
+      languages: null,
+    });
+  });
+
+  it('stores architecture rules, defaulting a new one to report-only', async () => {
+    const response = await patch({
+      rules: [{ from: 'src/ui/**', to: 'src/db/**' }],
+    });
+
+    expect(response.json().rules).toEqual([
+      { from: 'src/ui/**', to: 'src/db/**', enforced: false },
+    ]);
+  });
+
+  it('stores a plugin selection this workbench can actually run', async () => {
+    const response = await patch({ languages: [LANGUAGE_ID] });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().languages).toEqual([LANGUAGE_ID]);
+  });
+
+  it('refuses a plugin id this workbench has not loaded', async () => {
+    const response = await patch({ languages: ['strata-language-cobol'] });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json().message).toContain('strata-language-cobol');
+    // Nothing of the patch is stored when part of it is refused.
+    expect((await get()).json().languages).toBeNull();
+  });
+
+  it('refuses a metric or convention it does not know either', async () => {
+    expect((await patch({ metrics: [LANGUAGE_ID] })).statusCode).toBe(400);
+    expect((await patch({ convention: 'gitmoji' })).statusCode).toBe(400);
+  });
+
+  it('rejects a value that cannot mean anything', async () => {
+    expect((await patch({ historyLimit: 0 })).statusCode).toBe(400);
+    expect((await patch({ rev: '' })).statusCode).toBe(400);
+    expect((await patch({ rules: [{ from: 'src/**' }] })).statusCode).toBe(400);
+    expect((await patch({ nope: true })).statusCode).toBe(400);
+    // An empty patch is a client bug, not a way to read the config back.
+    expect((await patch({})).statusCode).toBe(400);
+  });
+
+  it('answers 404 for a project nobody registered', async () => {
+    expect((await patch({ rev: 'main' }, 'ghost')).statusCode).toBe(404);
+  });
+});

--- a/packages/server/src/routes/project-config.ts
+++ b/packages/server/src/routes/project-config.ts
@@ -1,0 +1,105 @@
+import type { FastifyInstance } from 'fastify';
+import {
+  InvalidConfigError,
+  type ProjectConfig,
+  type ProjectConfigPatch,
+} from '@strata/core';
+import type { RouteContext } from './context.js';
+import { httpError } from './http-error.js';
+import { requirePatch } from './patch.js';
+import { requireKnownPlugins } from './plugin-ids.js';
+
+interface IdParams {
+  id: string;
+}
+
+const params = {
+  type: 'object',
+  required: ['id'],
+  additionalProperties: false,
+  properties: { id: { type: 'string', minLength: 1 } },
+};
+
+const strings = { type: 'array', items: { type: 'string' } };
+
+const patchSchema = {
+  params,
+  body: {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      rev: { type: 'string', minLength: 1 },
+      historyLimit: { type: ['integer', 'null'], minimum: 1 },
+      ignore: strings,
+      paths: strings,
+      languages: { ...strings, type: ['array', 'null'] },
+      metrics: { ...strings, type: ['array', 'null'] },
+      convention: { type: ['string', 'null'], minLength: 1 },
+      rules: {
+        type: 'array',
+        items: {
+          type: 'object',
+          required: ['from', 'to'],
+          additionalProperties: false,
+          properties: {
+            from: { type: 'string', minLength: 1 },
+            to: { type: 'string', minLength: 1 },
+            enforced: { type: 'boolean', default: false },
+          },
+        },
+      },
+    },
+  },
+};
+
+/**
+ * What an analysis of one project does: revision, history window, scope,
+ * which plugins run, the commit convention and the architecture rules — the
+ * *Project settings* screens, minus identity. Display name and root belong to
+ * the registry entry (`PATCH /projects/:id`), because the root has to stay
+ * unique across projects and this is not the place that can promise that.
+ *
+ * `PATCH` merges: a field left out keeps its value, and one that is sent
+ * replaces it whole (an array is the new list, not an addition to the old).
+ */
+export function projectConfigRoute(
+  app: FastifyInstance,
+  ctx: RouteContext,
+): void {
+  app.get<{ Params: IdParams }>(
+    '/projects/:id/config',
+    { schema: { params } },
+    async (req) => found(ctx.projects.config(req.params.id), req.params.id),
+  );
+
+  app.patch<{ Params: IdParams; Body: ProjectConfigPatch }>(
+    '/projects/:id/config',
+    { schema: patchSchema },
+    async (req) => {
+      const { id } = req.params;
+      // An empty patch is a client bug, not a way to read the config back.
+      requirePatch(req.body, 'setting');
+      requireKnownPlugins(ctx.registry, 'language', req.body.languages);
+      requireKnownPlugins(ctx.registry, 'git-metric', req.body.metrics);
+      requireKnownPlugins(
+        ctx.registry,
+        'commit-convention',
+        req.body.convention,
+      );
+
+      try {
+        return found(ctx.projects.setConfig(id, req.body), id);
+      } catch (err) {
+        if (err instanceof InvalidConfigError) {
+          throw httpError(400, err.message);
+        }
+        throw err;
+      }
+    },
+  );
+}
+
+function found(config: ProjectConfig | undefined, id: string): ProjectConfig {
+  if (!config) throw httpError(404, `No project "${id}".`);
+  return config;
+}

--- a/packages/server/src/routes/projects.test.ts
+++ b/packages/server/src/routes/projects.test.ts
@@ -23,6 +23,7 @@ const exec = promisify(execFile);
  */
 
 let repo: string;
+let other: string;
 let plain: string;
 let projects: ProjectStore;
 let app: FastifyInstance;
@@ -31,13 +32,16 @@ beforeAll(async () => {
   repo = await realpath(mkdtempSync(join(tmpdir(), 'strata-projects-api-')));
   mkdirSync(join(repo, 'src'));
   await exec('git', ['init', '-q'], { cwd: repo });
+  other = await realpath(mkdtempSync(join(tmpdir(), 'strata-other-api-')));
+  await exec('git', ['init', '-q'], { cwd: other });
   plain = await realpath(mkdtempSync(join(tmpdir(), 'strata-plain-api-')));
 }, 30_000);
 
 afterAll(async () => {
   await app.close();
-  rmSync(repo, { recursive: true, force: true });
-  rmSync(plain, { recursive: true, force: true });
+  for (const dir of [repo, other, plain]) {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 beforeEach(async () => {
@@ -136,6 +140,58 @@ describe('GET /projects/:id', () => {
 
     const missing = await app.inject({ url: '/projects/ghost' });
     expect(missing.statusCode).toBe(404);
+  });
+});
+
+describe('PATCH /projects/:id', () => {
+  async function patch(body: Record<string, unknown>, id = 'strata') {
+    return await app.inject({
+      method: 'PATCH',
+      url: `/projects/${id}`,
+      payload: body,
+    });
+  }
+
+  it('renames a project, keeping its id and its root', async () => {
+    await add({ name: 'Strata', root: repo });
+
+    const response = await patch({ name: 'The workbench' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      id: 'strata',
+      name: 'The workbench',
+      root: repo,
+    });
+  });
+
+  it('re-points a project, resolving the new root like a registration', async () => {
+    await add({ name: 'Strata', root: repo });
+
+    const response = await patch({ root: join(repo, 'src') });
+
+    expect(response.json()).toMatchObject({ id: 'strata', root: repo });
+    expect((await patch({ root: plain })).statusCode).toBe(400);
+  });
+
+  it('refuses a root another project already holds', async () => {
+    await add({ name: 'Strata', root: repo });
+    await add({ name: 'Other', root: other });
+
+    const response = await patch({ root: repo }, 'other');
+
+    expect(response.statusCode).toBe(409);
+    expect(projects.get('other')?.root).toBe(other);
+  });
+
+  it('rejects a change that changes nothing, and 404s an unknown id', async () => {
+    await add({ name: 'Strata', root: repo });
+
+    expect((await patch({})).statusCode).toBe(400);
+    expect((await patch({ name: '' })).statusCode).toBe(400);
+    // Fastify strips undeclared fields, so a misspelled one patches nothing.
+    expect((await patch({ nmae: 'Typo' })).statusCode).toBe(400);
+    expect((await patch({ name: 'Ghost' }, 'ghost')).statusCode).toBe(404);
   });
 });
 

--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -2,41 +2,62 @@ import type { FastifyInstance } from 'fastify';
 import { DuplicateRootError, gitUtil, type Project } from '@strata/core';
 import type { RouteContext } from './context.js';
 import { httpError } from './http-error.js';
+import { requirePatch } from './patch.js';
 
 interface AddBody {
   name: string;
   root: string;
 }
 
+interface UpdateBody {
+  name?: string;
+  root?: string;
+}
+
 interface IdParams {
   id: string;
 }
+
+const identity = {
+  name: { type: 'string', minLength: 1, maxLength: 100 },
+  root: { type: 'string', minLength: 1 },
+};
 
 const addSchema = {
   body: {
     type: 'object',
     required: ['name', 'root'],
     additionalProperties: false,
-    properties: {
-      name: { type: 'string', minLength: 1, maxLength: 100 },
-      root: { type: 'string', minLength: 1 },
-    },
+    properties: identity,
   },
 };
 
-const idSchema = {
-  params: {
+const idParams = {
+  type: 'object',
+  required: ['id'],
+  additionalProperties: false,
+  properties: { id: { type: 'string', minLength: 1 } },
+};
+
+const idSchema = { params: idParams };
+
+const updateSchema = {
+  params: idParams,
+  body: {
     type: 'object',
-    required: ['id'],
     additionalProperties: false,
-    properties: { id: { type: 'string', minLength: 1 } },
+    properties: identity,
   },
 };
 
 /**
  * The project registry: what the sidebar switcher lists, what *Add project*
- * writes, and what *Danger zone → Remove project* drops. Removing an entry is
- * a registry operation only — the repository on disk is never touched.
+ * writes, what *Project settings → General* renames or re-points, and what
+ * *Danger zone → Remove project* drops. Removing an entry is a registry
+ * operation only — the repository on disk is never touched.
+ *
+ * Identity only. What an analysis of a project *does* is its config, one level
+ * down at `/projects/:id/config`.
  */
 export function projectsRoute(app: FastifyInstance, ctx: RouteContext): void {
   app.get('/projects', async () => ({ projects: ctx.projects.list() }));
@@ -51,20 +72,35 @@ export function projectsRoute(app: FastifyInstance, ctx: RouteContext): void {
     '/projects',
     { schema: addSchema },
     async (req, reply) => {
-      // Store the repository, not the path that was typed: a subdirectory
-      // analyses the whole repo anyway, so it would register a second entry
-      // for a project that is already there.
-      const root = await gitUtil.toplevel(req.body.root);
-      if (root === null) {
-        throw httpError(
-          400,
-          `${req.body.root} is not inside a git repository.`,
-        );
-      }
+      const root = await repoRoot(req.body.root);
       try {
         const project = ctx.projects.add({ name: req.body.name, root });
         reply.code(201);
         return project;
+      } catch (err) {
+        if (err instanceof DuplicateRootError) {
+          throw httpError(409, err.message);
+        }
+        throw err;
+      }
+    },
+  );
+
+  app.patch<{ Params: IdParams; Body: UpdateBody }>(
+    '/projects/:id',
+    { schema: updateSchema },
+    async (req) => {
+      const { id } = req.params;
+      requirePatch(req.body, 'field');
+      // A new root is resolved exactly like a registered one, so re-pointing a
+      // project cannot store something *Add project* would have refused.
+      const root =
+        req.body.root === undefined
+          ? undefined
+          : await repoRoot(req.body.root);
+      try {
+        const update = { name: req.body.name, root };
+        return found(ctx.projects.update(id, update), id);
       } catch (err) {
         if (err instanceof DuplicateRootError) {
           throw httpError(409, err.message);
@@ -84,6 +120,19 @@ export function projectsRoute(app: FastifyInstance, ctx: RouteContext): void {
       return { removed: true };
     },
   );
+}
+
+/**
+ * Store the repository, not the path that was typed: a subdirectory analyses
+ * the whole repo anyway, so it would register a second entry for a project
+ * that is already there.
+ */
+async function repoRoot(path: string): Promise<string> {
+  const root = await gitUtil.toplevel(path);
+  if (root === null) {
+    throw httpError(400, `${path} is not inside a git repository.`);
+  }
+  return root;
 }
 
 function found(project: Project | undefined, id: string): Project {


### PR DESCRIPTION
## What

Project-scoped settings, stored beside the registry entry and served over the API:

| Method | Path | |
|---|---|---|
| GET | `/projects/:id/config` | the settings, filled out with the defaults |
| PATCH | `/projects/:id/config` | any of `rev`, `historyLimit`, `ignore`, `paths`, `languages`, `metrics`, `convention`, `rules` |
| PATCH | `/projects/:id` | `{ name?, root? }` — rename or re-point, same root resolution and 409 as registering |

- **Identity and configuration are separate resources.** A root has to stay
  unique across projects and only the registry can promise that, so display name
  and root stay on `/projects/:id`; everything about what a run *does* is config.
- **Stored sparsely, defaulted on read** — a default that moves in a later
  release reaches every project that never overrode it, and "never set" stays
  distinguishable from "set to today's default". `PATCH` merges by field and
  replaces an array whole, so an editor can send back what it renders.
- **`/analyze` uses the settings as defaults** for `rev` and `historyLimit`, and
  an explicit request field still wins — *Re-analyze* follows *Project settings*
  while a CI job asking for a revision gets that revision.
- **A plugin id nobody loaded is refused** as it is written, listing what is
  registered. Stored silently it would look like a plugin that is switched on but
  never runs.
- Deleting a project deletes its settings, so an id handed out again never
  inherits the last holder's config. Registry schema goes to v2 (additive; an
  existing `projects.db` is migrated in place).

**Scope note:** `ignore`, `paths`, `languages`, `metrics` and `convention` are
stored and served but not yet read by the pipeline — wiring them into
`Strata.analyze` is real work in the core (file routing, plugin selection), and
`BACKLOG.md` now carries it as the next P0 in this area. `rules` waits on the
rule engine under *Architecture fitness*, which the backlog entry now points at
this storage.

## Why

Closes #58 — the *Project settings* screens need somewhere to write to.

## Type of change

- [x] feat / fix / perf / refactor
- [x] docs / test / build / ci / chore

## Checklist

- [x] `pnpm build && pnpm test && pnpm lint` pass locally (364 tests, 32 new)
- [x] Added/updated tests where it made sense — merge/normalise/refuse in
      `applyPatch`, defaults, store persistence and cascade-delete, rename and
      re-point (including the clash), and the routes via `app.inject` (including
      a real loaded plugin, so "known" and "unknown" ids are both covered)
- [x] Docs updated — both module `ARCHITECTURE.md`s, `docs/ARCHITECTURE.md`,
      README, BACKLOG

Smoke-tested against a running server: the defaults come back before anything is
set, a PATCH merges and drops a blank glob row, an unknown metric id is a 400
listing the registered ones, and `POST /analyze {root}` picked up the configured
`rev: main` and `historyLimit: 20` (20 commits) while a request asking for 3 got 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)