### PR TITLE
feat(core): app-scoped config store + endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,10 +20,11 @@ STRATA_API_PROXY=http://localhost:4000
 # Default: <cwd>/.strata/plugins — in the container, /app/.strata/plugins.
 STRATA_PLUGINS_DIR=.strata/plugins
 
-# --- Project registry -------------------------------------------------------
-# Where projects.db lives: the repositories registered with this workbench, and
-# a summary of the last analysis of each. Durable user data — kept out of the
-# cache database on purpose, so clearing the cache never drops it.
+# --- Project registry & app settings -----------------------------------------
+# Where projects.db and settings.db live: the repositories registered with this
+# workbench plus a summary of the last analysis of each, and the app-wide
+# settings behind /settings. Durable user data — kept out of the cache database
+# on purpose, so clearing the cache never drops either.
 # Default: <cwd>/.strata — in the container, /app/.strata (a persisted volume).
 STRATA_DATA_DIR=.strata
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -62,12 +62,23 @@ New area — the mockup's settings screens need somewhere to write to.
       `Strata.analyze`, and the chosen commit convention instead of
       first-registered-wins. (Architecture rules need the rule engine under
       *Architecture fitness*.)
-- [ ] **P0** App-scoped config store + endpoints: appearance (theme, density),
-      plugins directory, third-party plugin loading, cache on/off + clear,
-      CI gate thresholds, AI provider instances.
+- [x] App-scoped config store + endpoints — `GET`/`PATCH` `/settings` holds
+      appearance (theme, density), the plugins directory, third-party plugin
+      loading, the incremental cache toggle, the CI gate thresholds and the AI
+      provider instances, in `settings.db` (`$STRATA_DATA_DIR`, its own
+      database beside the registry). Stored sparsely and defaulted on read like
+      a project's config; a `PATCH` merges by section and then by field, so one
+      settings screen can send back only what it edits. Every setting whose
+      consumer already exists is honoured: the cache toggle is the default for
+      the next `/analyze`, and the plugins directory and third-party switch are
+      read when the server starts, which is when plugins load. *Clear cache*
+      stays `DELETE /cache` — an action, not a setting. Appearance, the gates
+      and the providers are stored and served for the screens below.
 - [ ] **P1** Secret storage for provider env values — write-only from the API's
       perspective; the mockup states *"sensitive values are stored separately and
-      are not returned to the app after saving"*, so redact on read.
+      are not returned to the app after saving"*, so redact on read. Until this
+      lands, `ai.providers[].env` on `/settings` is stored and served as
+      written, so nothing sensitive belongs in it.
 - [ ] **P1** Config precedence + a checked-in `strata.config.*` file so a project's
       scope, rules, and gates travel with the repo and drive headless CI mode.
 - [ ] **P2** Import/export a project config; per-project overrides of app defaults.
@@ -136,14 +147,15 @@ call surface, but everything about *configuring* an instance is new. Analysis
 itself stays fully offline.
 
 - [x] AI-provider contract + template (OpenAI-compatible / Ollama)
-- [ ] **P1** CLI-agent provider kind — spawn and talk to a coding-agent binary;
-      per-instance binary path, agent home path, shadow home (account-specific
-      home that keeps `auth.json` separate while sharing state), launch args,
-      env vars, and a model id list.
+- [ ] **P1** CLI-agent provider kind — spawn and talk to a coding-agent binary.
+      The per-instance declaration (binary path, agent home path, shadow home —
+      the account-specific home that keeps `auth.json` separate while sharing
+      state — launch args, env vars and a model id list) is persisted already,
+      behind `/settings` `ai.providers`; launching it is what is missing.
 - [ ] **P1** Provider health checks — resolve the binary, read its version and
-      auth state, list models; run on an interval (*Health check interval*,
-      `0` = manual only) and expose the three states the mockup renders:
-      *Ready*, *Not found*, *Disabled*.
+      auth state, list models; run on the stored interval
+      (`/settings` `ai.healthCheckInterval`, `0` = manual only) and expose the
+      three states the mockup renders: *Ready*, *Not found*, *Disabled*.
 - [ ] **P1** Provider registry UI — enable/disable, display name, accent colour,
       env vars, models, plus *Add custom provider*. See the Web UI section.
 - [ ] **P1** "Explain this hotspot / module" action
@@ -218,13 +230,19 @@ Sans/Mono.
 ### Application settings
 
 - [ ] **P1** Appearance — theme (dark / light / system) and density
-      (dense / balanced / airy)
+      (dense / balanced / airy). Persisted per workbench behind
+      `/settings` `appearance`; the shell still reads the theme from
+      `localStorage`, which is what this screen replaces.
 - [ ] **P1** Plugins & engine — plugins directory, third-party loading toggle,
-      incremental cache toggle and *Clear cache*
-- [ ] **P1** CI gates — fail on new import cycles, hotspot regression threshold
+      incremental cache toggle and *Clear cache*. All four are wired
+      (`/settings` `engine`, plus `DELETE /cache`); the screen is what is left.
+- [ ] **P1** CI gates — fail on new import cycles, hotspot regression threshold.
+      Stored behind `/settings` `gates`; headless CI mode is what reads them.
 - [ ] **P1** AI providers — provider cards with enable toggle, expandable detail
       (display name, accent colour, env vars, binary path, home path, shadow home,
-      launch args, models), health-check interval stepper, *Add custom provider*
+      launch args, models), health-check interval stepper, *Add custom provider*.
+      Every field is persisted behind `/settings` `ai` already; what is missing
+      is the screen and the runtime that launches what it describes.
 - [ ] **P2** About — version, licence, links to docs / architecture / backlog
 - [ ] **P2** Multi-repo workspace; saved views
 
@@ -233,8 +251,9 @@ Sans/Mono.
 - [x] CI (build/typecheck/lint/test), Conventional Commits enforcement (hook + CI)
 - [x] release-please + multi-arch GHCR image + Linux desktop stub
 - [ ] **P1** Headless CI mode — emit JSON/Markdown report, **fail on thresholds**
-      (hotspot regression, new cycles, rule violations), reading the same gate
-      config the *CI gates* screen edits
+      (hotspot regression, new cycles, rule violations), reading the gate
+      config the *CI gates* screen edits — `/settings` `gates` holds it, and
+      nothing reads it yet
 - [ ] **P1** Commit the pnpm lockfile and switch CI to `--frozen-lockfile`
 - [ ] **P1** Serve the built web UI from `@strata/server` so the Docker image is a
       single deployable workbench

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends git \
 
 COPY --from=build /out ./
 
-# The incremental cache and the project registry are written at runtime as
-# `node` — mount a volume here (see compose.yml) to keep them across restarts.
+# The incremental cache, the project registry and the app settings are written
+# at runtime as `node` — mount a volume here (see compose.yml) to keep them
+# across restarts.
 # Third-party plugins are read from the same volume: drop one directory per
 # plugin into /app/.strata/plugins (see docs/PLUGINS.md).
 ENV STRATA_CACHE_DIR=/app/.strata STRATA_DATA_DIR=/app/.strata \

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,8 @@ clean: ## Remove build output and caches
 	$(PNPM) -r exec rm -rf dist .tsbuildinfo || true
 	rm -rf coverage
 	# Only the analysis cache: .strata also holds projects.db (the registered
-	# projects) and any third-party plugins, and neither is build output.
+	# projects), settings.db (the app settings) and any third-party plugins, and
+	# none of those is build output.
 	rm -f .strata/cache.db .strata/cache.db-wal .strata/cache.db-shm
 
 .PHONY: distclean

--- a/README.md
+++ b/README.md
@@ -108,6 +108,28 @@ names `rev` or `historyLimit` itself still wins.
 The registry lives in `$STRATA_DATA_DIR` (default `<cwd>/.strata/projects.db`),
 its own database beside the cache: `DELETE /cache` never touches it.
 
+One scope up are the app-wide settings — appearance, the plugin and cache
+engine, the CI gate thresholds and the AI providers this workbench knows about.
+`PATCH` merges by section and by field, so a settings screen sends back only
+what it edits:
+
+```bash
+curl -s localhost:4000/settings
+curl -X PATCH localhost:4000/settings -H 'content-type: application/json' \
+  -d '{"appearance":{"theme":"light"},"gates":{"failOnNewCycles":true}}'
+# point the workbench at another plugins directory, or stop loading drop-ins
+curl -X PATCH localhost:4000/settings -H 'content-type: application/json' \
+  -d '{"engine":{"pluginsDir":"/opt/strata/plugins","thirdPartyPlugins":false}}'
+```
+
+The cache toggle applies to the next run; the two plugin settings are read when
+the server starts, because that is when plugins load. Appearance, the gates and
+the AI providers are stored and served for the screens and the headless CI mode
+still being built — see [`BACKLOG.md`](BACKLOG.md). Provider environment values
+are held as written, so nothing secret belongs in them until secret storage
+lands. The settings live beside the registry, in
+`$STRATA_DATA_DIR/settings.db`.
+
 Third-party plugins are drop-in: one directory per plugin (with its
 `strata.plugin.json`) under `$STRATA_PLUGINS_DIR`, default
 `<cwd>/.strata/plugins`. Built-ins load first, a plugin that fails to load is

--- a/compose.yml
+++ b/compose.yml
@@ -14,7 +14,8 @@ services:
     volumes:
       # Mount a repo you want to analyse (read-only) at /repos.
       - ${STRATA_REPOS_DIR:-./repos}:/repos:ro
-      # Persist the analysis cache and the project registry across restarts.
+      # Persist the analysis cache, the project registry and the app settings
+      # across restarts.
       # Third-party plugins are read from /app/.strata/plugins, so they live in
       # this volume too — or mount a host directory there instead (see
       # docs/PLUGINS.md).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -91,7 +91,8 @@ strata/
 │   │              git/ (exec, rev, branch, repo, files, history, churn) ·
 │   │              cache/ (types, schema, sqlite, null, open, keys, digest, …) ·
 │   │              projects/ (types, schema, sqlite, memory, open, id, …) ·
