### PR TITLE
feat(sdk): summarise the dependency graph in the language result

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -116,10 +116,14 @@ New area — the mockup's settings screens need somewhere to write to.
       config); user-declared ones wait for per-project plugin settings.
 - [x] Real metrics — cyclomatic complexity, max nesting depth and cross-file
       duplication per file, counted over the syntax tree rather than raw text.
-- [ ] **P0** Graph summary in the language result — node/edge counts, cycle count,
-      and fan-in/fan-out ranking (the mockup's *Max fan-in · sdk · 7* panel).
-      The graph view computes this in the browser meanwhile
-      (`apps/web/src/lib/graph/summary.ts`), which is what it stops doing.
+- [x] Graph summary in the language result — every `LanguageAnalysis` carries
+      node/edge counts, the cycle count and the files those cycles hold, and the
+      busiest node in each direction (the mockup's *Max fan-in · sdk · 7*
+      panel). `summariseGraph` in the SDK counts it, so every language module
+      reports the same numbers; a result that arrives without one — a plugin
+      built against an older SDK, or a run it cached back then — is summarised
+      by the core. The graph view stopped computing it in the browser:
+      `apps/web/src/lib/graph/summary.ts` now only adds the languages up.
 - [ ] **P1** Emit each SCC as an ordered path so the UI can print the cycle as
       `a → b → a` instead of an unordered node set. Ordered in the browser for
       now (`apps/web/src/lib/graph/cycles.ts`).

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ theme layer and API client wired; the analysis screens are next. See
 **Per-language analysis** (one plugin per language)
 - Dependency graph + import-cycle detection ✅ (TS/JS, parsed with tree-sitter,
   resolving `tsconfig.json` path aliases and dynamic imports)
+- Graph summary — nodes, edges, cycles and the busiest module in each
+  direction, counted with the graph ✅
 - Dead code — unreferenced exports, unreachable files, unused dependencies ✅ (TS/JS)
 - Metrics: LOC, cyclomatic complexity, nesting, duplication ✅ (TS/JS)
 - Angular module: component/DI graph, lazy boundaries ⏳

--- a/apps/web/ARCHITECTURE.md
+++ b/apps/web/ARCHITECTURE.md
@@ -40,7 +40,7 @@ app-scoped settings screens. The face of Strata for browser/self-host use.
 | `src/lib/format/*` | `number` (compact counts) and `path` (repo path → dir + name), used by every screen |
 | `src/lib/geometry/*` | `squarify` — the squarified treemap layout |
 | `src/lib/hotspots/*` | The hotspot feature end to end: `rows` (report → rows), `heat` (ramp), and the three views |
-| `src/lib/graph/*` | The dependency feature end to end: `merge` (report → one graph), `tree`/`rows` (the folder tree), `collapse` (closed folders), `rank` + `lanes` + `layered` (the columned layout), `edges`, `degree`, `summary`, `cycles`, `focus`, `viewport` (pan/zoom), and the five views |
+| `src/lib/graph/*` | The dependency feature end to end: `merge` (report → one graph), `summary` (report → the panel's numbers), `tree`/`rows` (the folder tree), `collapse` (closed folders), `rank` + `lanes` + `layered` (the columned layout), `edges`, `degree`, `cycles`, `focus`, `viewport` (pan/zoom), and the five views |
 | `src/lib/components/*` | Reusable UI pieces |
 | `src/routes/*` | SvelteKit routes; `+layout.ts` pins the app to SPA mode |
 | `src/lib/test/*` | Test helpers: `render` mounts a component, `graph` builds a graph from an edge list |
@@ -95,10 +95,9 @@ what more than one screen uses moves up into `lib/components/`.
   in `localStorage`. That is the project switcher's job — this goes away with it.
 - **Debt:** a treemap draws the top ~50 files; the rest of the ranking is only
   in the table. A zoom or a directory roll-up is the fix if it starts to bite.
-- **Debt:** the graph summary (nodes, edges, cycles, fan-in) is computed in the
-  browser from `languages[*].graph`. The backlog puts it in the language result;
-  when it lands, `summary.ts` fills its shape from the report and the view does
-  not change.
+- **Decision:** the graph summary (nodes, edges, cycles, fan-in) is read, not
+  computed: every language result carries its own, counted by the plugin, and
+  `summary.ts` only adds them up across languages.
 - **Debt:** package edges are styled but never drawn — by choice, the
   TypeScript module reports only imports that land in the repository. The
   legend shows a style only when the drawing contains it, and `merge.ts`
@@ -114,8 +113,9 @@ what more than one screen uses moves up into `lib/components/`.
   the graph pure layer (merge and package synthesis, the folder tree and its
   compression, collapsing and its edge merging, the ranking's direction and its
   cycle-breaking, the layered layout's uniform cards, non-overlap of cards *and*
-  containers, growth and purity, the panel rows, degrees and ranking, the
-  summary, cycle paths over real edges, the focus ranking, edge classification,
+  containers, growth and purity, the panel rows, degrees, the
+  summary fold across languages, cycle paths over real edges, the focus
+  ranking, edge classification,
   and the viewport's zoom, clamping, letterboxing and carrying across a resize) with its canvas, folder tree and
   cycle list, the analysis store (including a superseded run), plus the
   `/hotspots` and `/graph` routes end to end. Components mount through

--- a/apps/web/src/lib/graph/GraphStats.svelte
+++ b/apps/web/src/lib/graph/GraphStats.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
+  import type { GraphSummary } from '@strata/sdk';
   import { compactNumber, fileName } from '$lib/format';
-  import type { GraphSummary } from './summary';
 
   interface Props {
     summary: GraphSummary;

--- a/apps/web/src/lib/graph/degree.test.ts
+++ b/apps/web/src/lib/graph/degree.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { graphOf } from '$lib/test/graph';
-import { degrees, ranking } from './degree';
+import { degrees } from './degree';
 
 describe('degrees', () => {
   it('counts imports in and out, leaves included', () => {
@@ -10,17 +10,5 @@ describe('degrees', () => {
     expect(fanOut.get('c')).toBe(1);
     expect(fanIn.get('a')).toBe(0);
     expect(fanOut.get('d')).toBe(0);
-  });
-});
-
-describe('ranking', () => {
-  it('ranks busiest first and breaks ties by id', () => {
-    const { fanIn } = degrees(graphOf('a>c b>c a>d b>d x>e'));
-
-    expect(ranking(fanIn, 3)).toEqual([
-      { id: 'c', count: 2 },
-      { id: 'd', count: 2 },
-      { id: 'e', count: 1 },
-    ]);
   });
 });

--- a/apps/web/src/lib/graph/degree.ts
+++ b/apps/web/src/lib/graph/degree.ts
@@ -1,13 +1,7 @@
 import type { DependencyGraph } from '@strata/sdk';
 
-/** One node's share of the edges, as the fan-in / fan-out ranking prints it. */
-export interface DegreeEntry {
-  id: string;
-  count: number;
-}
-
 export interface Degrees {
-  /** How many nodes import this one — the mockup's *max fan-in*. */
+  /** How many nodes import this one. */
   fanIn: Map<string, number>;
   /** How many nodes this one imports. */
   fanOut: Map<string, number>;
@@ -35,18 +29,4 @@ export function degrees(
   }
 
   return { fanIn, fanOut };
-}
-
-/**
- * The ranking a panel shows: busiest first, ties broken by id so a re-run of
- * the same analysis never reshuffles the list.
- */
-export function ranking(
-  counts: ReadonlyMap<string, number>,
-  limit = Infinity,
-): DegreeEntry[] {
-  return [...counts]
-    .map(([id, count]) => ({ id, count }))
-    .sort((a, b) => b.count - a.count || a.id.localeCompare(b.id))
-    .slice(0, limit);
 }

--- a/apps/web/src/lib/graph/index.ts
+++ b/apps/web/src/lib/graph/index.ts
@@ -4,7 +4,7 @@ export {
   type CollapsedGraph,
 } from './collapse';
 export { cycleMembership, cycleViews, type CycleView } from './cycles';
-export { degrees, ranking, type DegreeEntry, type Degrees } from './degree';
+export { degrees, type Degrees } from './degree';
 export {
   classifyEdges,
   edgeDash,
@@ -25,7 +25,7 @@ export {
 export { everyLane, laneTree, type Lane } from './lanes';
 export { rankNodes, type Ranking } from './rank';
 export { folderRows, type FolderRow } from './rows';
-export { graphSummary, type GraphSummary } from './summary';
+export { reportSummary } from './summary';
 export {
   ancestorsOf,
   containerOf,

--- a/apps/web/src/lib/graph/merge.test.ts
+++ b/apps/web/src/lib/graph/merge.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { AnalysisReport } from '$lib/api';
+import { graphOf, languageOf } from '$lib/test/graph';
 import { mergedGraph } from './merge';
 
 function reportWith(
@@ -31,24 +32,16 @@ describe('mergedGraph', () => {
   it('folds every language into one graph', () => {
     const graph = mergedGraph(
       reportWith({
-        typescript: {
-          graph: {
-            nodes: [{ id: 'a.ts', label: 'a.ts', kind: 'file' }],
-            edges: [],
-            cycles: [],
-          },
-          deadCode: [],
-          metrics: [],
-        },
-        php: {
-          graph: {
-            nodes: [{ id: 'a.php', label: 'a.php', kind: 'file' }],
-            edges: [],
-            cycles: [],
-          },
-          deadCode: [],
-          metrics: [],
-        },
+        typescript: languageOf({
+          nodes: [{ id: 'a.ts', label: 'a.ts', kind: 'file' }],
+          edges: [],
+          cycles: [],
+        }),
+        php: languageOf({
+          nodes: [{ id: 'a.php', label: 'a.php', kind: 'file' }],
+          edges: [],
+          cycles: [],
+        }),
       }),
     );
 
@@ -56,18 +49,7 @@ describe('mergedGraph', () => {
   });
 
   it('drops nodes, edges and cycles two plugins both claimed', () => {
-    const language = {
-      graph: {
-        nodes: [
-          { id: 'a.ts', label: 'a.ts', kind: 'file' as const },
-          { id: 'b.ts', label: 'b.ts', kind: 'file' as const },
-        ],
-        edges: [{ from: 'a.ts', to: 'b.ts', kind: 'import' as const }],
-        cycles: [['a.ts', 'b.ts']],
-      },
-      deadCode: [],
-      metrics: [],
-    };
+    const language = languageOf(graphOf('a.ts>b.ts', [['a.ts', 'b.ts']]));
 
     const graph = mergedGraph(
       reportWith({ typescript: language, other: language }),
@@ -81,15 +63,11 @@ describe('mergedGraph', () => {
   it('gives an edge that leaves the file set a package node', () => {
     const graph = mergedGraph(
       reportWith({
-        typescript: {
-          graph: {
-            nodes: [{ id: 'a.ts', label: 'a.ts', kind: 'file' }],
-            edges: [{ from: 'a.ts', to: 'svelte', kind: 'import' }],
-            cycles: [],
-          },
-          deadCode: [],
-          metrics: [],
-        },
+        typescript: languageOf({
+          nodes: [{ id: 'a.ts', label: 'a.ts', kind: 'file' }],
+          edges: [{ from: 'a.ts', to: 'svelte', kind: 'import' }],
+          cycles: [],
+        }),
       }),
     );
 

--- a/apps/web/src/lib/graph/summary.test.ts
+++ b/apps/web/src/lib/graph/summary.test.ts
@@ -1,29 +1,95 @@
 import { describe, expect, it } from 'vitest';
-import { graphOf } from '$lib/test/graph';
-import { graphSummary } from './summary';
+import type { AnalysisReport } from '$lib/api';
+import { graphOf, languageOf } from '$lib/test/graph';
+import { reportSummary } from './summary';
 
-describe('graphSummary', () => {
-  it('counts the graph and names its busiest node', () => {
-    const summary = graphSummary(
-      graphOf('a>c b>c c>a c>d', [['a', 'c']]),
+function reportWith(languages: AnalysisReport['languages']): AnalysisReport {
+  return {
+    rev: 'abc',
+    run: {
+      branch: 'main',
+      files: 0,
+      durationMs: 1,
+      finishedAt: '2026-01-01T00:00:00.000Z',
+    },
+    languages,
+    metrics: [],
+    commits: [],
+    cache: {
+      enabled: false,
+      hits: 0,
+      misses: 0,
+      runHits: 0,
+      runMisses: 0,
+      writes: 0,
+    },
+  };
+}
+
+describe('reportSummary', () => {
+  it('reads the numbers the language module reported', () => {
+    const summary = reportSummary(
+      reportWith({
+        typescript: languageOf(graphOf('a>c b>c c>a c>d', [['a', 'c']]), {
+          maxFanIn: { id: 'c', count: 2 },
+          maxFanOut: { id: 'c', count: 2 },
+        }),
+      }),
     );
 
-    expect(summary.nodes).toBe(4);
-    expect(summary.edges).toBe(4);
+    expect(summary).toEqual({
+      nodes: 4,
+      edges: 4,
+      cycles: 1,
+      cycleNodes: 2,
+      maxFanIn: { id: 'c', count: 2 },
+      maxFanOut: { id: 'c', count: 2 },
+    });
+  });
+
+  it('adds every language up and keeps the busiest node of them all', () => {
+    const summary = reportSummary(
+      reportWith({
+        typescript: languageOf(graphOf('a.ts>c.ts', [['a.ts', 'c.ts']]), {
+          maxFanIn: { id: 'c.ts', count: 1 },
+        }),
+        php: languageOf(graphOf('a.php>c.php b.php>c.php'), {
+          maxFanIn: { id: 'c.php', count: 2 },
+        }),
+      }),
+    );
+
+    expect(summary.nodes).toBe(5);
+    expect(summary.edges).toBe(3);
     expect(summary.cycles).toBe(1);
     expect(summary.cycleNodes).toBe(2);
-    expect(summary.maxFanIn).toEqual({ id: 'c', count: 2 });
-    expect(summary.maxFanOut).toEqual({ id: 'c', count: 2 });
+    expect(summary.maxFanIn).toEqual({ id: 'c.php', count: 2 });
   });
 
   it('names nobody when nothing imports anything', () => {
-    const summary = graphSummary({
-      nodes: [{ id: 'a', label: 'a', kind: 'file' }],
-      edges: [],
-      cycles: [],
-    });
+    const summary = reportSummary(
+      reportWith({
+        typescript: languageOf({
+          nodes: [{ id: 'a', label: 'a', kind: 'file' }],
+          edges: [],
+          cycles: [],
+        }),
+      }),
+    );
 
+    expect(summary.nodes).toBe(1);
     expect(summary.maxFanIn).toBeNull();
     expect(summary.maxFanOut).toBeNull();
+  });
+
+  it('summarises a report no language plugin touched as zeroes', () => {
+    expect(reportSummary(reportWith({}))).toEqual({
+      nodes: 0,
+      edges: 0,
+      cycles: 0,
+      cycleNodes: 0,
+      maxFanIn: null,
+      maxFanOut: null,
+    });
   });
 });

--- a/apps/web/src/lib/graph/summary.ts
+++ b/apps/web/src/lib/graph/summary.ts
@@ -1,37 +1,47 @@
-import type { DependencyGraph } from '@strata/sdk';
-import { degrees, ranking, type DegreeEntry } from './degree';
-
-/** The numbers above the canvas: how big the graph is and where it knots. */
-export interface GraphSummary {
-  nodes: number;
-  edges: number;
-  cycles: number;
-  /** Nodes inside at least one cycle. */
-  cycleNodes: number;
-  /** The most-imported node, `null` for a graph with no edges at all. */
-  maxFanIn: DegreeEntry | null;
-  /** The node with the most imports of its own. */
-  maxFanOut: DegreeEntry | null;
-}
+import type { GraphSummary } from '@strata/sdk';
+import type { AnalysisReport } from '$lib/api';
 
 /**
- * Summarise the merged graph.
+ * The numbers above the canvas, folded out of the report.
  *
- * Computed here rather than read off the report: the language result carries
- * no summary yet. When it does, this is the shape to fill from it — the view
- * reads nothing else.
+ * Every language result carries its own `GraphSummary`, counted by the plugin
+ * over the graph it built; the browser only adds them up. Language plugins
+ * claim disjoint extensions, so their file sets are disjoint and the counts
+ * simply sum — the same assumption `mergedGraph` makes, except that the merge
+ * also deduplicates, so two plugins claiming one extension would be counted
+ * twice here and drawn once there.
+ *
+ * A report with no language results summarises to zeroes rather than to
+ * nothing: the panel renders the same either way.
  */
-export function graphSummary(graph: DependencyGraph): GraphSummary {
-  const { fanIn, fanOut } = degrees(graph);
-  const [topIn] = ranking(fanIn, 1);
-  const [topOut] = ranking(fanOut, 1);
-
-  return {
-    nodes: graph.nodes.length,
-    edges: graph.edges.length,
-    cycles: graph.cycles.length,
-    cycleNodes: new Set(graph.cycles.flat()).size,
-    maxFanIn: topIn && topIn.count > 0 ? topIn : null,
-    maxFanOut: topOut && topOut.count > 0 ? topOut : null,
+export function reportSummary(report: AnalysisReport): GraphSummary {
+  const summary: GraphSummary = {
+    nodes: 0,
+    edges: 0,
+    cycles: 0,
+    cycleNodes: 0,
+    maxFanIn: null,
+    maxFanOut: null,
   };
+
+  for (const language of Object.values(report.languages)) {
+    summary.nodes += language.summary.nodes;
+    summary.edges += language.summary.edges;
+    summary.cycles += language.summary.cycles;
+    summary.cycleNodes += language.summary.cycleNodes;
+    summary.maxFanIn = busier(summary.maxFanIn, language.summary.maxFanIn);
+    summary.maxFanOut = busier(summary.maxFanOut, language.summary.maxFanOut);
+  }
+
+  return summary;
+}
+
+/** The busier of two ranked nodes; ties go to the id, as the plugins rank. */
+function busier<T extends { id: string; count: number }>(
+  a: T | null,
+  b: T | null,
+): T | null {
+  if (!a || !b) return a ?? b;
+  if (b.count > a.count) return b;
+  return b.count === a.count && b.id < a.id ? b : a;
 }

--- a/apps/web/src/lib/hotspots/rows.test.ts
+++ b/apps/web/src/lib/hotspots/rows.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { AnalysisReport } from '$lib/api';
+import { languageOf } from '$lib/test/graph';
 import { hotspotRows } from './rows';
 
 function report(partial: Partial<AnalysisReport> = {}): AnalysisReport {
@@ -42,8 +43,7 @@ describe('hotspotRows', () => {
         metrics: [hotspots],
         languages: {
           typescript: {
-            graph: { nodes: [], edges: [], cycles: [] },
-            deadCode: [],
+            ...languageOf({ nodes: [], edges: [], cycles: [] }),
             metrics: [{ path: 'src/a.ts', loc: 120 }],
           },
         },

--- a/apps/web/src/lib/test/graph.ts
+++ b/apps/web/src/lib/test/graph.ts
@@ -1,4 +1,9 @@
-import type { DependencyGraph, GraphEdge } from '@strata/sdk';
+import type {
+  DependencyGraph,
+  GraphEdge,
+  GraphSummary,
+  LanguageAnalysis,
+} from '@strata/sdk';
 
 /**
  * Build a dependency graph from a compact edge list: `'a>b b>c c>a'`. Nodes are
@@ -23,5 +28,32 @@ export function graphOf(
     nodes: [...ids].sort().map((id) => ({ id, label: id, kind: 'file' })),
     edges: parsed,
     cycles,
+  };
+}
+
+/**
+ * One language's result, as a report carries it.
+ *
+ * Summarising is the plugin's job, so the counts here are only the graph's own
+ * sizes and nobody is ranked; a test that cares about the summary passes the
+ * fields it asserts on.
+ */
+export function languageOf(
+  graph: DependencyGraph,
+  summary: Partial<GraphSummary> = {},
+): LanguageAnalysis {
+  return {
+    graph,
+    deadCode: [],
+    metrics: [],
+    summary: {
+      nodes: graph.nodes.length,
+      edges: graph.edges.length,
+      cycles: graph.cycles.length,
+      cycleNodes: new Set(graph.cycles.flat()).size,
+      maxFanIn: null,
+      maxFanOut: null,
+      ...summary,
+    },
   };
 }

--- a/apps/web/src/routes/graph/+page.svelte
+++ b/apps/web/src/routes/graph/+page.svelte
@@ -23,8 +23,8 @@
     focusGraph,
     folderRows,
     folderTree,
-    graphSummary,
     mergedGraph,
+    reportSummary,
     neighbourhood,
   } from '$lib/graph';
 
@@ -44,8 +44,9 @@
   let report = $derived(analysis.report);
   let graph = $derived(report ? mergedGraph(report) : null);
   // The summary and the cycle list describe the repository, not the current
-  // view: closing a folder hides files, it does not un-import them.
-  let summary = $derived(graph ? graphSummary(graph) : null);
+  // view: closing a folder hides files, it does not un-import them. The counts
+  // come from the run itself — the language modules report them.
+  let summary = $derived(report ? reportSummary(report) : null);
   let cycles = $derived(graph ? cycleViews(graph) : []);
   let cycleOf = $derived(cycleMembership(cycles));
   // The folder tree of the repository, whatever is open: the panel lists it

--- a/apps/web/src/routes/graph/page.test.ts
+++ b/apps/web/src/routes/graph/page.test.ts
@@ -31,6 +31,15 @@ function reportWith(rev: string) {
         },
         deadCode: [],
         metrics: [],
+        // As the language module counts it — the screen only prints it.
+        summary: {
+          nodes: 3,
+          edges: 3,
+          cycles: 1,
+          cycleNodes: 2,
+          maxFanIn: { id: 'src/a.ts', count: 2 },
+          maxFanOut: { id: 'src/a.ts', count: 1 },
+        },
       },
     },
     metrics: [],

--- a/apps/web/src/routes/hotspots/page.test.ts
+++ b/apps/web/src/routes/hotspots/page.test.ts
@@ -19,6 +19,14 @@ function reportWith(rev: string) {
         graph: { nodes: [], edges: [], cycles: [] },
         deadCode: [],
         metrics: [{ path: 'src/big.ts', loc: 940 }],
+        summary: {
+          nodes: 0,
+          edges: 0,
+          cycles: 0,
+          cycleNodes: 0,
+          maxFanIn: null,
+          maxFanOut: null,
+        },
       },
     },
     metrics: [

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -127,7 +127,7 @@ Quality/Risks). Start here:
 
 | Kind | Contract (in `@strata/sdk`) | Produces |
 |------|------------------------------|----------|
-| `language` | `LanguagePlugin.analyze(ctx)` | `LanguageAnalysis` (graph, dead code, metrics) |
+| `language` | `LanguagePlugin.analyze(ctx)` | `LanguageAnalysis` (graph, graph summary, dead code, metrics) |
 | `commit-convention` | `CommitConventionPlugin.parse(commit)` | `ParsedCommit` |
 | `git-metric` | `GitMetricPlugin.compute(ctx, history)` | `MetricSeries` |
 | `ai-provider` | `AIProvider.chat()/embed()` | text / vectors |

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -29,13 +29,14 @@ this repo — see [Installing a plugin](#installing-a-plugin).
 ### Language plugin
 
 ```ts
-import { defineLanguagePlugin } from '@strata/sdk';
+import { defineLanguagePlugin, summariseGraph } from '@strata/sdk';
 
 export default defineLanguagePlugin({
   extensions: ['py'],
   async analyze(ctx) {
     // ctx.files is already filtered to your extensions
-    return { graph: { nodes: [], edges: [], cycles: [] }, deadCode: [], metrics: [] };
+    const graph = { nodes: [], edges: [], cycles: [] };
+    return { graph, deadCode: [], metrics: [], summary: summariseGraph(graph) };
   },
 });
 ```
@@ -44,6 +45,13 @@ Route real parsing through **tree-sitter** for accuracy — the TypeScript plugi
 loads `web-tree-sitter` with a pre-built WASM grammar, which keeps installation
 free of a native build step and is the pattern to copy. Return the standard
 `LanguageAnalysis` shape and the UI renders it for free.
+
+`summary` is the graph's headline numbers — node and edge counts, how many
+cycles and how many files they hold, and the busiest node in each direction.
+`summariseGraph` counts them for you, so every language module reports them the
+same way; fill the shape yourself only if your analyzer already knows better.
+A result that arrives without one is summarised by the core, so a plugin built
+against an older SDK keeps working.
 
 ### Commit-convention plugin
 

--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -41,6 +41,7 @@ itself behaves.
 | `registry.ts` | `PluginRegistry` — load plugins, contain load failures, `byKind()` / `loadedByKind()`. |
 | `manifest.ts` | `readManifest()` / `resolveEntry()` — validate a `strata.plugin.json` and its entry path. |
 | `plugin-shape.ts` | `pluginShapeError()` — does the module implement the kind it claims? |
+| `summarise.ts` | `summarised()` — fill in a language result's graph summary when the plugin (or its cached run) predates the field. |
 | `discover.ts` | `discoverPlugins(dir)` — the manifests installed in a plugins directory. |
 | `plugins-dir.ts` | `userPluginsDir()` — where drop-in plugins live (`STRATA_PLUGINS_DIR`). |
 | `git/exec.ts` | Run a read-only git command. |

--- a/packages/core/src/registry.test.ts
+++ b/packages/core/src/registry.test.ts
@@ -30,7 +30,7 @@ const PLUGIN_SOURCE = (kind: PluginKind) => `export default {
   extensions: ['ts'],
   convention: 'test',
   id: 'test',
-  async analyze() { return { graph: { nodes: [], edges: [], cycles: [] }, deadCode: [], metrics: [] }; },
+  async analyze() { return { graph: { nodes: [], edges: [], cycles: [] }, deadCode: [], metrics: [], summary: { nodes: 0, edges: 0, cycles: 0, cycleNodes: 0, maxFanIn: null, maxFanOut: null } }; },
   async compute() { return { id: 'test', label: 'Test', points: [] }; },
   parse() { return { type: 'feat', breaking: false, subject: '', tags: [], valid: true }; },
 };

--- a/packages/core/src/strata.ts
+++ b/packages/core/src/strata.ts
@@ -11,6 +11,7 @@ import {
 import { branchAt, git, history, listFiles, resolveRev } from './git/index.js';
 import { consoleLogger } from './logger.js';
 import type { PluginRegistry } from './registry.js';
+import { summarised } from './summarise.js';
 import type { AnalysisReport, AnalyzeOptions, StrataOptions } from './types.js';
 
 /**
@@ -62,7 +63,7 @@ export class Strata {
         runKey,
       );
       if (hit) {
-        languages[key] = hit;
+        languages[key] = summarised(hit);
         continue;
       }
 
@@ -72,7 +73,7 @@ export class Strata {
         cache: cache.scope(manifest.id, manifest.version),
       });
       cache.setRun(manifest.id, manifest.version, runKey, analysis);
-      languages[key] = analysis;
+      languages[key] = summarised(analysis);
       cache.flush();
     }
 

--- a/packages/core/src/summarise.test.ts
+++ b/packages/core/src/summarise.test.ts
@@ -1,0 +1,46 @@
+import type { LanguageAnalysis } from '@strata/sdk';
+import { describe, expect, it } from 'vitest';
+import { summarised } from './summarise.js';
+
+/** What a plugin built against an SDK without `summary` hands back. */
+const older = {
+  graph: {
+    nodes: [
+      { id: 'a.ts', label: 'a.ts', kind: 'file' as const },
+      { id: 'b.ts', label: 'b.ts', kind: 'file' as const },
+    ],
+    edges: [{ from: 'a.ts', to: 'b.ts', kind: 'import' as const }],
+    cycles: [],
+  },
+  deadCode: [],
+  metrics: [],
+} as unknown as LanguageAnalysis;
+
+describe('summarised', () => {
+  it('counts a graph whose plugin reported no summary', () => {
+    expect(summarised(older).summary).toEqual({
+      nodes: 2,
+      edges: 1,
+      cycles: 0,
+      cycleNodes: 0,
+      maxFanIn: { id: 'b.ts', count: 1 },
+      maxFanOut: { id: 'a.ts', count: 1 },
+    });
+  });
+
+  it('leaves a result that brought its own alone', () => {
+    const summary = {
+      nodes: 99,
+      edges: 0,
+      cycles: 0,
+      cycleNodes: 0,
+      maxFanIn: null,
+      maxFanOut: null,
+    };
+    const analysis: LanguageAnalysis = { ...older, summary };
+
+    // The plugin knows its own graph best — the count is not second-guessed.
+    expect(summarised(analysis)).toBe(analysis);
+    expect(summarised(analysis).summary.nodes).toBe(99);
+  });
+});

--- a/packages/core/src/summarise.ts
+++ b/packages/core/src/summarise.ts
@@ -1,0 +1,18 @@
+import { summariseGraph, type LanguageAnalysis } from '@strata/sdk';
+
+/**
+ * A language result, with its graph summary filled in if it arrived without one.
+ *
+ * The summary is part of the language contract, and the pipeline still cannot
+ * assume it is there: a third-party plugin built against an SDK that predates
+ * the field loads all the same — the manifest check compares major versions —
+ * and a run it cached before it was updated outlives the update. Deriving the
+ * numbers here costs one pass over a graph that is already in memory, and it
+ * keeps every reader of a report free of the question.
+ */
+export function summarised(analysis: LanguageAnalysis): LanguageAnalysis {
+  const { summary } = analysis as Partial<LanguageAnalysis>;
+  return summary
+    ? analysis
+    : { ...analysis, summary: summariseGraph(analysis.graph) };
+}

--- a/packages/sdk/ARCHITECTURE.md
+++ b/packages/sdk/ARCHITECTURE.md
@@ -38,6 +38,7 @@ path (`@strata/sdk`).
 | `repo.ts` | `RepoFile`, `RepoContext` |
 | `cache.ts` | `PluginCache` — the blob-keyed incremental cache contract |
 | `graph.ts` | `GraphNode`, `GraphEdge`, `DependencyGraph` |
+| `summary.ts` | `GraphSummary`, `DegreeEntry`, `summariseGraph` — a graph's headline numbers |
 | `language.ts` | `LanguagePlugin`, `LanguageAnalysis`, `DeadCodeFinding`, `CodeMetric` |
 | `commit.ts` | `CommitConventionPlugin`, `RawCommit`, `ParsedCommit` |
 | `metric.ts` | `GitMetricPlugin`, `MetricSeries`, `MetricPoint` |
@@ -47,8 +48,10 @@ path (`@strata/sdk`).
 ## 5. Runtime
 
 Almost none, but not zero: the `define*` helpers merely stamp the `kind`
-discriminant so the core can route a plugin without reflection, and
-`PLUGIN_KINDS` is the kind list as a value, for loaders validating a manifest.
+discriminant so the core can route a plugin without reflection,
+`PLUGIN_KINDS` is the kind list as a value, for loaders validating a manifest,
+and `summariseGraph` counts a dependency graph so that every language module
+reports the same numbers for the same graph.
 Both survive compilation, so a built plugin still imports `@strata/sdk` at
 runtime — it must be resolvable from the plugin (see
 [`docs/PLUGINS.md`](../../docs/PLUGINS.md)).

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -22,6 +22,7 @@ export * from './logger.js';
 export * from './cache.js';
 export * from './repo.js';
 export * from './graph.js';
+export * from './summary.js';
 
 // The four plugin kinds
 export * from './language.js';

--- a/packages/sdk/src/language.ts
+++ b/packages/sdk/src/language.ts
@@ -1,5 +1,6 @@
 import type { DependencyGraph } from './graph.js';
 import type { RepoContext } from './repo.js';
+import type { GraphSummary } from './summary.js';
 
 export interface DeadCodeFinding {
   path: string;
@@ -23,6 +24,11 @@ export interface LanguageAnalysis {
   graph: DependencyGraph;
   deadCode: DeadCodeFinding[];
   metrics: CodeMetric[];
+  /**
+   * The graph's headline numbers. `summariseGraph(graph)` computes it; a plugin
+   * that keeps richer knowledge of its own graph may fill it in itself.
+   */
+  summary: GraphSummary;
 }
 
 export interface LanguagePlugin {

--- a/packages/sdk/src/summary.test.ts
+++ b/packages/sdk/src/summary.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import type { DependencyGraph, GraphEdge } from './graph.js';
+import { summariseGraph } from './summary.js';
+
+/** A graph from a compact edge list: `'a>c b>c'`, nodes inferred from it. */
+function graphOf(edges: string, cycles: string[][] = []): DependencyGraph {
+  const parsed: GraphEdge[] = edges
+    .split(' ')
+    .filter(Boolean)
+    .map((edge) => {
+      const [from, to] = edge.split('>');
+      return { from: from!, to: to!, kind: 'import' };
+    });
+
+  const ids = new Set(parsed.flatMap((edge) => [edge.from, edge.to]));
+  return {
+    nodes: [...ids].sort().map((id) => ({ id, label: id, kind: 'file' })),
+    edges: parsed,
+    cycles,
+  };
+}
+
+describe('summariseGraph', () => {
+  it('counts the graph and names its busiest node', () => {
+    const summary = summariseGraph(graphOf('a>c b>c c>a c>d', [['a', 'c']]));
+
+    expect(summary).toEqual({
+      nodes: 4,
+      edges: 4,
+      cycles: 1,
+      cycleNodes: 2,
+      maxFanIn: { id: 'c', count: 2 },
+      maxFanOut: { id: 'c', count: 2 },
+    });
+  });
+
+  it('names nobody when nothing imports anything', () => {
+    const summary = summariseGraph({
+      nodes: [{ id: 'a', label: 'a', kind: 'file' }],
+      edges: [],
+      cycles: [],
+    });
+
+    expect(summary.nodes).toBe(1);
+    expect(summary.maxFanIn).toBeNull();
+    expect(summary.maxFanOut).toBeNull();
+  });
+
+  it('breaks a tie by id, so the same graph always names the same node', () => {
+    const summary = summariseGraph(graphOf('x>b x>a'));
+
+    expect(summary.maxFanIn).toEqual({ id: 'a', count: 1 });
+  });
+
+  it('counts a node once however many cycles hold it', () => {
+    const summary = summariseGraph(
+      graphOf('a>b b>a a>c c>a', [
+        ['a', 'b'],
+        ['a', 'c'],
+      ]),
+    );
+
+    expect(summary.cycles).toBe(2);
+    expect(summary.cycleNodes).toBe(3);
+  });
+});

--- a/packages/sdk/src/summary.ts
+++ b/packages/sdk/src/summary.ts
@@ -1,0 +1,73 @@
+import type { DependencyGraph } from './graph.js';
+
+/** One node's share of the edges, as a fan-in / fan-out ranking prints it. */
+export interface DegreeEntry {
+  id: string;
+  count: number;
+}
+
+/**
+ * The numbers a UI shows above a graph: how big it is and where it knots.
+ *
+ * Derivable from the graph itself, and carried beside it anyway: the counts are
+ * what a summary panel, an overview card or a CI gate reads, and none of them
+ * should have to walk every edge of a repository-sized graph to learn them.
+ */
+export interface GraphSummary {
+  nodes: number;
+  edges: number;
+  /** Strongly-connected components with more than one node. */
+  cycles: number;
+  /** Nodes inside at least one cycle. */
+  cycleNodes: number;
+  /** The most-imported node; `null` for a graph with no edges at all. */
+  maxFanIn: DegreeEntry | null;
+  /** The node with the most imports of its own. */
+  maxFanOut: DegreeEntry | null;
+}
+
+/**
+ * Summarise a dependency graph.
+ *
+ * Ships with the SDK so every language module reports the same numbers for the
+ * same graph — a summary each plugin derived its own way would be a second,
+ * quietly disagreeing definition of "how many edges".
+ */
+export function summariseGraph(graph: DependencyGraph): GraphSummary {
+  const fanIn = new Map<string, number>();
+  const fanOut = new Map<string, number>();
+  for (const node of graph.nodes) {
+    fanIn.set(node.id, 0);
+    fanOut.set(node.id, 0);
+  }
+  for (const edge of graph.edges) {
+    fanOut.set(edge.from, (fanOut.get(edge.from) ?? 0) + 1);
+    fanIn.set(edge.to, (fanIn.get(edge.to) ?? 0) + 1);
+  }
+
+  return {
+    nodes: graph.nodes.length,
+    edges: graph.edges.length,
+    cycles: graph.cycles.length,
+    cycleNodes: new Set(graph.cycles.flat()).size,
+    maxFanIn: busiest(fanIn),
+    maxFanOut: busiest(fanOut),
+  };
+}
+
+/**
+ * The node the most edges touch, or `null` if none do.
+ *
+ * Ties are broken by id so re-running the same analysis never reshuffles the
+ * name the panel prints.
+ */
+function busiest(counts: ReadonlyMap<string, number>): DegreeEntry | null {
+  let top: DegreeEntry | null = null;
+  for (const [id, count] of counts) {
+    if (count === 0) continue;
+    if (!top || count > top.count || (count === top.count && id < top.id)) {
+      top = { id, count };
+    }
+  }
+  return top;
+}

--- a/plugins/language-typescript/ARCHITECTURE.md
+++ b/plugins/language-typescript/ARCHITECTURE.md
@@ -29,7 +29,7 @@ exports, unreachable files, unused dependencies). The reference language plugin
 
 | File | Responsibility |
 |------|----------------|
-| `index.ts` | The plugin: assemble nodes/edges/metrics, return `LanguageAnalysis`. |
+| `index.ts` | The plugin: assemble nodes/edges/metrics, summarise the graph, return `LanguageAnalysis`. |
 | `parser.ts` | Load the grammars once; parse one file and lend out its syntax tree. |
 | `scan.ts` | Everything derivable from one file → `{ loc, imports, exports, stars, complexity, nesting, fingerprint }`, cached per blob via `ctx.cache`. |
 | `imports.ts` | Read `import` / `require` / `import()` off the tree → specifier + the names taken. |
@@ -65,7 +65,13 @@ before the first specifier is resolved. It then iterates the matched files,
 collects each file's scan (one parse per file) and resolves its specifiers into
 nodes/edges. Finally it runs the cross-file passes — duplication, and the three
 dead-code passes over the resolved graph plus the workspace manifests — and
-returns `{ graph, deadCode, metrics }`.
+returns `{ graph, summary, deadCode, metrics }`.
+
+The summary is the graph's headline numbers — nodes, edges, cycles, the files
+those cycles hold, and the busiest node in each direction. `summariseGraph` from
+the SDK counts them, here, once: the graph is repository-sized, the numbers
+never change after the run, and a reader that recounts them is a second
+definition of the same thing waiting to disagree.
 
 Dead code is three questions against one graph:
 

--- a/plugins/language-typescript/package.json
+++ b/plugins/language-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@strata/plugin-language-typescript",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "TypeScript/JavaScript language-analysis plugin for Strata.",
   "license": "Apache-2.0",
   "type": "module",

--- a/plugins/language-typescript/src/index.test.ts
+++ b/plugins/language-typescript/src/index.test.ts
@@ -118,6 +118,57 @@ describe('typescript plugin', () => {
     expect(deadCode).toEqual([]);
   });
 
+  it('summarises the graph it just built', async () => {
+    const ctx = context(
+      {
+        'src/index.ts': [
+          `import { a } from './a.js';`,
+          `import { b } from './b.js';`,
+          'export const main = () => a + b;',
+        ].join('\n'),
+        'src/a.ts': [
+          `import { shared } from './shared.js';`,
+          'export const a = shared;',
+        ].join('\n'),
+        'src/b.ts': [
+          `import { shared } from './shared.js';`,
+          'export const b = shared;',
+        ].join('\n'),
+        'src/shared.ts': 'export const shared = 1;',
+      },
+      { 'package.json': '{ "name": "demo", "main": "./dist/index.js" }' },
+    );
+
+    const { summary } = await plugin.analyze(ctx);
+
+    expect(summary).toEqual({
+      nodes: 4,
+      edges: 4,
+      cycles: 0,
+      cycleNodes: 0,
+      maxFanIn: { id: 'src/shared.ts', count: 2 },
+      maxFanOut: { id: 'src/index.ts', count: 2 },
+    });
+  });
+
+  it('counts the files a cycle holds', async () => {
+    const ctx = context({
+      'src/a.ts': [
+        `import { b } from './b.js';`,
+        'export const a = () => b();',
+      ].join('\n'),
+      'src/b.ts': [
+        `import { a } from './a.js';`,
+        'export const b = () => a();',
+      ].join('\n'),
+    });
+
+    const { summary } = await plugin.analyze(ctx);
+
+    expect(summary.cycles).toBe(1);
+    expect(summary.cycleNodes).toBe(2);
+  });
+
   it('says nothing about exports when no entry point can be found', async () => {
     const ctx = context({
       'src/a.ts': 'export const a = 1;',

--- a/plugins/language-typescript/src/index.ts
+++ b/plugins/language-typescript/src/index.ts
@@ -1,5 +1,6 @@
 import {
   defineLanguagePlugin,
+  summariseGraph,
   type CodeMetric,
   type GraphNode,
   type LanguageAnalysis,
@@ -90,10 +91,14 @@ export default defineLanguagePlugin({
     }));
 
     const edges = importEdges(analysed);
+    const graph = { nodes, edges, cycles: findCycles(nodes, edges) };
     return {
-      graph: { nodes, edges, cycles: findCycles(nodes, edges) },
+      graph,
       deadCode: findDeadCode(analysed, manifests),
       metrics,
+      // Counted here, once, rather than by every reader of the result: the
+      // graph is repository-sized and the numbers never change after this.
+      summary: summariseGraph(graph),
     };
   },
 });

--- a/plugins/language-typescript/strata.plugin.json
+++ b/plugins/language-typescript/strata.plugin.json
@@ -2,7 +2,7 @@
   "id": "strata-language-typescript",
   "name": "TypeScript / JavaScript",
   "kind": "language",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "sdk": "0.1.0",
   "main": "./dist/index.js",
   "description": "Import dependency graph, cycle detection, and metrics for TS/JS. Angular and other analyzers build on this.",


### PR DESCRIPTION
Node/edge counts, cycles and the fan-in/fan-out ranking now come out of the analysis instead of being recomputed by whoever renders it — the mockup's *Max fan-in · sdk · 7* panel.

## What changed

- **`@strata/sdk`** — new `summary.ts`: `GraphSummary`, `DegreeEntry` and `summariseGraph(graph)`. `LanguageAnalysis` gains a required `summary`.
- **`plugins/language-typescript`** — summarises the graph it just built. Version 0.5.0 → 0.6.0, because the incremental cache is keyed on it and a stale entry would serve a summary-less result.
- **`@strata/core`** — `summarise.ts` fills in a missing summary. A third-party plugin built against an older SDK still loads (the manifest check compares major versions) and the runs it cached outlive its update, so the pipeline does not assume the field is there.
- **`apps/web`** — `lib/graph/summary.ts` stops walking the graph; it folds the languages' summaries instead, and the panel renders what the run reported. `degree.ts` loses `ranking`, which existed only for the old computation.

## Why in the SDK

`summariseGraph` is shipped rather than left to each plugin so that Angular, PHP and any third-party module report the same numbers for the same graph. A plugin whose analyzer knows better may still fill the shape itself.

## Verified

`pnpm build`, `pnpm typecheck`, `pnpm lint`, `pnpm test` (408 passing). Analysing this repository end to end reports:

```json
{"nodes":237,"edges":417,"cycles":2,"cycleNodes":4,
 "maxFanIn":{"id":"packages/sdk/src/index.ts","count":55},
 "maxFanOut":{"id":"apps/web/src/lib/graph/index.ts","count":13}}
```

Closes #63