-│   │              config/ (types, defaults, patch, errors)
+│   │              config/ (types, defaults, patch, errors) ·
+│   │              settings/ (types, defaults, patch, schema, sqlite, memory, …)
 │   └── server/   @strata/server  Fastify HTTP API over the core
 │                  app.ts · main.ts (entry) · registry.ts · routes/*
 ├── plugins/
@@ -210,6 +211,17 @@ publish. The Linux desktop job is still a stub — it produces no bundle until
   copy of it. `/analyze` takes these as its defaults and lets an explicit
   request field win. Identity — display name and root — stays on the registry
   entry, which is the only place that can keep a root unique.
+- **App settings** — how the workbench itself behaves (appearance, the plugins
+  directory and third-party loading, the incremental cache, the CI gate
+  thresholds, the AI provider instances), behind `/settings`. A third SQLite
+  file (`$STRATA_DATA_DIR`, else `<cwd>/.strata/settings.db`), stored sparsely
+  and defaulted on read like a project's config. Two scopes, split by what the
+  setting belongs to: nothing here is about one repository, and nothing in
+  `/projects/:id/config` is about the workbench. Reading a setting is not the
+  same as it taking effect — the cache toggle applies to the next run, the
+  plugin settings are read when the server starts (which is when plugins load),
+  and appearance, gates and providers are stored for consumers still being
+  built.
 - **One responsibility per file** — implementation, types, helpers and
   alternate implementations live in separate modules; every `index.ts` is a
   barrel that only re-exports. Public import paths (`@strata/core`,

--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -10,8 +10,9 @@ to plugins. This is the only module that knows about all four plugin kinds.
 
 It also owns what the workbench has to remember between runs: the incremental
 cache, the **project registry** — which repositories are registered, and what
-the last analysis of each one found — and each project's **configuration**,
-what an analysis of it is supposed to do.
+the last analysis of each one found — each project's **configuration**, what an
+analysis of it is supposed to do, and the **app settings**, how the workbench
+itself behaves.
 
 ## 2. Constraints
 
@@ -26,8 +27,8 @@ what an analysis of it is supposed to do.
 - **Depends on:** `@strata/sdk` (contracts), `git` CLI.
 - **Consumed by:** `@strata/server` (and `scripts/analyze.mjs`).
 - **Public API:** `Strata.analyze(opts) → AnalysisReport`, `PluginRegistry`,
-  `discoverPlugins()` / `userPluginsDir()`, `openProjectStore()`, `gitUtil`
-  helpers.
+  `discoverPlugins()` / `userPluginsDir()`, `openProjectStore()`,
+  `openSettingsStore()`, `gitUtil` helpers.
 
 ## 4. Building Blocks
 
@@ -65,6 +66,14 @@ what an analysis of it is supposed to do.
 | `config/defaults.ts` | `DEFAULT_PROJECT_CONFIG` + `withDefaults()` — fill a stored config out. |
 | `config/patch.ts` | `applyPatch()` — merge, normalise, refuse what cannot be stored. |
 | `config/errors.ts` | `InvalidConfigError`. |
+| `settings/types.ts` | `AppSettings` and its sections, `SettingsStore`, options. |
+| `settings/defaults.ts` | `DEFAULT_APP_SETTINGS` + `withAppDefaults()`. |
+| `settings/patch.ts` | `applyAppPatch()` — merge two levels deep, normalise, refuse. |
+| `settings/open.ts` | `openSettingsStore()` — resolve location, degrade safely. |
+| `settings/sqlite.ts` | The persistent settings (`settings.db`). |
+| `settings/memory.ts` | The process-lifetime settings (fallback, tests). |
+| `settings/schema.ts` | Table, pragmas, schema stamp. |
+| `settings/errors.ts` | `InvalidSettingsError`. |
 
 ## 5. Runtime
 
@@ -89,6 +98,12 @@ A project's config is stored **sparsely** — only the fields someone set — an
 patch through `applyPatch()`, which normalises (trims, drops blank rows,
 collapses duplicates) and throws `InvalidConfigError` on a value that cannot
 mean anything.
+
+`openSettingsStore()` is the app-scoped twin, and works the same way one scope
+up: one row in `settings.db`, stored sparsely, filled out by
+`withAppDefaults()`, merged by `applyAppPatch()`. Its patch is two levels deep
+— a section left out keeps everything it had, a field left out inside a named
+section keeps its value — because each section is one settings screen.
 
 ## 6. Decisions
 
@@ -143,6 +158,16 @@ mean anything.
   the registry can promise); everything about what an analysis *does* lives in
   the config. Deleting a project deletes both, so an id handed out again never
   inherits the last holder's settings.
+- **App settings are their own database too** (`settings.db`, beside
+  `projects.db`). They are one row about the workbench, not a list that grows
+  per project, and the registry's schema is the one that keeps changing as
+  project features land — a migration there must not be able to cost somebody
+  their provider configuration. Same durability rules as the registry: opening
+  degrades to memory and a warning, a write that fails throws.
+- **A settings section is a settings screen**, and the sections are stored as
+  one JSON value rather than a column per field. Adding a screen is then not a
+  migration, and a `PATCH` that names one section says exactly what the screen
+  it came from can promise.
 
 ## 7. Quality & Risks
 
@@ -162,6 +187,11 @@ mean anything.
   against the registry as they are written; a stale one survives only until the
   next edit of that field, and an unknown revision fails the run it is used in
   rather than the settings screen.
+- **Risk:** an AI provider's `env` values are stored and served in plain text,
+  so a token put there is readable by anyone who can reach the API.
+  **Mitigation:** none yet — secret storage (write-only, redacted on read) is
+  the next step in this area, and until it lands nothing sensitive belongs in
+  provider settings. The store is local and the API assumes a trusted network.
 - **Risk:** `git` output parsing edge cases (root commit, renames). **Mitigation:**
   record-separator parsing; covered by analysis smoke runs.
 - **Risk:** a plugin runs **in-process, with the server's privileges** — the

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -53,4 +53,28 @@ export {
   type ProjectConfig,
   type ProjectConfigPatch,
 } from './config/index.js';
+export {
+  openSettingsStore,
+  memorySettingsStore,
+  DEFAULT_APP_SETTINGS,
+  withAppDefaults,
+  applyAppPatch,
+  InvalidSettingsError,
+  DENSITIES,
+  THEME_MODES,
+  type AIProviderInput,
+  type AIProviderInstance,
+  type AISettings,
+  type AISettingsPatch,
+  type AppearanceSettings,
+  type AppSettings,
+  type AppSettingsPatch,
+  type Density,
+  type EngineSettings,
+  type GateSettings,
+  type SettingsStore,
+  type SettingsStoreOptions,
+  type StoredAppSettings,
+  type ThemeMode,
+} from './settings/index.js';
 export * as gitUtil from './git/index.js';

--- a/packages/core/src/settings/defaults.ts
+++ b/packages/core/src/settings/defaults.ts
@@ -1,0 +1,46 @@
+import type {
+  AIProviderInstance,
+  AppSettings,
+  StoredAppSettings,
+} from './types.js';
+
+/**
+ * How the workbench behaves before anyone configures it: the OS theme, the
+ * middle density, the plugins directory the environment names, third-party
+ * plugins and the incremental cache on, no CI gate, no AI provider. Exactly
+ * what the server did before there were app settings.
+ */
+export const DEFAULT_APP_SETTINGS: AppSettings = {
+  appearance: { theme: 'system', density: 'balanced' },
+  engine: { pluginsDir: null, thirdPartyPlugins: true, cache: true },
+  gates: { failOnNewCycles: false, hotspotRegression: null },
+  ai: { healthCheckInterval: 0, providers: [] },
+};
+
+/**
+ * Fill a stored (sparse) settings object out to a whole one. Everything is
+ * copied on the way out, so a caller cannot mutate the defaults — or the
+ * store's own state — through the value it gets back.
+ */
+export function withAppDefaults(stored: StoredAppSettings): AppSettings {
+  const { appearance, engine, gates, ai } = DEFAULT_APP_SETTINGS;
+  return {
+    appearance: { ...appearance, ...stored.appearance },
+    engine: { ...engine, ...stored.engine },
+    gates: { ...gates, ...stored.gates },
+    ai: {
+      healthCheckInterval:
+        stored.ai?.healthCheckInterval ?? ai.healthCheckInterval,
+      providers: (stored.ai?.providers ?? ai.providers).map(copyProvider),
+    },
+  };
+}
+
+function copyProvider(provider: AIProviderInstance): AIProviderInstance {
+  return {
+    ...provider,
+    args: [...provider.args],
+    env: { ...provider.env },
+    models: [...provider.models],
+  };
+}

--- a/packages/core/src/settings/errors.ts
+++ b/packages/core/src/settings/errors.ts
@@ -1,0 +1,11 @@
+/**
+ * A settings patch that cannot be stored as written — the app-scoped twin of
+ * `InvalidConfigError`. Separate from any other failure so the HTTP layer can
+ * answer 400 with the reason, rather than 500 with none.
+ */
+export class InvalidSettingsError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidSettingsError';
+  }
+}

--- a/packages/core/src/settings/index.ts
+++ b/packages/core/src/settings/index.ts
@@ -1,0 +1,15 @@
+/**
+ * App-scoped settings — what the workbench-wide *Settings* screens edit:
+ * appearance, the plugin/cache engine, the CI gates and the AI providers.
+ * Stored sparsely in `settings.db` and merged with `DEFAULT_APP_SETTINGS` on
+ * the way out.
+ *
+ * The project-scoped twin is `config/`, which is about what an analysis of one
+ * repository does.
+ */
+export * from './types.js';
+export * from './defaults.js';
+export * from './patch.js';
+export * from './errors.js';
+export { openSettingsStore } from './open.js';
+export { memorySettingsStore } from './memory.js';

--- a/packages/core/src/settings/memory.ts
+++ b/packages/core/src/settings/memory.ts
@@ -1,0 +1,30 @@
+import { withAppDefaults } from './defaults.js';
+import { applyAppPatch } from './patch.js';
+import type {
+  AppSettings,
+  AppSettingsPatch,
+  SettingsStore,
+  StoredAppSettings,
+} from './types.js';
+
+/**
+ * Settings that live for as long as the process does — what a workbench falls
+ * back to when the database cannot be opened (a read-only container, a file
+ * written by a newer Strata). Every screen works; nothing survives a restart,
+ * and the warning at open time says so.
+ *
+ * Also what the store tests and callers use when they want no file at all.
+ */
+export function memorySettingsStore(): SettingsStore {
+  let stored: StoredAppSettings = {};
+
+  return {
+    path: null,
+    get: () => withAppDefaults(stored),
+    patch(patch: AppSettingsPatch): AppSettings {
+      stored = applyAppPatch(stored, patch);
+      return withAppDefaults(stored);
+    },
+    close: () => {},
+  };
+}

--- a/packages/core/src/settings/open.ts
+++ b/packages/core/src/settings/open.ts
@@ -1,0 +1,36 @@
+import { resolve } from 'node:path';
+import { createConsoleLogger } from '../logger.js';
+import { memorySettingsStore } from './memory.js';
+import { SqliteSettingsStore } from './sqlite.js';
+import type { SettingsStore, SettingsStoreOptions } from './types.js';
+
+/** Beside `projects.db`, in the directory that is already a persisted volume. */
+const DEFAULT_DIR = '.strata';
+
+/**
+ * Open the app settings. Never throws at startup: a location that cannot be
+ * opened (read-only container, missing permissions, a file from a newer build)
+ * degrades to in-memory settings and a warning, so the workbench still runs on
+ * its defaults — it simply forgets a change when the process exits.
+ *
+ * Writes on an opened store do *not* degrade; see `sqlite.ts`.
+ */
+export function openSettingsStore(
+  opts: SettingsStoreOptions = {},
+): SettingsStore {
+  const log = opts.log ?? createConsoleLogger('strata:settings');
+  const file =
+    opts.path ??
+    resolve(
+      opts.dir ?? process.env.STRATA_DATA_DIR ?? DEFAULT_DIR,
+      'settings.db',
+    );
+  try {
+    return new SqliteSettingsStore(file, log);
+  } catch (err) {
+    log.warn(
+      `not persisted — could not open ${file}: ${(err as Error).message}`,
+    );
+    return memorySettingsStore();
+  }
+}

--- a/packages/core/src/settings/patch.ts
+++ b/packages/core/src/settings/patch.ts
@@ -1,0 +1,242 @@
+import { resolve } from 'node:path';
+import { InvalidSettingsError } from './errors.js';
+import {
+  DENSITIES,
+  THEME_MODES,
+  type AIProviderInput,
+  type AIProviderInstance,
+  type AISettings,
+  type AISettingsPatch,
+  type AppearanceSettings,
+  type AppSettingsPatch,
+  type EngineSettings,
+  type GateSettings,
+  type StoredAppSettings,
+} from './types.js';
+
+/** A provider id lands in a URL and in stored settings, so it stays a slug. */
+const PROVIDER_ID = /^[a-z0-9][a-z0-9-]*$/;
+
+/** POSIX environment variable names: what a subprocess can actually receive. */
+const ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+const HEX_COLOUR = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+
+/**
+ * Merge a patch into the stored settings and hand back the new stored value —
+ * still sparse, so untouched fields keep following the defaults.
+ *
+ * Sections merge field by field, and an array replaces the stored one whole.
+ * Everything is normalised on the way in (trimmed, blank rows dropped,
+ * duplicates collapsed) and refused when it cannot mean anything: a settings
+ * screen that posts an empty provider row should not store a provider nobody
+ * can launch.
+ */
+export function applyAppPatch(
+  stored: StoredAppSettings,
+  patch: AppSettingsPatch,
+): StoredAppSettings {
+  const next: StoredAppSettings = { ...stored };
+
+  if (patch.appearance) {
+    next.appearance = appearance(stored.appearance, patch.appearance);
+  }
+  if (patch.engine) next.engine = engine(stored.engine, patch.engine);
+  if (patch.gates) next.gates = gates(stored.gates, patch.gates);
+  if (patch.ai) next.ai = ai(stored.ai, patch.ai);
+
+  return next;
+}
+
+function appearance(
+  stored: Partial<AppearanceSettings> = {},
+  patch: Partial<AppearanceSettings>,
+): Partial<AppearanceSettings> {
+  const next = { ...stored };
+  if (patch.theme !== undefined) {
+    next.theme = oneOf(patch.theme, THEME_MODES, 'theme');
+  }
+  if (patch.density !== undefined) {
+    next.density = oneOf(patch.density, DENSITIES, 'density');
+  }
+  return next;
+}
+
+function engine(
+  stored: Partial<EngineSettings> = {},
+  patch: Partial<EngineSettings>,
+): Partial<EngineSettings> {
+  const next = { ...stored };
+  if (patch.pluginsDir !== undefined) {
+    // Absolute, like a project root: the server resolves relative paths
+    // against its own working directory, which is not the one a settings
+    // screen was typed in.
+    next.pluginsDir =
+      patch.pluginsDir === null
+        ? null
+        : resolve(required(patch.pluginsDir, 'plugins directory'));
+  }
+  if (patch.thirdPartyPlugins !== undefined) {
+    next.thirdPartyPlugins = patch.thirdPartyPlugins;
+  }
+  if (patch.cache !== undefined) next.cache = patch.cache;
+  return next;
+}
+
+function gates(
+  stored: Partial<GateSettings> = {},
+  patch: Partial<GateSettings>,
+): Partial<GateSettings> {
+  const next = { ...stored };
+  if (patch.failOnNewCycles !== undefined) {
+    next.failOnNewCycles = patch.failOnNewCycles;
+  }
+  if (patch.hotspotRegression !== undefined) {
+    next.hotspotRegression = threshold(patch.hotspotRegression);
+  }
+  return next;
+}
+
+function ai(
+  stored: Partial<AISettings> = {},
+  patch: AISettingsPatch,
+): Partial<AISettings> {
+  const next = { ...stored };
+  if (patch.healthCheckInterval !== undefined) {
+    next.healthCheckInterval = interval(patch.healthCheckInterval);
+  }
+  if (patch.providers !== undefined) {
+    next.providers = providers(patch.providers);
+  }
+  return next;
+}
+
+function threshold(value: number | null): number | null {
+  if (value === null) return null;
+  if (!Number.isFinite(value) || value < 0) {
+    throw new InvalidSettingsError(
+      'The hotspot regression threshold is a percentage of 0 or more — ' +
+        'use null for no gate.',
+    );
+  }
+  return value;
+}
+
+function interval(value: number): number {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new InvalidSettingsError(
+      'The health-check interval is a whole number of minutes, 0 or more — ' +
+        'use 0 to check only when asked.',
+    );
+  }
+  return value;
+}
+
+/** Two cards for one id would be two names for the same provider. */
+function providers(values: AIProviderInput[]): AIProviderInstance[] {
+  const seen = new Set<string>();
+  return values.map((value) => {
+    const instance = provider(value);
+    if (seen.has(instance.id)) {
+      throw new InvalidSettingsError(
+        `Two AI providers share the id "${instance.id}".`,
+      );
+    }
+    seen.add(instance.id);
+    return instance;
+  });
+}
+
+function provider(input: AIProviderInput): AIProviderInstance {
+  return {
+    id: providerId(input.id),
+    name: required(input.name, 'provider name'),
+    // A provider is off until somebody turns it on: adding a card is not the
+    // same decision as letting Strata launch what it points at.
+    enabled: input.enabled ?? false,
+    accent: colour(input.accent),
+    binary: optional(input.binary, 'binary path'),
+    home: optional(input.home, 'agent home'),
+    shadowHome: optional(input.shadowHome, 'shadow home'),
+    // Duplicates and order are meaningful in an argument vector, so only blank
+    // rows — what an empty row in a chip list looks like — are dropped.
+    args: (input.args ?? []).map((a) => a.trim()).filter(Boolean),
+    env: env(input.env ?? {}),
+    models: unique((input.models ?? []).map((m) => m.trim()).filter(Boolean)),
+  };
+}
+
+function providerId(value: string): string {
+  const id = required(value, 'provider id');
+  if (!PROVIDER_ID.test(id)) {
+    throw new InvalidSettingsError(
+      `"${id}" is not a usable provider id — use lower-case letters, ` +
+        'digits and dashes.',
+    );
+  }
+  return id;
+}
+
+function colour(value: string | null | undefined): string | null {
+  if (value === undefined || value === null) return null;
+  const trimmed = value.trim();
+  if (!HEX_COLOUR.test(trimmed)) {
+    throw new InvalidSettingsError(
+      `"${value}" is not a colour — use a hex value such as "#4da3ff".`,
+    );
+  }
+  return trimmed;
+}
+
+function env(values: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(values)) {
+    const name = key.trim();
+    if (!ENV_NAME.test(name)) {
+      throw new InvalidSettingsError(
+        `"${key}" is not an environment variable name.`,
+      );
+    }
+    // The value is kept as written — trimming somebody's token or path
+    // separator would be a change they did not ask for.
+    out[name] = value;
+  }
+  return out;
+}
+
+function required(value: string, field: string): string {
+  const trimmed = value?.trim() ?? '';
+  if (!trimmed) throw new InvalidSettingsError(`The ${field} cannot be blank.`);
+  return trimmed;
+}
+
+/** A field that is either a real value or explicitly unset. */
+function optional(
+  value: string | null | undefined,
+  field: string,
+): string | null {
+  if (value === undefined || value === null) return null;
+  return required(value, field);
+}
+
+function oneOf<T extends string>(
+  value: T,
+  allowed: readonly T[],
+  field: string,
+): T {
+  if (!allowed.includes(value)) {
+    throw new InvalidSettingsError(
+      `"${value}" is not a ${field} — pick one of ${allowed.join(', ')}.`,
+    );
+  }
+  return value;
+}
+
+function unique(values: string[]): string[] {
+  const seen = new Set<string>();
+  return values.filter((v) => {
+    if (seen.has(v)) return false;
+    seen.add(v);
+    return true;
+  });
+}

--- a/packages/core/src/settings/schema.ts
+++ b/packages/core/src/settings/schema.ts
@@ -1,0 +1,58 @@
+import type { DatabaseSync } from 'node:sqlite';
+
+/**
+ * Bump when the table layout changes — and write the migration. Like the
+ * project registry, this file holds data nobody can recompute, so a mismatch
+ * never wipes.
+ */
+export const SCHEMA_VERSION = 1;
+
+const TABLES = `
+-- One workbench, one row. The settings live as JSON rather than a column per
+-- field because they are read and written whole, and because a new section
+-- (a new settings screen) should not be a migration.
+CREATE TABLE IF NOT EXISTS settings (
+  id    INTEGER PRIMARY KEY CHECK (id = 1),
+  value TEXT NOT NULL
+);
+`;
+
+/** Pragmas for a small, durable, occasionally-shared file. */
+export function configure(db: DatabaseSync): void {
+  db.exec('PRAGMA journal_mode = WAL');
+  // Settings writes are rare and user-initiated: durability beats throughput.
+  db.exec('PRAGMA synchronous = FULL');
+  db.exec('PRAGMA busy_timeout = 5000');
+}
+
+/**
+ * Create the table and stamp the schema version.
+ *
+ * A file written by a *newer* Strata is left untouched and reported: opening it
+ * with this build's expectations would either fail confusingly or quietly drop
+ * settings the newer build still needs. The caller degrades to in-memory
+ * settings, so the workbench still runs on its defaults — it just does not
+ * persist what is changed.
+ */
+export function migrate(db: DatabaseSync): void {
+  db.exec(
+    'CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)',
+  );
+  const row = db
+    .prepare("SELECT value FROM meta WHERE key = 'schema_version'")
+    .get() as { value?: string } | undefined;
+  const found = Number(row?.value ?? SCHEMA_VERSION);
+
+  if (found > SCHEMA_VERSION) {
+    throw new Error(
+      `app settings are at schema ${found}, but this build understands ${SCHEMA_VERSION} — ` +
+        'they were written by a newer Strata.',
+    );
+  }
+
+  db.exec(TABLES);
+  db.prepare(
+    `INSERT INTO meta (key, value) VALUES ('schema_version', ?)
+     ON CONFLICT (key) DO UPDATE SET value = excluded.value`,
+  ).run(String(SCHEMA_VERSION));
+}

--- a/packages/core/src/settings/settings.test.ts
+++ b/packages/core/src/settings/settings.test.ts
@@ -1,0 +1,224 @@
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  applyAppPatch,
+  DEFAULT_APP_SETTINGS,
+  InvalidSettingsError,
+  withAppDefaults,
+  type StoredAppSettings,
+} from './index.js';
+
+/**
+ * App settings are stored sparsely and filled out on read, so the two halves
+ * have to agree: what a patch keeps, what it replaces, and what it refuses to
+ * store at all — a provider card posted from an empty form must not become a
+ * provider Strata would try to launch.
+ */
+
+describe('withAppDefaults', () => {
+  it('fills empty settings out to the pre-configuration behaviour', () => {
+    expect(withAppDefaults({})).toEqual({
+      appearance: { theme: 'system', density: 'balanced' },
+      engine: { pluginsDir: null, thirdPartyPlugins: true, cache: true },
+      gates: { failOnNewCycles: false, hotspotRegression: null },
+      ai: { healthCheckInterval: 0, providers: [] },
+    });
+  });
+
+  it('defaults the rest of a section somebody half-configured', () => {
+    expect(withAppDefaults({ appearance: { density: 'airy' } })).toMatchObject({
+      appearance: { theme: 'system', density: 'airy' },
+    });
+  });
+
+  it('copies out, so a caller cannot mutate the defaults', () => {
+    withAppDefaults({}).ai.providers.push({
+      id: 'codex',
+      name: 'Codex',
+      enabled: true,
+      accent: null,
+      binary: null,
+      home: null,
+      shadowHome: null,
+      args: [],
+      env: {},
+      models: [],
+    });
+
+    expect(DEFAULT_APP_SETTINGS.ai.providers).toEqual([]);
+  });
+
+  it('copies a stored provider, so neither can be mutated through the other', () => {
+    const stored: StoredAppSettings = applyAppPatch(
+      {},
+      { ai: { providers: [{ id: 'codex', name: 'Codex', models: ['o4'] }] } },
+    );
+
+    withAppDefaults(stored).ai.providers[0]?.models.push('gpt-5');
+
+    expect(withAppDefaults(stored).ai.providers[0]?.models).toEqual(['o4']);
+  });
+});
+
+describe('applyAppPatch', () => {
+  const stored: StoredAppSettings = {
+    appearance: { theme: 'dark' },
+    engine: { cache: false },
+  };
+
+  it('merges section by section and leaves the rest alone', () => {
+    expect(applyAppPatch(stored, { gates: { failOnNewCycles: true } })).toEqual({
+      appearance: { theme: 'dark' },
+      engine: { cache: false },
+      gates: { failOnNewCycles: true },
+    });
+  });
+
+  it('merges field by field inside a section', () => {
+    expect(
+      applyAppPatch(stored, { appearance: { density: 'dense' } }).appearance,
+    ).toEqual({ theme: 'dark', density: 'dense' });
+  });
+
+  it('makes the plugins directory absolute, and takes null for "follow the environment"', () => {
+    expect(
+      applyAppPatch({}, { engine: { pluginsDir: 'plugins/local' } }).engine,
+    ).toEqual({ pluginsDir: resolve('plugins/local') });
+    expect(
+      applyAppPatch({ engine: { pluginsDir: '/opt/plugins' } }, {
+        engine: { pluginsDir: null },
+      }).engine,
+    ).toEqual({ pluginsDir: null });
+  });
+
+  it('keeps a provider, defaulting a new one to disabled and empty', () => {
+    const patched = applyAppPatch(
+      {},
+      { ai: { providers: [{ id: 'codex', name: ' Codex ' }] } },
+    );
+
+    expect(patched.ai?.providers).toEqual([
+      {
+        id: 'codex',
+        name: 'Codex',
+        enabled: false,
+        accent: null,
+        binary: null,
+        home: null,
+        shadowHome: null,
+        args: [],
+        env: {},
+        models: [],
+      },
+    ]);
+  });
+
+  it('replaces the provider list whole rather than adding to it', () => {
+    const first = applyAppPatch(
+      {},
+      { ai: { providers: [{ id: 'codex', name: 'Codex' }] } },
+    );
+
+    const second = applyAppPatch(first, {
+      ai: { providers: [{ id: 'claude', name: 'Claude' }] },
+    });
+
+    expect(second.ai?.providers?.map((p) => p.id)).toEqual(['claude']);
+  });
+
+  it('drops blank rows, keeps repeated launch args and collapses repeated models', () => {
+    const patched = applyAppPatch(
+      {},
+      {
+        ai: {
+          providers: [
+            {
+              id: 'codex',
+              name: 'Codex',
+              args: ['--verbose', ' ', '--verbose'],
+              models: [' o4 ', '', 'o4'],
+            },
+          ],
+        },
+      },
+    );
+
+    expect(patched.ai?.providers?.[0]).toMatchObject({
+      args: ['--verbose', '--verbose'],
+      models: ['o4'],
+    });
+  });
+
+  it('keeps an environment value exactly as written', () => {
+    const patched = applyAppPatch(
+      {},
+      {
+        ai: {
+          providers: [
+            { id: 'codex', name: 'Codex', env: { ' AGENT_HOME ': '/opt/a b/' } },
+          ],
+        },
+      },
+    );
+
+    expect(patched.ai?.providers?.[0]?.env).toEqual({ AGENT_HOME: '/opt/a b/' });
+  });
+
+  it('refuses a value that cannot mean anything', () => {
+    expect(() =>
+      applyAppPatch({}, { appearance: { theme: 'midnight' as never } }),
+    ).toThrow(InvalidSettingsError);
+    expect(() =>
+      applyAppPatch({}, { appearance: { density: 'roomy' as never } }),
+    ).toThrow(InvalidSettingsError);
+    expect(() => applyAppPatch({}, { engine: { pluginsDir: '  ' } })).toThrow(
+      InvalidSettingsError,
+    );
+    expect(() =>
+      applyAppPatch({}, { gates: { hotspotRegression: -1 } }),
+    ).toThrow(InvalidSettingsError);
+    expect(() => applyAppPatch({}, { ai: { healthCheckInterval: 2.5 } })).toThrow(
+      InvalidSettingsError,
+    );
+    expect(() => applyAppPatch({}, { ai: { healthCheckInterval: -5 } })).toThrow(
+      InvalidSettingsError,
+    );
+  });
+
+  it('refuses a provider nobody could launch or address', () => {
+    const refuse = (provider: unknown) =>
+      expect(() =>
+        applyAppPatch({}, { ai: { providers: [provider as never] } }),
+      ).toThrow(InvalidSettingsError);
+
+    refuse({ id: 'Codex Agent', name: 'Codex' });
+    refuse({ id: 'codex', name: '  ' });
+    refuse({ id: 'codex', name: 'Codex', binary: '  ' });
+    refuse({ id: 'codex', name: 'Codex', accent: 'blue' });
+    refuse({ id: 'codex', name: 'Codex', env: { 'not a name': 'x' } });
+  });
+
+  it('refuses two providers with the same id', () => {
+    expect(() =>
+      applyAppPatch(
+        {},
+        {
+          ai: {
+            providers: [
+              { id: 'codex', name: 'Codex' },
+              { id: 'codex', name: 'Codex, again' },
+            ],
+          },
+        },
+      ),
+    ).toThrow(InvalidSettingsError);
+  });
+
+  it('does not touch what it was given', () => {
+    const before = structuredClone(stored);
+
+    applyAppPatch(stored, { appearance: { theme: 'light' } });
+
+    expect(stored).toEqual(before);
+  });
+});

--- a/packages/core/src/settings/sqlite.ts
+++ b/packages/core/src/settings/sqlite.ts
@@ -1,0 +1,90 @@
+import { mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { DatabaseSync, type StatementSync } from 'node:sqlite';
+import type { Logger } from '@strata/sdk';
+import { consoleLogger } from '../logger.js';
+import { withAppDefaults } from './defaults.js';
+import { applyAppPatch } from './patch.js';
+import { configure, migrate } from './schema.js';
+import type {
+  AppSettings,
+  AppSettingsPatch,
+  SettingsStore,
+  StoredAppSettings,
+} from './types.js';
+
+/**
+ * The persistent app settings: one SQLite file of its own, beside `cache.db`
+ * and `projects.db`. Not a table in the registry — the registry's schema is the
+ * one that grows with every project feature, and a migration there must not be
+ * able to cost somebody their provider configuration.
+ *
+ * Failures are *not* swallowed the way the cache swallows its own: a "Save"
+ * that reports success and stores nothing loses user intent, so a write that
+ * fails throws and the API turns it into an error the user can see.
+ */
+export class SqliteSettingsStore implements SettingsStore {
+  readonly path: string;
+
+  private readonly db: DatabaseSync;
+  private readonly select: StatementSync;
+  private readonly upsert: StatementSync;
+
+  constructor(
+    path: string,
+    private readonly log: Logger = consoleLogger,
+  ) {
+    this.path = resolve(path);
+    mkdirSync(dirname(this.path), { recursive: true });
+    this.db = new DatabaseSync(this.path);
+
+    try {
+      configure(this.db);
+      migrate(this.db);
+    } catch (err) {
+      // A file this build will not touch (see `schema.ts`) still leaves an open
+      // handle and its WAL sidecars behind if we only rethrow.
+      this.db.close();
+      throw err;
+    }
+
+    this.select = this.db.prepare('SELECT value FROM settings WHERE id = 1');
+    this.upsert = this.db.prepare(
+      `INSERT INTO settings (id, value) VALUES (1, ?)
+       ON CONFLICT (id) DO UPDATE SET value = excluded.value`,
+    );
+  }
+
+  get(): AppSettings {
+    return withAppDefaults(this.stored());
+  }
+
+  patch(patch: AppSettingsPatch): AppSettings {
+    const stored = applyAppPatch(this.stored(), patch);
+    this.upsert.run(JSON.stringify(stored));
+    return withAppDefaults(stored);
+  }
+
+  /** Only what was explicitly set; the defaults are applied on the way out. */
+  private stored(): StoredAppSettings {
+    const row = this.select.get() as { value: string } | undefined;
+    if (row === undefined) return {};
+    try {
+      return JSON.parse(row.value) as StoredAppSettings;
+    } catch (err) {
+      // Unreadable settings fall back to the defaults rather than failing the
+      // screen that reads them; the next PATCH overwrites the bad row. Every
+      // setting silently reverting is worth saying out loud, though.
+      this.log.warn(
+        `settings in ${this.path} could not be read and are being ignored: ${
+          (err as Error).message
+        }`,
+      );
+      return {};
+    }
+  }
+
+  close(): void {
+    this.db.close();
+  }
+}

--- a/packages/core/src/settings/store.test.ts
+++ b/packages/core/src/settings/store.test.ts
@@ -1,0 +1,162 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { DEFAULT_APP_SETTINGS } from './defaults.js';
+import { memorySettingsStore, openSettingsStore } from './index.js';
+
+/**
+ * Nothing in here is derived, so the interesting cases are the ones that would
+ * lose a change: a restart, a patch that names one section of one screen, and a
+ * location that cannot be opened at all.
+ */
+describe('settings store', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'strata-settings-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('answers with the defaults before anything is configured', () => {
+    const store = openSettingsStore({ dir });
+
+    expect(store.get()).toEqual(DEFAULT_APP_SETTINGS);
+    expect(store.path).toBe(join(dir, 'settings.db'));
+    store.close();
+  });
+
+  it('keeps a change across restarts', () => {
+    const store = openSettingsStore({ dir });
+    store.patch({ appearance: { theme: 'light' } });
+    store.patch({
+      ai: {
+        healthCheckInterval: 15,
+        providers: [{ id: 'codex', name: 'Codex', enabled: true }],
+      },
+    });
+    store.close();
+
+    const reopened = openSettingsStore({ dir });
+    expect(reopened.get()).toMatchObject({
+      appearance: { theme: 'light', density: 'balanced' },
+      ai: {
+        healthCheckInterval: 15,
+        providers: [{ id: 'codex', name: 'Codex', enabled: true }],
+      },
+    });
+    reopened.close();
+  });
+
+  it('stores only what was set, so a default that moves still reaches it', () => {
+    const store = openSettingsStore({ dir });
+    store.patch({ gates: { failOnNewCycles: true } });
+    store.close();
+
+    const reopened = openSettingsStore({ dir });
+    expect(stored(join(dir, 'settings.db'))).toEqual({
+      gates: { failOnNewCycles: true },
+    });
+    expect(reopened.get().engine).toEqual(DEFAULT_APP_SETTINGS.engine);
+    reopened.close();
+  });
+
+  it('reads the same settings back from memory as from a file', () => {
+    const memory = memorySettingsStore();
+    const file = openSettingsStore({ dir });
+    const patch = { engine: { cache: false }, gates: { hotspotRegression: 10 } };
+
+    expect(memory.patch(patch)).toEqual(file.patch(patch));
+    expect(memory.get()).toEqual(file.get());
+    file.close();
+    memory.close();
+  });
+
+  it('falls back to memory rather than failing when the file cannot be opened', () => {
+    // A directory is not a database — the same shape of failure as a read-only
+    // container, without needing one.
+    const store = openSettingsStore({ path: dir, log: silent });
+
+    expect(store.path).toBeNull();
+    expect(store.patch({ appearance: { theme: 'dark' } }).appearance.theme).toBe(
+      'dark',
+    );
+    store.close();
+  });
+
+  it('falls back to the defaults on a row it cannot read, and says so', () => {
+    const path = join(dir, 'settings.db');
+    const store = openSettingsStore({ path });
+    store.patch({ appearance: { theme: 'dark' } });
+    store.close();
+    corrupt(path);
+
+    const warnings: string[] = [];
+    const reopened = openSettingsStore({
+      path,
+      log: { ...silent, warn: (m) => warnings.push(m) },
+    });
+
+    expect(reopened.get()).toEqual(DEFAULT_APP_SETTINGS);
+    expect(warnings.join()).toContain(path);
+    // The next write overwrites the bad row rather than merging into it.
+    expect(reopened.patch({ appearance: { theme: 'light' } }).appearance).toEqual(
+      { theme: 'light', density: 'balanced' },
+    );
+    reopened.close();
+  });
+
+  it('leaves settings written by a newer Strata alone', () => {
+    const path = join(dir, 'settings.db');
+    const store = openSettingsStore({ path });
+    store.patch({ appearance: { theme: 'dark' } });
+    store.close();
+    stampSchema(path, 99);
+
+    const reopened = openSettingsStore({ path, log: silent });
+
+    // Degraded to memory: this build's defaults, and the file untouched.
+    expect(reopened.path).toBeNull();
+    expect(reopened.get()).toEqual(DEFAULT_APP_SETTINGS);
+    expect(stored(path)).toEqual({ appearance: { theme: 'dark' } });
+    reopened.close();
+  });
+});
+
+const silent = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+};
+
+/** The raw row, to assert that only what was set is written down. */
+function stored(path: string): unknown {
+  const db = new DatabaseSync(path);
+  const row = db.prepare('SELECT value FROM settings WHERE id = 1').get() as
+    | { value: string }
+    | undefined;
+  db.close();
+  return row === undefined ? undefined : JSON.parse(row.value);
+}
+
+/** Whatever left this behind, it is not settings any more. */
+function corrupt(path: string): void {
+  const db = new DatabaseSync(path);
+  db.prepare('UPDATE settings SET value = ? WHERE id = 1').run('{not json');
+  db.close();
+}
+
+/** Pretend the file was written by a build this one does not understand. */
+function stampSchema(path: string, version: number): void {
+  const db = new DatabaseSync(path);
+  db.prepare(
+    `INSERT INTO meta (key, value) VALUES ('schema_version', ?)
+     ON CONFLICT (key) DO UPDATE SET value = excluded.value`,
+  ).run(String(version));
+  db.close();
+}

--- a/packages/core/src/settings/types.ts
+++ b/packages/core/src/settings/types.ts
@@ -1,0 +1,190 @@
+import type { Logger } from '@strata/sdk';
+
+/** What the workbench paints in; `system` defers to the OS preference. */
+export type ThemeMode = 'dark' | 'light' | 'system';
+
+/** How much room the shell gives a row of data. */
+export type Density = 'dense' | 'balanced' | 'airy';
+
+/** The order the *Appearance* screen renders them in. */
+export const THEME_MODES = [
+  'dark',
+  'light',
+  'system',
+] as const satisfies readonly ThemeMode[];
+
+export const DENSITIES = [
+  'dense',
+  'balanced',
+  'airy',
+] as const satisfies readonly Density[];
+
+/** *Settings → Appearance*. Read by the shell, not by an analysis. */
+export interface AppearanceSettings {
+  theme: ThemeMode;
+  density: Density;
+}
+
+/** *Settings → Plugins & engine*. The only section a run reads. */
+export interface EngineSettings {
+  /**
+   * Directory drop-in plugins are read from, or `null` to follow the
+   * environment (`STRATA_PLUGINS_DIR`, else `<cwd>/.strata/plugins`). Stored
+   * absolute, and read when the server starts — which is when plugins load.
+   */
+  pluginsDir: string | null;
+  /**
+   * Load drop-in plugins at all. Off is the way back into a workbench that a
+   * third-party plugin has made unusable, without deleting the directory.
+   */
+  thirdPartyPlugins: boolean;
+  /** Incremental cache on/off. *Clear cache* is `DELETE /cache`, not a setting. */
+  cache: boolean;
+}
+
+/**
+ * *Settings → CI gates* — the thresholds headless CI mode fails a build on.
+ * Both default to off: turning a build red is a decision, the same way an
+ * architecture rule reports until it is marked enforced.
+ */
+export interface GateSettings {
+  /** Fail when the run finds an import cycle the baseline did not have. */
+  failOnNewCycles: boolean;
+  /**
+   * Percent a hotspot score may grow before the gate fails; `null` for no
+   * gate. A percentage rather than an absolute score, because scores are only
+   * comparable within one repository.
+   */
+  hotspotRegression: number | null;
+}
+
+/**
+ * One configured AI provider: a local coding-agent CLI Strata launches as a
+ * subprocess, or a custom one somebody added. This is the *declaration* only —
+ * resolving the binary, checking its health and talking to it are the provider
+ * work still on the backlog.
+ */
+export interface AIProviderInstance {
+  /** Stable slug; what a provider card and any future `/ai/:id` address. */
+  id: string;
+  /** What the card is labelled. */
+  name: string;
+  /** A new provider is off until somebody turns it on. */
+  enabled: boolean;
+  /** Hex colour the card is tinted with, or `null` for the default accent. */
+  accent: string | null;
+  /** Path to the agent's binary; `null` to look it up on `PATH`. */
+  binary: string | null;
+  /** The agent's own home directory, if it keeps one. */
+  home: string | null;
+  /**
+   * Account-specific home that keeps `auth.json` separate while sharing the
+   * rest of the agent's state — how one machine runs two accounts.
+   */
+  shadowHome: string | null;
+  /** Extra arguments to launch the binary with, in order. */
+  args: string[];
+  /**
+   * Environment the subprocess gets. Plain values: secret storage is a
+   * separate step, so nothing sensitive belongs here yet — what is stored here
+   * is served back by `GET /settings` as written.
+   */
+  env: Record<string, string>;
+  /** Model ids this provider offers. */
+  models: string[];
+}
+
+/** *Settings → AI providers*. */
+export interface AISettings {
+  /** Minutes between provider health checks; `0` checks only on request. */
+  healthCheckInterval: number;
+  providers: AIProviderInstance[];
+}
+
+/**
+ * Everything the app-wide *Settings* screens configure: how the workbench
+ * looks, what its engine loads and caches, what its CI gates fail on, and
+ * which AI providers it knows about.
+ *
+ * App-scoped on purpose — none of it belongs to one repository. What an
+ * analysis of a *project* does is `ProjectConfig`, one scope down.
+ *
+ * Stored sparsely — only what somebody set — and merged with the defaults on
+ * read, so a default that moves in a later release reaches every workbench
+ * that never overrode it.
+ */
+export interface AppSettings {
+  appearance: AppearanceSettings;
+  engine: EngineSettings;
+  gates: GateSettings;
+  ai: AISettings;
+}
+
+/** Only the sections and fields somebody set. */
+export type StoredAppSettings = {
+  [K in keyof AppSettings]?: Partial<AppSettings[K]>;
+};
+
+/**
+ * What a settings screen sends for one provider. Id and name are required —
+ * everything else falls back to the provider defaults, so *Add custom
+ * provider* can post a card that is nothing but a name.
+ */
+export interface AIProviderInput
+  extends Partial<Omit<AIProviderInstance, 'id' | 'name'>> {
+  id: string;
+  name: string;
+}
+
+export interface AISettingsPatch {
+  healthCheckInterval?: number;
+  /** The new list, whole — not an addition to the stored one. */
+  providers?: AIProviderInput[];
+}
+
+/**
+ * A partial update, two levels deep: a section left out keeps everything it
+ * had, a field left out inside a named section keeps its value, and an array
+ * that is sent replaces the stored one whole. So a screen can send back just
+ * the row it changed, and an editor rendering a whole list can send back
+ * exactly what it shows.
+ */
+export interface AppSettingsPatch {
+  appearance?: Partial<AppearanceSettings>;
+  engine?: Partial<EngineSettings>;
+  gates?: Partial<GateSettings>;
+  ai?: AISettingsPatch;
+}
+
+export interface SettingsStoreOptions {
+  /** Database file. Overrides `dir`. */
+  path?: string;
+  /**
+   * Directory to hold `settings.db`. Defaults to `$STRATA_DATA_DIR`, else
+   * `<cwd>/.strata`.
+   */
+  dir?: string;
+  /** Where to report a store that could not be opened. */
+  log?: Logger;
+}
+
+/**
+ * The app-scoped settings store: one row about this workbench. Durable user
+ * data like the project registry, and nothing in it is derived, so `DELETE
+ * /cache` never touches it.
+ *
+ * Synchronous throughout, for the same reason the registry is: it is a single
+ * row read on request, and `node:sqlite` is synchronous anyway.
+ */
+export interface SettingsStore {
+  /** The database file backing the store, or `null` when it is in memory. */
+  readonly path: string | null;
+  /** Every setting, filled out with the defaults. */
+  get(): AppSettings;
+  /**
+   * Merge a patch into what is stored and return the result. Throws
+   * `InvalidSettingsError` on a value that cannot be stored as written.
+   */
+  patch(patch: AppSettingsPatch): AppSettings;
+  close(): void;
+}

--- a/packages/server/ARCHITECTURE.md
+++ b/packages/server/ARCHITECTURE.md
@@ -11,8 +11,8 @@ UI and CI. Keeps transport concerns out of the core.
 
 ## 2. Constraints
 
-- Stateless request handling (state lives in the core: the cache and the
-  project registry).
+- Stateless request handling (state lives in the core: the cache, the project
+  registry and the app settings).
 - No business logic beyond validation + delegation to the core.
 - Must run in the container as a non-root user.
 
@@ -25,7 +25,7 @@ UI and CI. Keeps transport concerns out of the core.
 | Method | Path | Purpose |
 |--------|------|---------|
 | GET | `/health` | Liveness. |
-| GET | `/plugins` | What loaded, from where, and what was skipped: `{ directory, plugins, failures }` — each plugin its manifest plus a `source` (`builtin`/`user`). |
+| GET | `/plugins` | What loaded, from where, and what was skipped: `{ directory, plugins, failures }` — each plugin its manifest plus a `source` (`builtin`/`user`). `directory` is the one actually scanned at startup. |
 | GET | `/projects` | `{ projects }` — the registry, in registration order; each entry carries its id, display name, root and last-analysis summary. |
 | POST | `/projects` | Body `{ name, root }` → the created `Project` (201). The root is resolved to the repository that owns it; 400 if it owns none, 409 if that repository is already registered. |
 | GET | `/projects/:id` | One project, or 404. |
@@ -33,18 +33,20 @@ UI and CI. Keeps transport concerns out of the core.
 | DELETE | `/projects/:id` | Drop the entry and its config (`{ removed: true }`), or 404. Never touches the repository on disk. |
 | GET | `/projects/:id/config` | That project's settings, filled out with the defaults. |
 | PATCH | `/projects/:id/config` | Body: any of `rev`, `historyLimit`, `ignore`, `paths`, `languages`, `metrics`, `convention`, `rules` → the whole config. Merges by field; an array replaces. 400 on a value that cannot be stored or a plugin id nobody loaded. |
-| POST | `/analyze` | Body `{ root, rev?, historyLimit?, cache? }` → `AnalysisReport` (incl. run metadata and cache stats). Over a registered root, the project's config supplies the defaults and the run updates its last-analysis summary. |
-| DELETE | `/cache` | Empty the incremental cache. Registered projects are untouched — they live in their own database. |
+| GET | `/settings` | The app-wide settings, filled out with the defaults: `{ appearance, engine, gates, ai }`. |
+| PATCH | `/settings` | Body: any of those four sections → all of them. Merges two levels deep (section, then field); an array replaces. 400 on a value that cannot be stored, or on a section named with no field in it. |
+| POST | `/analyze` | Body `{ root, rev?, historyLimit?, cache? }` → `AnalysisReport` (incl. run metadata and cache stats). Over a registered root, the project's config supplies the defaults and the run updates its last-analysis summary; the cache default comes from the app settings. |
+| DELETE | `/cache` | Empty the incremental cache — the *Clear cache* button, which is an action rather than a setting. Registered projects and app settings are untouched: both live in their own databases. |
 
 ## 4. Building Blocks
 
 | File | Responsibility |
 |------|----------------|
 | `index.ts` | Barrel — the package's public surface. |
-| `app.ts` | `createServer()` — plugin registry, one `Strata`, one project store, routes, shutdown hook. |
+| `app.ts` | `createServer()` — settings, plugin registry, one `Strata`, one project store, routes, shutdown hook. |
 | `main.ts` | Process entry point (`node dist/main.js`). |
-| `registry.ts` | `buildRegistry()` — load the built-ins, then the user plugins directory. |
-| `routes/health.ts` … `routes/project-config.ts` | One module per endpoint. |
+| `registry.ts` | `buildRegistry(opts)` — load the built-ins, then the user plugins directory the settings name (unless third-party loading is off). |
+| `routes/health.ts` … `routes/settings.ts` | One module per endpoint. |
 | `routes/http-error.ts` | `httpError(status, message)` — a thrown error Fastify serialises in its own error shape. |
 | `routes/patch.ts` | `requirePatch()` — refuse a PATCH that changes nothing. |
 | `routes/plugin-ids.ts` | `requireKnownPlugins()` — refuse settings naming a plugin nobody loaded. |
@@ -66,8 +68,19 @@ once at startup, as does opening the registry.
 - **A plugin that will not load never fails startup** — it is reported on
   `GET /plugins` instead, which is what the plugins settings screen reads.
 - **One long-lived `Strata`**, so the cache is opened once and closed with the
-  server (`onClose`), not per request. The project store is opened and closed
-  the same way.
+  server (`onClose`), not per request. The project store and the settings store
+  are opened and closed the same way.
+- **Settings are read before plugins are loaded** — *Plugins & engine* decides
+  which directory is scanned and whether drop-in plugins are loaded at all, and
+  loading happens exactly once, at startup. So `createServer()` opens the
+  settings first, and `/plugins` reports the directory that was actually
+  scanned rather than the one a setting has been changed to since: a pending
+  change should read as pending, not as history.
+- **A setting is honoured where its consumer already exists**, and stored
+  otherwise. The cache toggle is a per-run default on `/analyze`, the plugin
+  settings are read at startup — appearance, the CI gates and the AI providers
+  are served to a shell, a headless CI mode and a provider runtime that are
+  still being built, and the backlog says so rather than the API pretending.
 - **`/analyze` refreshes the registry itself** — the switcher shows how long ago
   each project was analysed, and a run over a registered root is that fact,
   whoever asked for it. No `projectId` in the request body, so a CI run and a
@@ -95,9 +108,14 @@ once at startup, as does opening the registry.
 - **Risk:** `root` points anywhere on disk, and the API is unauthenticated —
   `DELETE /cache` is reachable by anyone who can reach the port (cost: a
   recomputation), and so is `DELETE /projects/:id` (cost: a registry entry, and
-  nothing on disk). **Mitigation:** the API assumes a trusted network and
-  deployments mount repos read-only under a fixed prefix; path allow-listing and
-  auth are on the backlog. Do not expose the port publicly.
+  nothing on disk). `PATCH /settings` is reachable too, and it names a plugins
+  directory the next start will load code from. **Mitigation:** the API assumes
+  a trusted network and deployments mount repos read-only under a fixed prefix;
+  path allow-listing and auth are on the backlog. Do not expose the port
+  publicly.
+- **Risk:** AI provider `env` values are stored and served in plain text.
+  **Mitigation:** secret storage is the next item in that area; until it lands,
+  nothing sensitive belongs in provider settings.
 - **Risk:** malformed request bodies. **Mitigation:** `/analyze` carries a JSON
   schema, so a wrong-typed field (`"cache": "false"`) is a 400 rather than a
   silently ignored option.

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -1,26 +1,65 @@
 import Fastify, { type FastifyInstance } from 'fastify';
-import { openProjectStore, Strata } from '@strata/core';
+import {
+  createConsoleLogger,
+  DEFAULT_APP_SETTINGS,
+  openProjectStore,
+  openSettingsStore,
+  Strata,
+  userPluginsDir,
+  type EngineSettings,
+  type SettingsStore,
+} from '@strata/core';
 import { buildRegistry } from './registry.js';
 import { registerRoutes } from './routes/index.js';
 
 /**
- * Build the HTTP app: discover plugins once, hold one `Strata` (so the
- * incremental cache is opened once and closed with the server) and one project
- * registry, register routes.
+ * Build the HTTP app: read the app settings, discover plugins the way they say
+ * to, hold one `Strata` (so the incremental cache is opened once and closed
+ * with the server), one project registry and one settings store, register
+ * routes.
+ *
+ * The settings come first because *Plugins & engine* decides what gets loaded,
+ * and loading happens exactly once, here.
  */
 export async function createServer(): Promise<FastifyInstance> {
   const app = Fastify({ logger: true });
-  const registry = await buildRegistry();
+  const settings = openSettingsStore();
+  const engine = engineSettings(settings);
+  const pluginsDir = engine.pluginsDir ?? userPluginsDir();
+  const registry = await buildRegistry({
+    pluginsDir,
+    thirdParty: engine.thirdPartyPlugins,
+  });
   const strata = new Strata(registry);
   const projects = openProjectStore();
 
-  registerRoutes(app, { strata, registry, projects });
+  registerRoutes(app, { strata, registry, projects, settings, pluginsDir });
 
-  // Flush and close the cache and the registry with the server.
+  // Flush and close the cache, the registry and the settings with the server.
   app.addHook('onClose', async () => {
     strata.close();
     projects.close();
+    settings.close();
   });
 
   return app;
+}
+
+/**
+ * What *Plugins & engine* says, or the defaults. Opening the settings already
+ * degrades rather than throws; reading them has to as well, because a store
+ * that opened but cannot be read (a locked or corrupt file) would otherwise
+ * take the whole server down over a preference.
+ */
+function engineSettings(settings: SettingsStore): EngineSettings {
+  try {
+    return settings.get().engine;
+  } catch (err) {
+    createConsoleLogger('strata:settings').warn(
+      `starting on the default engine settings — could not read them: ${
+        (err as Error).message
+      }`,
+    );
+    return DEFAULT_APP_SETTINGS.engine;
+  }
 }

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -12,6 +12,17 @@ const BUILTINS = [
   'plugins/language-typescript/strata.plugin.json',
 ];
 
+/** What *Settings → Plugins & engine* decides about loading. */
+export interface RegistryOptions {
+  /** Where drop-in plugins live. Defaults to `userPluginsDir()`. */
+  pluginsDir?: string;
+  /**
+   * Load drop-in plugins at all (default `true`). Off is the way back into a
+   * workbench a third-party plugin has made unusable, without deleting it.
+   */
+  thirdParty?: boolean;
+}
+
 /**
  * Discover and load plugins: the built-ins that ship here, then every plugin
  * installed in the user plugins directory (see docs/PLUGINS.md). Built-ins go
@@ -20,11 +31,15 @@ const BUILTINS = [
  * Neither step can fail startup — a plugin that will not load is recorded in
  * `registry.failures()` and served on `GET /plugins`.
  */
-export async function buildRegistry(): Promise<PluginRegistry> {
+export async function buildRegistry(
+  opts: RegistryOptions = {},
+): Promise<PluginRegistry> {
   const registry = new PluginRegistry();
   for (const rel of BUILTINS) {
     await registry.load(resolve(REPO_ROOT, rel), 'builtin');
   }
-  await registry.loadDirectory(userPluginsDir(), 'user');
+  if (opts.thirdParty !== false) {
+    await registry.loadDirectory(opts.pluginsDir ?? userPluginsDir(), 'user');
+  }
   return registry;
 }

--- a/packages/server/src/routes/analyze.test.ts
+++ b/packages/server/src/routes/analyze.test.ts
@@ -1,10 +1,12 @@
 import Fastify, { type FastifyInstance } from 'fastify';
 import {
   memoryProjectStore,
+  memorySettingsStore,
   type AnalysisReport,
   type AnalyzeOptions,
   type PluginRegistry,
   type ProjectStore,
+  type SettingsStore,
   type Strata,
 } from '@strata/core';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -48,14 +50,20 @@ const strata = {
 } as unknown as Strata;
 
 let projects: ProjectStore;
+let settings: SettingsStore;
 let app: FastifyInstance;
 
-function build(store: ProjectStore): FastifyInstance {
+function build(
+  store: ProjectStore,
+  appSettings: SettingsStore = settings,
+): FastifyInstance {
   const instance = Fastify();
   analyzeRoute(instance, {
     strata,
     projects: store,
+    settings: appSettings,
     registry: {} as PluginRegistry,
+    pluginsDir: '/app/.strata/plugins',
   });
   return instance;
 }
@@ -71,6 +79,7 @@ async function analyze(root: string, body: Record<string, unknown> = {}) {
 beforeEach(() => {
   requested = undefined;
   projects = memoryProjectStore();
+  settings = memorySettingsStore();
   app = build(projects);
 });
 
@@ -117,6 +126,43 @@ describe('POST /analyze', () => {
     // `HEAD` and no cap are what the core does anyway; a null limit must not
     // reach it as a number.
     expect(requested).toMatchObject({ rev: 'HEAD', historyLimit: undefined });
+  });
+
+  it('runs with the cache the app settings leave switched on', async () => {
+    await analyze('/repos/strata');
+    expect(requested).toMatchObject({ cache: true });
+
+    settings.patch({ engine: { cache: false } });
+    await analyze('/repos/strata');
+
+    expect(requested).toMatchObject({ cache: false });
+  });
+
+  it('lets a request ask for a cold run whatever the settings say', async () => {
+    await analyze('/repos/strata', { cache: false });
+    expect(requested).toMatchObject({ cache: false });
+
+    settings.patch({ engine: { cache: false } });
+    await analyze('/repos/strata', { cache: true });
+
+    expect(requested).toMatchObject({ cache: true });
+  });
+
+  it('still returns the report when the settings cannot be read', async () => {
+    const broken: SettingsStore = {
+      ...settings,
+      get: () => {
+        throw new Error('database is locked');
+      },
+    };
+    await app.close();
+    app = build(projects, broken);
+
+    const response = await analyze('/repos/strata');
+
+    expect(response.statusCode).toBe(200);
+    // No preference reaches the core, so it keeps its own default.
+    expect(requested).toMatchObject({ cache: undefined });
   });
 
   it('analyses a root nobody registered without recording anything', async () => {

--- a/packages/server/src/routes/analyze.ts
+++ b/packages/server/src/routes/analyze.ts
@@ -39,7 +39,9 @@ export function analyzeRoute(app: FastifyInstance, ctx: RouteContext): void {
       root,
       rev: rev ?? config?.rev,
       historyLimit: historyLimit ?? config?.historyLimit ?? undefined,
-      cache,
+      // The incremental cache is app-scoped, not per project: it is keyed on
+      // blob shas and shared across every repository this workbench analyses.
+      cache: cache ?? cacheEnabled(ctx, req.log),
     });
 
     // The switcher shows how long ago each project was analysed, so every run
@@ -60,6 +62,23 @@ export function analyzeRoute(app: FastifyInstance, ctx: RouteContext): void {
     }
     return report;
   });
+}
+
+/**
+ * Whether *Settings → Plugins & engine* leaves the incremental cache on;
+ * `undefined` leaves the core its own default. Settings that cannot be read
+ * cost the run a preference, never the run itself.
+ */
+function cacheEnabled(
+  ctx: RouteContext,
+  log: { warn(message: string): void },
+): boolean | undefined {
+  try {
+    return ctx.settings.get().engine.cache;
+  } catch (err) {
+    log.warn(`could not read the app settings: ${(err as Error).message}`);
+    return undefined;
+  }
 }
 
 /**

--- a/packages/server/src/routes/context.ts
+++ b/packages/server/src/routes/context.ts
@@ -1,8 +1,21 @@
-import type { PluginRegistry, ProjectStore, Strata } from '@strata/core';
+import type {
+  PluginRegistry,
+  ProjectStore,
+  SettingsStore,
+  Strata,
+} from '@strata/core';
 
 /** What every route needs from the app it is registered on. */
 export interface RouteContext {
   strata: Strata;
   registry: PluginRegistry;
   projects: ProjectStore;
+  settings: SettingsStore;
+  /**
+   * Directory the drop-in plugins were actually read from at startup — the
+   * app settings' `engine.pluginsDir`, or the environment's default. Resolved
+   * once, so `/plugins` reports what was scanned rather than what a setting
+   * changed to since.
+   */
+  pluginsDir: string;
 }

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -5,6 +5,7 @@ import { healthRoute } from './health.js';
 import { pluginsRoute } from './plugins.js';
 import { projectConfigRoute } from './project-config.js';
 import { projectsRoute } from './projects.js';
+import { settingsRoute } from './settings.js';
 import type { RouteContext } from './context.js';
 
 export type { RouteContext } from './context.js';
@@ -15,6 +16,7 @@ export function registerRoutes(app: FastifyInstance, ctx: RouteContext): void {
   pluginsRoute(app, ctx);
   projectsRoute(app, ctx);
   projectConfigRoute(app, ctx);
+  settingsRoute(app, ctx);
   analyzeRoute(app, ctx);
   cacheRoute(app, ctx);
 }

--- a/packages/server/src/routes/plugins.ts
+++ b/packages/server/src/routes/plugins.ts
@@ -1,15 +1,21 @@
 import type { FastifyInstance } from 'fastify';
-import { userPluginsDir } from '@strata/core';
 import type { RouteContext } from './context.js';
 
 /**
  * What the server loaded at startup: every plugin's manifest tagged with where
  * it came from, the directory third-party plugins are read from, and anything
  * that was found but skipped — all three drive the plugins settings screen.
+ *
+ * The directory is the one resolved at startup, when plugins load — so a
+ * *Plugins directory* edited since then reads as the pending change it is,
+ * rather than as where these plugins came from. It is reported whether or not
+ * third-party loading is switched on, because it is where a drop-in plugin
+ * goes either way; whether they were loaded is `engine.thirdPartyPlugins` on
+ * `/settings`, which is the toggle the same screen renders beside the path.
  */
 export function pluginsRoute(app: FastifyInstance, ctx: RouteContext): void {
   app.get('/plugins', async () => ({
-    directory: userPluginsDir(),
+    directory: ctx.pluginsDir,
     plugins: ctx.registry
       .all()
       .map((l) => ({ ...l.manifest, source: l.source })),

--- a/packages/server/src/routes/project-config.test.ts
+++ b/packages/server/src/routes/project-config.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import Fastify, { type FastifyInstance } from 'fastify';
 import {
   memoryProjectStore,
+  memorySettingsStore,
   PluginRegistry,
   type ProjectStore,
   type Strata,
@@ -70,7 +71,13 @@ beforeEach(() => {
   projects = memoryProjectStore();
   id = projects.add({ name: 'Strata', root: '/repos/strata' }).id;
   app = Fastify();
-  projectConfigRoute(app, { projects, registry, strata: {} as Strata });
+  projectConfigRoute(app, {
+    projects,
+    registry,
+    settings: memorySettingsStore(),
+    strata: {} as Strata,
+    pluginsDir: '/app/.strata/plugins',
+  });
 });
 
 afterEach(async () => {

--- a/packages/server/src/routes/projects.test.ts
+++ b/packages/server/src/routes/projects.test.ts
@@ -7,6 +7,7 @@ import { promisify } from 'node:util';
 import Fastify, { type FastifyInstance } from 'fastify';
 import {
   memoryProjectStore,
+  memorySettingsStore,
   type PluginRegistry,
   type ProjectStore,
   type Strata,
@@ -50,8 +51,10 @@ beforeEach(async () => {
   app = Fastify();
   projectsRoute(app, {
     projects,
+    settings: memorySettingsStore(),
     strata: {} as Strata,
     registry: {} as PluginRegistry,
+    pluginsDir: '/app/.strata/plugins',
   });
 });
 

--- a/packages/server/src/routes/settings.test.ts
+++ b/packages/server/src/routes/settings.test.ts
@@ -1,0 +1,198 @@
+import Fastify, { type FastifyInstance } from 'fastify';
+import {
+  memoryProjectStore,
+  memorySettingsStore,
+  type PluginRegistry,
+  type SettingsStore,
+  type Strata,
+} from '@strata/core';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { settingsRoute } from './settings.js';
+
+/**
+ * The app-wide *Settings* screens read and write through here. A PATCH merges
+ * two levels deep, so a screen that edits one section leaves the others alone —
+ * and a value the workbench could not act on is refused rather than stored.
+ */
+
+let settings: SettingsStore;
+let app: FastifyInstance;
+
+beforeEach(() => {
+  settings = memorySettingsStore();
+  app = Fastify();
+  settingsRoute(app, {
+    settings,
+    projects: memoryProjectStore(),
+    registry: {} as PluginRegistry,
+    strata: {} as Strata,
+    pluginsDir: '/app/.strata/plugins',
+  });
+});
+
+afterEach(async () => {
+  await app.close();
+});
+
+function get() {
+  return app.inject({ url: '/settings' });
+}
+
+async function patch(body: unknown) {
+  return await app.inject({
+    method: 'PATCH',
+    url: '/settings',
+    payload: body as Record<string, unknown>,
+  });
+}
+
+describe('GET /settings', () => {
+  it('answers with the defaults before anything is configured', async () => {
+    const response = await get();
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      appearance: { theme: 'system', density: 'balanced' },
+      engine: { pluginsDir: null, thirdPartyPlugins: true, cache: true },
+      gates: { failOnNewCycles: false, hotspotRegression: null },
+      ai: { healthCheckInterval: 0, providers: [] },
+    });
+  });
+});
+
+describe('PATCH /settings', () => {
+  it('merges into what is stored and answers with all of it', async () => {
+    await patch({ appearance: { theme: 'light' } });
+
+    const response = await patch({ appearance: { density: 'dense' } });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().appearance).toEqual({
+      theme: 'light',
+      density: 'dense',
+    });
+    expect((await get()).json().appearance.theme).toBe('light');
+  });
+
+  it('leaves the sections a screen did not touch alone', async () => {
+    await patch({ engine: { cache: false } });
+
+    const response = await patch({ gates: { hotspotRegression: 15 } });
+
+    expect(response.json()).toMatchObject({
+      engine: { cache: false },
+      gates: { hotspotRegression: 15, failOnNewCycles: false },
+      appearance: { theme: 'system' },
+    });
+  });
+
+  it('stores a plugins directory as an absolute path, and null to follow the environment', async () => {
+    const set = await patch({ engine: { pluginsDir: '/opt/strata/plugins' } });
+    expect(set.json().engine.pluginsDir).toBe('/opt/strata/plugins');
+
+    const cleared = await patch({ engine: { pluginsDir: null } });
+    expect(cleared.json().engine.pluginsDir).toBeNull();
+  });
+
+  it('stores an AI provider, defaulting a new one to disabled', async () => {
+    const response = await patch({
+      ai: {
+        providers: [
+          {
+            id: 'codex',
+            name: 'Codex',
+            binary: '/usr/local/bin/codex',
+            shadowHome: '/home/dev/.codex-work',
+            args: ['--json'],
+            env: { CODEX_PROFILE: 'work' },
+            models: ['o4-mini'],
+          },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().ai.providers).toEqual([
+      {
+        id: 'codex',
+        name: 'Codex',
+        enabled: false,
+        accent: null,
+        binary: '/usr/local/bin/codex',
+        home: null,
+        shadowHome: '/home/dev/.codex-work',
+        args: ['--json'],
+        env: { CODEX_PROFILE: 'work' },
+        models: ['o4-mini'],
+      },
+    ]);
+  });
+
+  it('replaces the provider list whole, the way the screen renders it', async () => {
+    await patch({ ai: { providers: [{ id: 'codex', name: 'Codex' }] } });
+
+    const response = await patch({
+      ai: { providers: [{ id: 'claude', name: 'Claude' }] },
+    });
+
+    const ids = response.json().ai.providers.map((p: { id: string }) => p.id);
+    expect(ids).toEqual(['claude']);
+  });
+
+  it('rejects a value that cannot mean anything', async () => {
+    expect((await patch({ appearance: { theme: 'midnight' } })).statusCode).toBe(
+      400,
+    );
+    expect((await patch({ appearance: { density: 'roomy' } })).statusCode).toBe(
+      400,
+    );
+    expect((await patch({ gates: { hotspotRegression: -1 } })).statusCode).toBe(
+      400,
+    );
+    expect((await patch({ ai: { healthCheckInterval: -1 } })).statusCode).toBe(
+      400,
+    );
+    expect((await patch({ engine: { cache: 'off' } })).statusCode).toBe(400);
+    expect((await patch({ nope: true })).statusCode).toBe(400);
+  });
+
+  it('rejects a provider nobody could launch or address', async () => {
+    const refused = async (provider: unknown) => {
+      const response = await patch({ ai: { providers: [provider] } });
+      return response.statusCode;
+    };
+
+    expect(await refused({ name: 'Codex' })).toBe(400);
+    expect(await refused({ id: 'Codex Agent', name: 'Codex' })).toBe(400);
+    expect(await refused({ id: 'codex', name: '' })).toBe(400);
+    expect(await refused({ id: 'codex', name: 'Codex', accent: 'blue' })).toBe(
+      400,
+    );
+    expect(
+      await refused({ id: 'codex', name: 'Codex', env: { 'a b': 'x' } }),
+    ).toBe(400);
+
+    // Nothing of a refused patch is stored.
+    expect((await get()).json().ai.providers).toEqual([]);
+  });
+
+  it('rejects two providers sharing an id, which the schema cannot see', async () => {
+    const response = await patch({
+      ai: {
+        providers: [
+          { id: 'codex', name: 'Codex' },
+          { id: 'codex', name: 'Codex, again' },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json().message).toContain('codex');
+  });
+
+  it('rejects a patch that changes nothing', async () => {
+    expect((await patch({})).statusCode).toBe(400);
+    // Naming a screen without naming a setting on it is the same client bug.
+    expect((await patch({ appearance: {} })).statusCode).toBe(400);
+  });
+});

--- a/packages/server/src/routes/settings.ts
+++ b/packages/server/src/routes/settings.ts
@@ -1,0 +1,107 @@
+import type { FastifyInstance } from 'fastify';
+import {
+  DENSITIES,
+  InvalidSettingsError,
+  THEME_MODES,
+  type AppSettingsPatch,
+} from '@strata/core';
+import type { RouteContext } from './context.js';
+import { httpError } from './http-error.js';
+import { requirePatch } from './patch.js';
+
+const provider = {
+  type: 'object',
+  required: ['id', 'name'],
+  additionalProperties: false,
+  properties: {
+    id: { type: 'string', pattern: '^[a-z0-9][a-z0-9-]*$', maxLength: 48 },
+    name: { type: 'string', minLength: 1, maxLength: 100 },
+    enabled: { type: 'boolean' },
+    accent: {
+      type: ['string', 'null'],
+      pattern: '^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$',
+    },
+    binary: { type: ['string', 'null'], minLength: 1 },
+    home: { type: ['string', 'null'], minLength: 1 },
+    shadowHome: { type: ['string', 'null'], minLength: 1 },
+    args: { type: 'array', items: { type: 'string' } },
+    env: {
+      type: 'object',
+      propertyNames: { pattern: '^[A-Za-z_][A-Za-z0-9_]*$' },
+      additionalProperties: { type: 'string' },
+    },
+    models: { type: 'array', items: { type: 'string' } },
+  },
+};
+
+/** One object per settings screen, so a screen can PATCH only its own section. */
+const section = (properties: Record<string, unknown>) => ({
+  type: 'object',
+  additionalProperties: false,
+  properties,
+});
+
+const patchSchema = {
+  body: section({
+    appearance: section({
+      theme: { enum: [...THEME_MODES] },
+      density: { enum: [...DENSITIES] },
+    }),
+    engine: section({
+      pluginsDir: { type: ['string', 'null'], minLength: 1 },
+      thirdPartyPlugins: { type: 'boolean' },
+      cache: { type: 'boolean' },
+    }),
+    gates: section({
+      failOnNewCycles: { type: 'boolean' },
+      hotspotRegression: { type: ['number', 'null'], minimum: 0 },
+    }),
+    ai: section({
+      healthCheckInterval: { type: 'integer', minimum: 0 },
+      providers: { type: 'array', items: provider },
+    }),
+  }),
+};
+
+/**
+ * The app-wide *Settings* screens: appearance, the plugin and cache engine, the
+ * CI gates, and the AI providers this workbench knows about. One scope up from
+ * `/projects/:id/config` — nothing here belongs to a single repository.
+ *
+ * `PATCH` merges two levels deep: a section left out keeps everything it had, a
+ * field left out inside a section keeps its value, and an array that is sent
+ * replaces the stored one whole.
+ *
+ * Reading is not the same as taking effect. The cache toggle applies to the
+ * next run; the plugins directory and the third-party switch are read when the
+ * server starts, because that is when plugins load; appearance, the gates and
+ * the providers are stored for the shell, headless CI mode and the provider
+ * work still to come.
+ */
+export function settingsRoute(app: FastifyInstance, ctx: RouteContext): void {
+  app.get('/settings', async () => ctx.settings.get());
+
+  app.patch<{ Body: AppSettingsPatch }>(
+    '/settings',
+    { schema: patchSchema },
+    async (req) => {
+      // An empty patch is a client bug, not a way to read the settings back —
+      // and `{"appearance": {}}` names a screen and changes nothing on it.
+      requirePatch(req.body, 'setting');
+      for (const [name, fields] of Object.entries(req.body)) {
+        if (Object.keys(fields).length === 0) {
+          throw httpError(400, `Name at least one ${name} setting to change.`);
+        }
+      }
+
+      try {
+        return ctx.settings.patch(req.body);
+      } catch (err) {
+        if (err instanceof InvalidSettingsError) {
+          throw httpError(400, err.message);
+        }
+        throw err;
+      }
+    },
+  );
+}


### PR DESCRIPTION
## What

Adds the app-scoped settings store and its endpoints: `GET`/`PATCH` `/settings`,
holding appearance (theme, density), the plugins directory, third-party plugin
loading, the incremental cache toggle, the CI gate thresholds and the AI
provider instances.

Four sections, one per settings screen:

| Section | Fields |
|---|---|
| `appearance` | `theme` (dark/light/system), `density` (dense/balanced/airy) |
| `engine` | `pluginsDir`, `thirdPartyPlugins`, `cache` |
| `gates` | `failOnNewCycles`, `hotspotRegression` |
| `ai` | `healthCheckInterval`, `providers[]` (id, name, enabled, accent, binary, home, shadowHome, args, env, models) |

```bash
curl -s localhost:4000/settings
curl -X PATCH localhost:4000/settings -H 'content-type: application/json' \
  -d '{"appearance":{"theme":"light"},"gates":{"failOnNewCycles":true}}'
```

## Why

The mockup's app-wide **Settings** area needs somewhere to write to, the same
way *Project settings* got `/projects/:id/config` in #58.

The two are separate resources because they answer different questions:
`/projects/:id/config` is what an analysis of one repository does, and nothing
on `/settings` belongs to a repository at all.

Closes #59

## Notes for the reviewer

**Merge depth.** A `PATCH` merges two levels — a section left out keeps
everything it had, a field left out inside a named section keeps its value — so
one screen can send back only what it edits. Arrays still replace whole, which
is what an editor rendering a provider list can post. Naming a section with no
field in it (`{"appearance":{}}`) is a 400, like the existing empty-patch check.

**Its own database.** `settings.db`, beside `projects.db` rather than a table in
it: the registry's schema is the one that keeps changing as project features
land, and a migration there must not be able to cost somebody their provider
configuration. Stored sparsely and defaulted on read, for the same reason a
project's config is.

**Honoured where the consumer exists, stored where it does not.** The cache
toggle is the default for the next `/analyze` (an explicit `cache` field in the
request still wins); the plugins directory and the third-party switch are read
when the server starts, because that is when plugins load — so `buildRegistry`
takes them and `/plugins` reports the directory actually scanned, letting a path
edited since read as the pending change it is. *Clear cache* stays
`DELETE /cache`: an action, not a setting. Appearance, the gates and the
providers have no consumer yet (shell, headless CI mode, provider runtime are
their own backlog items), so `BACKLOG.md` now cross-references `/settings` from
each of those instead of the API pretending.

**A provider is declared, not launched.** It is off until somebody turns it on,
the same way a new architecture rule reports until it is marked enforced.

**Worth knowing:** provider `env` values are stored and served as written.
Secret storage is the P1 item right after this one, so nothing sensitive belongs
in them yet — called out in the README, both `ARCHITECTURE.md` risk sections and
the backlog item.

## Type of change

- [x] feat / fix / perf / refactor
- [ ] docs / test / build / ci / chore

## Checklist

- [x] `pnpm build && pnpm test && pnpm lint` pass locally (399 tests, 66 files)
- [x] Added/updated tests where it made sense — `settings/settings.test.ts`,
      `settings/store.test.ts`, `routes/settings.test.ts`, plus the cache-default
      and degrade cases in `routes/analyze.test.ts`
- [x] Docs updated — README, `docs/ARCHITECTURE.md`, both module
      `ARCHITECTURE.md` files, `.env.example`, `Dockerfile`, `compose.yml`,
      `Makefile`, `BACKLOG.md`

Also ran the built server for real: defaults, section merges, provider
round-trip, every refusal path, persistence across a restart, the configured
plugins directory taking effect at boot, and the cache toggle reaching an
analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
