### PR TITLE
feat(web): frame the workbench in a shell

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -180,9 +180,13 @@ Sans/Mono.
       switchable dark / light / system), a typed REST client per endpoint, and
       IBM Plex self-hosted. The palette is derived from the mockup's
       description, so expect a tuning pass as screens land.
-- [ ] **P0** App shell — left rail (logo, project switcher, analysis nav, plugin
-      count, settings entries), sticky header (breadcrumb, branch + rev chips,
-      last-run summary, *Re-analyze*), scrollable main pane
+- [x] App shell (`lib/shell`) — left rail (logo, the analysed project, the
+      analysis nav, the settings entries, the plugin count), a header that
+      sticks to the content column (breadcrumb, branch + rev chips, the last
+      run's files / duration / age, *Re-analyze*, appearance), and one
+      scrolling main pane. Screens still on this list are in the nav, disabled,
+      so the map of the workbench is whole; below `md` the rail gives way to a
+      nav strip in the header. The project slot is the switcher's, below.
 - [ ] **P0** Project switcher — dropdown listing registered projects with file
       count and last-analysis age, select / remove / *Add project* (which lands on
       *Project settings → Analyze / run* for the first analysis)

--- a/apps/web/ARCHITECTURE.md
+++ b/apps/web/ARCHITECTURE.md
@@ -1,9 +1,9 @@
 # Module: `@strata/web` — Architecture (arc42)
 
 > Trimmed arc42, consistent with [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md).
-> Status: **in progress** — theme layer, API client and the hotspot and
-> dependency-graph screens in place; the workbench shell and the remaining
-> analysis screens are still to build.
+> Status: **in progress** — theme layer, API client, the workbench shell and
+> the hotspot and dependency-graph screens in place; the project switcher and
+> the remaining analysis and settings screens are still to build.
 
 ## 1. Purpose & Goals
 
@@ -37,7 +37,9 @@ app-scoped settings screens. The face of Strata for browser/self-host use.
 | `src/lib/theme/*` | `mode` (types + resolution), `storage`, `apply`, `controller.svelte` (state) |
 | `src/lib/api/*` | `base` (origin), `request` (fetch + `ApiError`), one module per endpoint, `types` |
 | `src/lib/analysis/*` | The app-wide last report (`store.svelte`), the remembered repo path, and `RunForm` |
-| `src/lib/format/*` | `number` (compact counts) and `path` (repo path → dir + name), used by every screen |
+| `src/lib/plugins/*` | What the workbench loaded (`store.svelte`), fetched once for the whole app |
+| `src/lib/shell/*` | The frame: `nav` (the map of the workbench), `project` (root → name), `summary` (report → the header's chips), and the views — `Shell`, `Rail`, `Header`, `NavList`, `RunSummary`, `CurrentProject`, `PluginCount`, `Logo` |
+| `src/lib/format/*` | `number` (compact counts), `path` (repo path → dir + name), `duration` and `age`, used by every screen |
 | `src/lib/geometry/*` | `squarify` — the squarified treemap layout |
 | `src/lib/hotspots/*` | The hotspot feature end to end: `rows` (report → rows), `heat` (ramp), and the three views |
 | `src/lib/graph/*` | The dependency feature end to end: `merge` (report → one graph), `summary` (report → the panel's numbers), `tree`/`rows` (the folder tree), `collapse` (closed folders), `rank` + `lanes` + `layered` (the columned layout), `edges`, `degree`, `cycles`, `focus`, `viewport` (pan/zoom), and the five views |
@@ -80,6 +82,9 @@ what more than one screen uses moves up into `lib/components/`.
 | 16 | **Pan and zoom move a `viewBox`, never the layout** | Re-running the layout at each zoom step would rearrange the picture under the reader. `viewport.ts` holds the window as plain values, so the clamping — never out past the whole graph, never off its edge — is one tested thing rather than arithmetic in event handlers |
 | 17 | **The canvas fills the room the page gives it** | The window takes the *canvas's* shape, not the drawing's, and a drawing that does not match is letterboxed and centred. Sizing the element to the drawing instead would leave a tall graph as a thin ribbon and a short one as a sliver, wasting the space either way. Resizing the page carries the window across rather than resetting it |
 | 18 | **Cycles ordered into a path in the UI** | Tarjan emits a component, not a route through it, and `a → b → a` is what a reader can act on. `cycles.ts` walks the component over real edges until the language result carries the path itself |
+| 19 | **The window is the frame: only the main pane scrolls** | The rail and the header hold still and the content column scrolls inside them. That is what lets a treemap or a graph canvas size itself against the room it is given — a page that scrolls as a whole gives a canvas a viewport that moves out from under it — and it keeps the branch, revision and *Re-analyze* reachable from the bottom of a long table |
+| 20 | **The shell takes the route as a prop** | `+layout.svelte` is the only thing that reads `$app/state`; `Shell` and everything under it is handed a `pathname`. The frame then mounts in a test the same way every other component does, without SvelteKit's runtime, and the nav's active-entry rule stays a pure function (`nav.ts`) |
+| 21 | **Screens on the backlog are listed, disabled** | The rail is the map of the workbench. Hiding *Commits*, *Dead code* and the two settings scopes until they exist would make each one appear as a surprise; showing them as `soon` says what Strata is going to be, and an inert entry cannot navigate to a route that is not there |
 
 ## 7. Quality & Risks
 
@@ -92,7 +97,9 @@ what more than one screen uses moves up into `lib/components/`.
   than exported from it; expect a tuning pass when the screens land. The light
   heat ramp already took one, so a single light ink clears 4.5:1 on every step.
 - **Debt:** the hotspot screen types the repo path into a form and remembers it
-  in `localStorage`. That is the project switcher's job — this goes away with it.
+  in `localStorage`, and the rail names *that* path as the current project.
+  That is the project switcher's job — a dropdown over the registered projects,
+  with *Add project* — and `CurrentProject` is the slot it takes over.
 - **Debt:** a treemap draws the top ~50 files; the rest of the ranking is only
   in the table. A zoom or a directory roll-up is the fix if it starts to bite.
 - **Decision:** the graph summary (nodes, edges, cycles, fan-in) is read, not
@@ -117,6 +124,9 @@ what more than one screen uses moves up into `lib/components/`.
   summary fold across languages, cycle paths over real edges, the focus
   ranking, edge classification,
   and the viewport's zoom, clamping, letterboxing and carrying across a resize) with its canvas, folder tree and
-  cycle list, the analysis store (including a superseded run), plus the
-  `/hotspots` and `/graph` routes end to end. Components mount through
-  `lib/test/render`; graphs come from `lib/test/graph`.
+  cycle list, the analysis store (including a superseded run), the shell (the
+  nav's active entry and its planned ones, the project label, the run summary's
+  fold, the rail, the header's breadcrumb and *Re-analyze*, and the frame
+  itself), the plugin store's load-once, plus the `/hotspots` and `/graph`
+  routes end to end. Components mount through `lib/test/render`; graphs come
+  from `lib/test/graph`.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -46,7 +46,9 @@ src/
     theme/            tokens.css (both palettes) + the appearance controller
     api/              one module per endpoint over a shared request helper
     analysis/         the last report, held app-wide, + the form that runs one
-    format/           compact numbers and repo paths, shared by every screen
+    plugins/          what the workbench loaded, fetched once for the app
+    shell/            the workbench frame: rail, sticky header, scrolling pane
+    format/           compact numbers, repo paths, durations and ages
     geometry/         squarify — the treemap layout
     hotspots/         the hotspot feature: report → rows, heat, views
     graph/            the dependency feature: folder tree, collapse, rank, layered, views
@@ -76,8 +78,16 @@ storage key on purpose, so keep the two in step.
 
 ## Status
 
-The theme layer, the typed API client and the first two analysis screens:
+The theme layer, the typed API client, the app shell and the first two analysis
+screens:
 
+- **The shell** (`lib/shell`) — a left rail (logo, the current project, the
+  analysis nav, the settings entries and the plugin count), a header that
+  sticks to the content column (breadcrumb, branch and revision chips, the last
+  run's files/duration/age, *Re-analyze*, appearance), and one scrolling main
+  pane. Screens that are on the backlog are listed in the nav, disabled, so the
+  map of the workbench is complete. Below `md` the rail gives way to a nav
+  strip in the header.
 - **Hotspots** (`/hotspots`) — a squarified treemap sized by score and coloured
   by complexity, its heat legend, and the ranked table.
 - **Dependencies** (`/graph`) — the import graph as uniform cards in ranks, in
@@ -91,10 +101,11 @@ The theme layer, the typed API client and the first two analysis screens:
   neighbourhood; selecting a cycle lights up the knot.
 
 Until the project switcher lands, the repo to analyse is typed into the form on
-those pages and remembered in `localStorage`.
+those pages and remembered in `localStorage`; the rail names it and the header
+re-runs it.
 
-The app shell (left rail, header, project switcher) and the remaining analysis
-screens are next — see [`BACKLOG.md`](../../BACKLOG.md) and the *web-ui* issues.
+The project switcher and the remaining analysis and settings screens are next —
+see [`BACKLOG.md`](../../BACKLOG.md) and the *web-ui* issues.
 
 Where each screen's data comes from:
 

--- a/apps/web/src/lib/format/age.test.ts
+++ b/apps/web/src/lib/format/age.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { relativeAge } from './age';
+
+const now = Date.parse('2026-08-15T12:00:00.000Z');
+const ago = (ms: number) => new Date(now - ms).toISOString();
+
+describe('relativeAge', () => {
+  it('calls anything inside the last minute recent', () => {
+    expect(relativeAge(ago(0), now)).toBe('just now');
+    expect(relativeAge(ago(59_000), now)).toBe('just now');
+  });
+
+  it('steps up through minutes, hours, days and weeks', () => {
+    expect(relativeAge(ago(5 * 60_000), now)).toBe('5 min ago');
+    expect(relativeAge(ago(3 * 3_600_000), now)).toBe('3 h ago');
+    expect(relativeAge(ago(2 * 86_400_000), now)).toBe('2 d ago');
+    expect(relativeAge(ago(3 * 7 * 86_400_000), now)).toBe('3 w ago');
+  });
+
+  it('never prints a future for a clock that runs behind', () => {
+    expect(relativeAge(new Date(now + 20_000).toISOString(), now)).toBe(
+      'just now',
+    );
+  });
+
+  it('has nothing to say about an unparseable timestamp', () => {
+    expect(relativeAge('not a date', now)).toBe('—');
+  });
+});

--- a/apps/web/src/lib/format/age.ts
+++ b/apps/web/src/lib/format/age.ts
@@ -1,0 +1,22 @@
+/**
+ * How long ago something happened. The header prints the last run's age next
+ * to the branch and revision chips and re-reads it on a timer, so it has to
+ * stay short, never wrap, and degrade quietly on a timestamp it cannot parse.
+ */
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+const WEEK = 7 * DAY;
+
+export function relativeAge(iso: string, now: number = Date.now()): string {
+  const at = Date.parse(iso);
+  if (Number.isNaN(at)) return '—';
+
+  const elapsed = now - at;
+  // A browser clock a few seconds behind the server must not print a future.
+  if (elapsed < MINUTE) return 'just now';
+  if (elapsed < HOUR) return `${Math.floor(elapsed / MINUTE)} min ago`;
+  if (elapsed < DAY) return `${Math.floor(elapsed / HOUR)} h ago`;
+  if (elapsed < WEEK) return `${Math.floor(elapsed / DAY)} d ago`;
+  return `${Math.floor(elapsed / WEEK)} w ago`;
+}

--- a/apps/web/src/lib/format/duration.test.ts
+++ b/apps/web/src/lib/format/duration.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { formatDuration } from './duration';
+
+describe('formatDuration', () => {
+  it('keeps sub-second runs in milliseconds', () => {
+    expect(formatDuration(0)).toBe('0 ms');
+    expect(formatDuration(842.4)).toBe('842 ms');
+  });
+
+  it('prints seconds with one decimal', () => {
+    expect(formatDuration(1000)).toBe('1.0 s');
+    expect(formatDuration(2440)).toBe('2.4 s');
+  });
+
+  it('splits a long run into minutes and seconds', () => {
+    expect(formatDuration(64_000)).toBe('1 m 4 s');
+    expect(formatDuration(120_000)).toBe('2 m');
+    // Rounding the remainder on its own would say "1 m 60 s" here.
+    expect(formatDuration(119_600)).toBe('2 m');
+  });
+
+  it('has nothing to say about a nonsense duration', () => {
+    expect(formatDuration(Number.NaN)).toBe('—');
+    expect(formatDuration(-1)).toBe('—');
+  });
+});

--- a/apps/web/src/lib/format/duration.ts
+++ b/apps/web/src/lib/format/duration.ts
@@ -1,0 +1,19 @@
+/**
+ * How long a run took, in the shortest form that still reads exactly: an
+ * incremental analysis lands in milliseconds and a cold one over a large
+ * repository takes minutes, and the header prints both in the same slot.
+ */
+export function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return '—';
+  if (ms < 1000) return `${Math.round(ms)} ms`;
+
+  const seconds = ms / 1000;
+  if (seconds < 60) return `${seconds.toFixed(1)} s`;
+
+  // Round to whole seconds first: rounding the remainder on its own turns
+  // 119.6 s into "1 m 60 s".
+  const total = Math.round(seconds);
+  const minutes = Math.floor(total / 60);
+  const rest = total % 60;
+  return rest === 0 ? `${minutes} m` : `${minutes} m ${rest} s`;
+}

--- a/apps/web/src/lib/format/index.ts
+++ b/apps/web/src/lib/format/index.ts
@@ -1,2 +1,4 @@
+export { relativeAge } from './age';
+export { formatDuration } from './duration';
 export { compactNumber } from './number';
 export { dirName, fileName } from './path';

--- a/apps/web/src/lib/plugins/index.ts
+++ b/apps/web/src/lib/plugins/index.ts
@@ -1,0 +1,1 @@
+export { plugins, PluginsStore, type PluginsStatus } from './store.svelte';

--- a/apps/web/src/lib/plugins/store.svelte.ts
+++ b/apps/web/src/lib/plugins/store.svelte.ts
@@ -1,0 +1,63 @@
+import { ApiError, fetchPlugins, type PluginsResponse } from '$lib/api';
+
+export type PluginsStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+/**
+ * What the workbench loaded. The rail prints the count, the overview will list
+ * the plugins themselves, and the settings screens read the same response — so
+ * it is fetched once for the app rather than per screen.
+ *
+ * Exported as a class as well as the singleton below: a test wants its own
+ * instance, the app wants one.
+ */
+export class PluginsStore {
+  #status = $state<PluginsStatus>('idle');
+  #response = $state<PluginsResponse | null>(null);
+  #error = $state('');
+
+  get status(): PluginsStatus {
+    return this.#status;
+  }
+
+  get response(): PluginsResponse | null {
+    return this.#response;
+  }
+
+  get error(): string {
+    return this.#error;
+  }
+
+  /** How many plugins loaded; `null` until the first response arrives. */
+  get count(): number | null {
+    return this.#response ? this.#response.plugins.length : null;
+  }
+
+  /** Plugins that were found but could not be loaded. */
+  get failures(): number {
+    return this.#response?.failures.length ?? 0;
+  }
+
+  /**
+   * Load once. Safe to call from every component that mounts — the second
+   * caller joins the first request instead of making another.
+   */
+  load(): void {
+    if (this.#status !== 'idle') return;
+    void this.reload();
+  }
+
+  async reload(): Promise<void> {
+    this.#status = 'loading';
+    try {
+      this.#response = await fetchPlugins();
+      this.#error = '';
+      this.#status = 'ready';
+    } catch (err) {
+      this.#error =
+        err instanceof ApiError ? err.message : 'Unexpected client error.';
+      this.#status = 'error';
+    }
+  }
+}
+
+export const plugins = new PluginsStore();

--- a/apps/web/src/lib/plugins/store.test.ts
+++ b/apps/web/src/lib/plugins/store.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PluginsStore } from './store.svelte';
+
+const response = {
+  directory: '/home/dev/.strata/plugins',
+  plugins: [
+    { id: 'language-typescript', name: 'TypeScript', kind: 'language' },
+    { id: 'git-hotspots', name: 'Hotspots', kind: 'metric' },
+  ],
+  failures: [
+    { manifestPath: '/plugins/broken', source: 'user', error: 'no entry' },
+  ],
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('plugins store', () => {
+  it('counts what loaded and what was skipped', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => Response.json(response)),
+    );
+
+    const store = new PluginsStore();
+    expect(store.count).toBeNull();
+
+    await store.reload();
+
+    expect(store.status).toBe('ready');
+    expect(store.count).toBe(2);
+    expect(store.failures).toBe(1);
+  });
+
+  it('loads once however many views ask for it', async () => {
+    const fetchMock = vi.fn(async () => Response.json(response));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const store = new PluginsStore();
+    store.load();
+    store.load();
+    await vi.waitFor(() => {
+      expect(store.status).toBe('ready');
+    });
+    store.load();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces a server that is not there', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new TypeError('fetch failed');
+      }),
+    );
+
+    const store = new PluginsStore();
+    await store.reload();
+
+    expect(store.status).toBe('error');
+    expect(store.error).toBeTruthy();
+    expect(store.count).toBeNull();
+  });
+});

--- a/apps/web/src/lib/shell/CurrentProject.svelte
+++ b/apps/web/src/lib/shell/CurrentProject.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import { analysis } from '$lib/analysis';
+  import { projectLabel } from './project';
+
+  /**
+   * The project the workbench is pointed at. A switcher belongs here — a
+   * dropdown over the registered projects, with *Add project* — and lands with
+   * the project registry; until then this names the repository the last run
+   * used, which is the one every screen is showing.
+   */
+  analysis.init();
+
+  let name = $derived(projectLabel(analysis.root));
+</script>
+
+<div
+  class="border-line bg-elevated rounded-lg border px-3 py-2"
+  aria-label="Current project"
+>
+  <p class="text-subtle text-[0.625rem] tracking-wide uppercase">Project</p>
+  {#if name}
+    <p class="truncate text-sm font-medium" title={analysis.root}>{name}</p>
+    <p class="text-subtle truncate font-mono text-[0.6875rem]" title={analysis.root}>
+      {analysis.root}
+    </p>
+  {:else}
+    <p class="text-muted text-sm">No project yet</p>
+    <p class="text-subtle text-[0.6875rem]">
+      Point Strata at a repository to start.
+    </p>
+  {/if}
+</div>

--- a/apps/web/src/lib/shell/Header.svelte
+++ b/apps/web/src/lib/shell/Header.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+  import { analysis } from '$lib/analysis';
+  import ThemeSwitch from '$lib/components/ThemeSwitch.svelte';
+  import NavList from './NavList.svelte';
+  import RunSummary from './RunSummary.svelte';
+  import { ANALYSIS_NAV, sectionLabel, SETTINGS_NAV } from './nav';
+  import { projectLabel } from './project';
+
+  interface Props {
+    pathname: string;
+  }
+
+  let { pathname }: Props = $props();
+
+  // *Re-analyze* re-runs whatever the workbench is pointed at, so it needs the
+  // remembered path even on a reload that has not run anything yet.
+  analysis.init();
+
+  let section = $derived(sectionLabel(pathname));
+  let project = $derived(projectLabel(analysis.root));
+  let running = $derived(analysis.status === 'running');
+</script>
+
+<!--
+  Sticky against the scrolling pane, not the window: the rail is fixed beside
+  it, so the header only ever spans the content column.
+-->
+<header
+  class="bg-bg/85 border-line sticky top-0 z-20 border-b backdrop-blur-sm"
+>
+  <div class="flex flex-wrap items-center gap-x-4 gap-y-2 px-4 py-3 sm:px-6">
+    <nav class="min-w-0 flex-1" aria-label="Breadcrumb">
+      <ol class="flex min-w-0 items-center gap-2 text-sm">
+        <li class="text-muted min-w-0 truncate" title={analysis.root}>
+          {project || 'Strata'}
+        </li>
+        <li class="text-subtle" aria-hidden="true">/</li>
+        <li class="truncate font-medium" aria-current="page">{section}</li>
+      </ol>
+    </nav>
+
+    <div class="flex flex-wrap items-center gap-3">
+      <RunSummary report={analysis.report} />
+      <button
+        type="button"
+        class="border-line bg-surface text-ink hover:bg-elevated rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+        disabled={running || !analysis.root}
+        title={analysis.root
+          ? `Re-run the analysis of ${analysis.root}`
+          : 'Point Strata at a repository first'}
+        onclick={() => void analysis.run()}
+      >
+        {running ? 'Analysing…' : 'Re-analyze'}
+      </button>
+      <ThemeSwitch />
+    </div>
+  </div>
+
+  <!-- No room for the rail on a narrow screen: the same nav, laid across. -->
+  <div class="border-line border-t px-2 py-2 md:hidden">
+    <NavList
+      items={[...ANALYSIS_NAV, ...SETTINGS_NAV]}
+      {pathname}
+      orientation="row"
+      label="Workbench"
+    />
+  </div>
+</header>

--- a/apps/web/src/lib/shell/Header.test.ts
+++ b/apps/web/src/lib/shell/Header.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from '$lib/test/render';
+import Header from './Header.svelte';
+
+/**
+ * The header reads the app-wide analysis store, which is a single instance and
+ * survives between the tests below — so the first test here is the one that
+ * runs before any repository has been named.
+ */
+
+const report = {
+  rev: '982eb56cafe1234',
+  run: {
+    branch: 'main',
+    files: 1240,
+    durationMs: 2440,
+    finishedAt: new Date().toISOString(),
+  },
+  languages: {},
+  metrics: [],
+  commits: [],
+  cache: {
+    enabled: false,
+    hits: 0,
+    misses: 0,
+    runHits: 0,
+    runMisses: 0,
+    writes: 0,
+  },
+};
+
+const reanalyze = (ui: ReturnType<typeof render>) =>
+  [...ui.container.querySelectorAll('button')].find((button) =>
+    button.textContent?.includes('Re-analyze'),
+  )!;
+
+let ui: ReturnType<typeof render>;
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  ui?.destroy();
+  vi.unstubAllGlobals();
+  localStorage.clear();
+});
+
+describe('Header', () => {
+  it('has nothing to re-analyse before a repository is named', () => {
+    ui = render(Header, { pathname: '/hotspots' });
+
+    expect(reanalyze(ui).disabled).toBe(true);
+    expect(ui.container.textContent).toContain('No analysis yet');
+  });
+
+  it('breadcrumbs the project and the section', () => {
+    localStorage.setItem('strata:root', '/home/dev/workspace/strata');
+    ui = render(Header, { pathname: '/graph' });
+
+    const crumbs = [...ui.container.querySelectorAll('nav li')].map((li) =>
+      li.textContent?.trim(),
+    );
+    expect(crumbs).toEqual(['strata', '/', 'Dependencies']);
+  });
+
+  it('re-runs the analysis of the remembered repository', async () => {
+    const fetchMock = vi.fn(async () => Response.json(report));
+    vi.stubGlobal('fetch', fetchMock);
+    localStorage.setItem('strata:root', '/home/dev/workspace/strata');
+
+    ui = render(Header, { pathname: '/hotspots' });
+    reanalyze(ui).click();
+
+    await vi.waitFor(() => {
+      expect(ui.container.textContent).toContain('982eb56c');
+    });
+
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    expect(url).toContain('/analyze');
+    expect(JSON.parse(String(init.body))).toEqual({
+      root: '/home/dev/workspace/strata',
+    });
+  });
+
+  it('chips the branch and revision of the last run, with its summary', () => {
+    ui = render(Header, { pathname: '/hotspots' });
+
+    const text = ui.container.textContent ?? '';
+    expect(text).toContain('main');
+    expect(text).toContain('982eb56c');
+    expect(text).toContain('1.2k files');
+    expect(text).toContain('2.4 s');
+    expect(text).toContain('just now');
+  });
+});

--- a/apps/web/src/lib/shell/Logo.svelte
+++ b/apps/web/src/lib/shell/Logo.svelte
@@ -1,0 +1,35 @@
+<!--
+  Strata: layers, read from the top down. Drawn in `currentColor` so the mark
+  takes the ink of whichever theme is painted.
+-->
+<a class="flex items-center gap-2.5" href="/" aria-label="Strata — workbench">
+  <svg
+    class="text-accent shrink-0"
+    width="22"
+    height="22"
+    viewBox="0 0 22 22"
+    fill="none"
+    aria-hidden="true"
+  >
+    <rect x="2" y="4" width="18" height="3.4" rx="1.2" fill="currentColor" />
+    <rect
+      x="2"
+      y="9.3"
+      width="13"
+      height="3.4"
+      rx="1.2"
+      fill="currentColor"
+      opacity="0.72"
+    />
+    <rect
+      x="2"
+      y="14.6"
+      width="8"
+      height="3.4"
+      rx="1.2"
+      fill="currentColor"
+      opacity="0.45"
+    />
+  </svg>
+  <span class="text-base font-semibold tracking-tight">Strata</span>
+</a>

--- a/apps/web/src/lib/shell/NavList.svelte
+++ b/apps/web/src/lib/shell/NavList.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import { activeNav, type NavItem } from './nav';
+
+  interface Props {
+    items: readonly NavItem[];
+    /** The route the app is on; decides which entry is current. */
+    pathname: string;
+    /** `column` in the rail, `row` in the narrow-screen strip. */
+    orientation?: 'column' | 'row';
+    label?: string;
+  }
+
+  let { items, pathname, orientation = 'column', label }: Props = $props();
+
+  let current = $derived(activeNav(pathname)?.href ?? null);
+  let base = $derived(
+    orientation === 'column'
+      ? 'w-full justify-between px-3 py-2'
+      : 'shrink-0 gap-2 px-3 py-1.5',
+  );
+</script>
+
+<ul
+  class={orientation === 'column'
+    ? 'space-y-0.5'
+    : 'flex gap-1 overflow-x-auto'}
+  aria-label={label}
+>
+  {#each items as item (item.href)}
+    <li>
+      {#if item.status === 'planned'}
+        <!-- On the backlog: shown so the map is complete, inert so it cannot
+             lead anywhere that is not there yet. -->
+        <span
+          class="text-subtle flex cursor-not-allowed items-center rounded-lg text-sm {base}"
+          aria-disabled="true"
+          title="Not built yet"
+        >
+          <span class="truncate">{item.label}</span>
+          <span class="text-subtle ml-2 text-[0.625rem] tracking-wide uppercase"
+            >soon</span
+          >
+        </span>
+      {:else}
+        <a
+          href={item.href}
+          aria-current={current === item.href ? 'page' : undefined}
+          class="flex items-center rounded-lg text-sm transition-colors {base}
+                 {current === item.href
+            ? 'bg-accent-soft text-ink font-medium'
+            : 'text-muted hover:bg-elevated hover:text-ink'}"
+        >
+          <span class="truncate">{item.label}</span>
+        </a>
+      {/if}
+    </li>
+  {/each}
+</ul>

--- a/apps/web/src/lib/shell/PluginCount.svelte
+++ b/apps/web/src/lib/shell/PluginCount.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import { plugins } from '$lib/plugins';
+
+  // The rail is on screen for the whole session, so this is where the app-wide
+  // plugin list gets loaded — once, whatever screen the reader opened on.
+  $effect(() => {
+    plugins.load();
+  });
+
+  let count = $derived(plugins.count);
+</script>
+
+<div class="text-xs">
+  {#if plugins.status === 'error'}
+    <p class="text-warn">Server unreachable</p>
+    <p class="text-subtle mt-0.5">Plugins unknown</p>
+  {:else if count === null}
+    <p class="text-subtle">Loading plugins…</p>
+  {:else}
+    <p class="text-muted">
+      <span class="text-ink font-mono">{count}</span>
+      {count === 1 ? 'plugin' : 'plugins'} loaded
+    </p>
+    {#if plugins.failures > 0}
+      <p class="text-warn mt-0.5">
+        {plugins.failures} skipped
+      </p>
+    {/if}
+  {/if}
+</div>

--- a/apps/web/src/lib/shell/Rail.svelte
+++ b/apps/web/src/lib/shell/Rail.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import CurrentProject from './CurrentProject.svelte';
+  import Logo from './Logo.svelte';
+  import NavList from './NavList.svelte';
+  import PluginCount from './PluginCount.svelte';
+  import { ANALYSIS_NAV, SETTINGS_NAV } from './nav';
+
+  interface Props {
+    pathname: string;
+  }
+
+  let { pathname }: Props = $props();
+</script>
+
+<!--
+  The rail owns the whole window height and never scrolls with the content: on
+  a narrow screen there is no room for it, and the header carries the same nav
+  as a strip instead.
+-->
+<aside
+  class="border-line bg-surface hidden w-60 shrink-0 flex-col border-r md:flex lg:w-64"
+>
+  <div class="px-4 py-4">
+    <Logo />
+  </div>
+
+  <div class="px-3 pb-2">
+    <CurrentProject />
+  </div>
+
+  <nav class="min-h-0 flex-1 overflow-y-auto px-3 py-3" aria-label="Workbench">
+    <p class="text-subtle px-3 pb-1 text-[0.625rem] tracking-wide uppercase">
+      Analysis
+    </p>
+    <NavList items={ANALYSIS_NAV} {pathname} label="Analysis" />
+
+    <p class="text-subtle px-3 pt-5 pb-1 text-[0.625rem] tracking-wide uppercase">
+      Settings
+    </p>
+    <NavList items={SETTINGS_NAV} {pathname} label="Settings" />
+  </nav>
+
+  <div class="border-line border-t px-4 py-3">
+    <PluginCount />
+  </div>
+</aside>

--- a/apps/web/src/lib/shell/Rail.test.ts
+++ b/apps/web/src/lib/shell/Rail.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { analysis } from '$lib/analysis';
+import { render } from '$lib/test/render';
+import Rail from './Rail.svelte';
+
+const pluginsResponse = {
+  directory: '/home/dev/.strata/plugins',
+  plugins: [
+    { id: 'language-typescript', name: 'TypeScript', kind: 'language' },
+    { id: 'git-hotspots', name: 'Hotspots', kind: 'metric' },
+    { id: 'git-coupling', name: 'Coupling', kind: 'metric' },
+  ],
+  failures: [],
+};
+
+const entry = (ui: ReturnType<typeof render>, label: string) =>
+  [...ui.container.querySelectorAll('a, span[aria-disabled]')].find(
+    (element) => element.textContent?.trim().startsWith(label),
+  );
+
+let ui: ReturnType<typeof render>;
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => Response.json(pluginsResponse)),
+  );
+});
+
+afterEach(() => {
+  ui?.destroy();
+  vi.unstubAllGlobals();
+  localStorage.clear();
+});
+
+describe('Rail', () => {
+  it('lists the analysis screens and the settings scopes', () => {
+    ui = render(Rail, { pathname: '/hotspots' });
+
+    const text = ui.container.textContent ?? '';
+    for (const label of [
+      'Overview',
+      'Hotspots',
+      'Dependencies',
+      'Commits',
+      'Dead code',
+      'Project settings',
+      'App settings',
+    ]) {
+      expect(text).toContain(label);
+    }
+  });
+
+  it('marks the screen the app is on', () => {
+    ui = render(Rail, { pathname: '/graph' });
+
+    expect(entry(ui, 'Dependencies')?.getAttribute('aria-current')).toBe(
+      'page',
+    );
+    expect(entry(ui, 'Hotspots')?.getAttribute('aria-current')).toBeNull();
+  });
+
+  it('shows a screen that is not built yet without linking to it', () => {
+    ui = render(Rail, { pathname: '/hotspots' });
+
+    const commits = entry(ui, 'Commits');
+    expect(commits?.tagName).toBe('SPAN');
+    expect(commits?.getAttribute('aria-disabled')).toBe('true');
+  });
+
+  it('counts the plugins the workbench loaded', async () => {
+    ui = render(Rail, { pathname: '/' });
+
+    await vi.waitFor(() => {
+      expect(ui.container.textContent).toContain('plugins loaded');
+    });
+    expect(ui.container.textContent).toContain('3');
+  });
+
+  it('names the repository the workbench is pointed at', () => {
+    analysis.root = '/home/dev/workspace/strata';
+    ui = render(Rail, { pathname: '/' });
+
+    expect(ui.container.textContent).toContain('strata');
+    expect(ui.container.textContent).toContain('/home/dev/workspace/strata');
+  });
+});

--- a/apps/web/src/lib/shell/RunSummary.svelte
+++ b/apps/web/src/lib/shell/RunSummary.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import type { AnalysisReport } from '$lib/api';
+  import { runDisplay } from './summary';
+
+  interface Props {
+    report: AnalysisReport | null;
+  }
+
+  let { report }: Props = $props();
+
+  // The age keeps counting while the workbench sits open: a header that still
+  // says "just now" an hour later is worse than no age at all.
+  let now = $state(Date.now());
+  $effect(() => {
+    const timer = setInterval(() => {
+      now = Date.now();
+    }, 30_000);
+    return () => clearInterval(timer);
+  });
+
+  let run = $derived(report ? runDisplay(report, now) : null);
+</script>
+
+{#if run}
+  <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+    <span
+      class="border-line bg-elevated flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-xs"
+    >
+      <span class="text-subtle">branch</span>
+      <span class="truncate">{run.branch}</span>
+    </span>
+    <span
+      class="border-line bg-elevated flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-xs"
+    >
+      <span class="text-subtle">rev</span>
+      <span class="font-mono">{run.rev}</span>
+    </span>
+    <p class="text-subtle text-xs whitespace-nowrap">
+      {run.files} files · {run.duration} · {run.age}
+    </p>
+  </div>
+{:else}
+  <p class="text-subtle text-xs">No analysis yet</p>
+{/if}

--- a/apps/web/src/lib/shell/Shell.svelte
+++ b/apps/web/src/lib/shell/Shell.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import Header from './Header.svelte';
+  import Rail from './Rail.svelte';
+
+  interface Props {
+    /** The route the app is on. The layout reads it from SvelteKit. */
+    pathname: string;
+    children: Snippet;
+  }
+
+  let { pathname, children }: Props = $props();
+</script>
+
+<!--
+  The window is the frame: the rail and the header stay put and only the main
+  pane scrolls, so a treemap or a graph canvas can size itself against the room
+  it is given instead of against a page that grows underneath it.
+-->
+<div class="bg-bg text-ink flex h-dvh overflow-hidden">
+  <Rail {pathname} />
+
+  <div class="flex min-w-0 flex-1 flex-col overflow-y-auto">
+    <Header {pathname} />
+
+    <!-- Full width on purpose: a treemap and a graph canvas both take
+         whatever room they are given, and the rail already sets the margin. -->
+    <main class="w-full flex-1 px-4 py-6 sm:px-6 sm:py-8">
+      {@render children()}
+    </main>
+  </div>
+</div>

--- a/apps/web/src/lib/shell/Shell.test.ts
+++ b/apps/web/src/lib/shell/Shell.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createRawSnippet } from 'svelte';
+import { render } from '$lib/test/render';
+import Shell from './Shell.svelte';
+
+const children = createRawSnippet(() => ({
+  render: () => '<p>screen content</p>',
+}));
+
+let ui: ReturnType<typeof render>;
+
+afterEach(() => {
+  ui?.destroy();
+  vi.unstubAllGlobals();
+  localStorage.clear();
+});
+
+describe('Shell', () => {
+  it('frames a screen with the rail, the header and one scrolling pane', () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        Response.json({ directory: '/plugins', plugins: [], failures: [] }),
+      ),
+    );
+
+    ui = render(Shell, { pathname: '/hotspots', children });
+
+    expect(ui.container.querySelector('aside')).not.toBeNull();
+    // The header sticks to the pane that scrolls, not to the window.
+    const header = ui.container.querySelector('header')!;
+    expect(header.className).toContain('sticky');
+    expect(header.parentElement?.className).toContain('overflow-y-auto');
+    // Exactly one main landmark: the screens render inside it.
+    expect(ui.container.querySelectorAll('main')).toHaveLength(1);
+    expect(ui.container.querySelector('main')?.textContent).toContain(
+      'screen content',
+    );
+  });
+});

--- a/apps/web/src/lib/shell/index.ts
+++ b/apps/web/src/lib/shell/index.ts
@@ -1,0 +1,12 @@
+export { default as Shell } from './Shell.svelte';
+export {
+  activeNav,
+  ANALYSIS_NAV,
+  NAV_ITEMS,
+  sectionLabel,
+  SETTINGS_NAV,
+  type NavItem,
+  type NavStatus,
+} from './nav';
+export { projectLabel } from './project';
+export { runDisplay, type RunDisplay } from './summary';

--- a/apps/web/src/lib/shell/nav.test.ts
+++ b/apps/web/src/lib/shell/nav.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { activeNav, ANALYSIS_NAV, sectionLabel, SETTINGS_NAV } from './nav';
+
+describe('nav', () => {
+  it('lists the analysis screens and the two settings scopes', () => {
+    expect(ANALYSIS_NAV.map((item) => item.label)).toEqual([
+      'Overview',
+      'Hotspots',
+      'Dependencies',
+      'Commits',
+      'Dead code',
+    ]);
+    expect(SETTINGS_NAV.map((item) => item.label)).toEqual([
+      'Project settings',
+      'App settings',
+    ]);
+  });
+
+  it('marks screens that are not built yet as planned', () => {
+    expect(ANALYSIS_NAV.find((item) => item.href === '/graph')?.status).toBe(
+      'ready',
+    );
+    expect(ANALYSIS_NAV.find((item) => item.href === '/commits')?.status).toBe(
+      'planned',
+    );
+  });
+
+  it('finds the entry a path is on', () => {
+    expect(activeNav('/hotspots')?.label).toBe('Hotspots');
+    expect(activeNav('/hotspots/')?.label).toBe('Hotspots');
+    expect(activeNav('/')?.label).toBe('Overview');
+  });
+
+  it('keeps the root entry from swallowing every other path', () => {
+    expect(activeNav('/graph')?.href).toBe('/graph');
+  });
+
+  it('highlights the section a sub-page belongs to', () => {
+    expect(activeNav('/settings/project/scope')?.label).toBe(
+      'Project settings',
+    );
+  });
+
+  it('names the section, and falls back on an unknown path', () => {
+    expect(sectionLabel('/graph')).toBe('Dependencies');
+    expect(sectionLabel('/nowhere')).toBe('Workbench');
+    expect(activeNav('/nowhere')).toBeNull();
+  });
+});

--- a/apps/web/src/lib/shell/nav.ts
+++ b/apps/web/src/lib/shell/nav.ts
@@ -1,0 +1,64 @@
+/**
+ * What the rail lists, in order. Screens that are on the backlog but not built
+ * are listed too, disabled: the shell is the map of the workbench, and a map
+ * with holes in it reads as something broken rather than something coming.
+ */
+export type NavStatus = 'ready' | 'planned';
+
+export interface NavItem {
+  /** Route the entry points at; also its identity in the list. */
+  href: string;
+  label: string;
+  status: NavStatus;
+}
+
+/** The analysis screens — one run, read five ways. */
+export const ANALYSIS_NAV: readonly NavItem[] = [
+  { href: '/', label: 'Overview', status: 'ready' },
+  { href: '/hotspots', label: 'Hotspots', status: 'ready' },
+  { href: '/graph', label: 'Dependencies', status: 'ready' },
+  { href: '/commits', label: 'Commits', status: 'planned' },
+  { href: '/dead-code', label: 'Dead code', status: 'planned' },
+];
+
+/** The two settings scopes: what this project does, and what the app does. */
+export const SETTINGS_NAV: readonly NavItem[] = [
+  { href: '/settings/project', label: 'Project settings', status: 'planned' },
+  { href: '/settings/app', label: 'App settings', status: 'planned' },
+];
+
+export const NAV_ITEMS: readonly NavItem[] = [
+  ...ANALYSIS_NAV,
+  ...SETTINGS_NAV,
+];
+
+/**
+ * The entry a path sits inside. The longest matching href wins, so a future
+ * `/settings/project/scope` highlights *Project settings* rather than falling
+ * back to the root entry.
+ */
+export function activeNav(pathname: string): NavItem | null {
+  const path = normalise(pathname);
+  let best: NavItem | null = null;
+  for (const item of NAV_ITEMS) {
+    if (!contains(item.href, path)) continue;
+    if (!best || item.href.length > best.href.length) best = item;
+  }
+  return best;
+}
+
+/** What the breadcrumb calls the current screen. */
+export function sectionLabel(pathname: string): string {
+  return activeNav(pathname)?.label ?? 'Workbench';
+}
+
+/** `/` matches only itself — every path is below it otherwise. */
+function contains(href: string, path: string): boolean {
+  if (href === '/') return path === '/';
+  return path === href || path.startsWith(`${href}/`);
+}
+
+function normalise(pathname: string): string {
+  const trimmed = pathname.replace(/\/+$/, '');
+  return trimmed || '/';
+}

--- a/apps/web/src/lib/shell/project.test.ts
+++ b/apps/web/src/lib/shell/project.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { projectLabel } from './project';
+
+describe('projectLabel', () => {
+  it('names a project after its folder', () => {
+    expect(projectLabel('/home/dev/workspace/strata')).toBe('strata');
+    expect(projectLabel('  /home/dev/workspace/strata/  ')).toBe('strata');
+    expect(projectLabel('C:\\code\\strata')).toBe('strata');
+  });
+
+  it('is empty when no repository has been named', () => {
+    expect(projectLabel('')).toBe('');
+    expect(projectLabel('   ')).toBe('');
+  });
+
+  it('keeps a bare name as it is', () => {
+    expect(projectLabel('strata')).toBe('strata');
+  });
+});

--- a/apps/web/src/lib/shell/project.ts
+++ b/apps/web/src/lib/shell/project.ts
@@ -1,0 +1,12 @@
+import { fileName } from '$lib/format';
+
+/**
+ * What the rail and the breadcrumb call the analysed repository: the folder's
+ * name, because an absolute path is too long for either slot. Until the
+ * project registry lands this is all the identity a project has.
+ */
+export function projectLabel(root: string): string {
+  const trimmed = root.trim().replaceAll('\\', '/').replace(/\/+$/, '');
+  if (!trimmed) return '';
+  return fileName(trimmed) || trimmed;
+}

--- a/apps/web/src/lib/shell/summary.test.ts
+++ b/apps/web/src/lib/shell/summary.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import type { AnalysisReport } from '$lib/api';
+import { runDisplay } from './summary';
+
+const now = Date.parse('2026-08-15T12:00:00.000Z');
+
+const report = {
+  rev: '982eb56cafe1234',
+  run: {
+    branch: 'main',
+    files: 1240,
+    durationMs: 2440,
+    finishedAt: '2026-08-15T11:55:00.000Z',
+  },
+  languages: {},
+  metrics: [],
+  commits: [],
+  cache: {
+    enabled: false,
+    hits: 0,
+    misses: 0,
+    runHits: 0,
+    runMisses: 0,
+    writes: 0,
+  },
+} as unknown as AnalysisReport;
+
+describe('runDisplay', () => {
+  it('folds the run into the strings the header prints', () => {
+    expect(runDisplay(report, now)).toEqual({
+      branch: 'main',
+      rev: '982eb56c',
+      files: '1.2k',
+      duration: '2.4 s',
+      age: '5 min ago',
+    });
+  });
+
+  it('calls a revision on no branch detached', () => {
+    const detached = {
+      ...report,
+      run: { ...report.run, branch: null },
+    } as AnalysisReport;
+
+    expect(runDisplay(detached, now).branch).toBe('detached');
+  });
+
+  it('stays printable when a report carries no run summary', () => {
+    const bare = { ...report, run: undefined } as unknown as AnalysisReport;
+
+    expect(runDisplay(bare, now)).toEqual({
+      branch: 'detached',
+      rev: '982eb56c',
+      files: '0',
+      duration: '—',
+      age: '—',
+    });
+  });
+});

--- a/apps/web/src/lib/shell/summary.ts
+++ b/apps/web/src/lib/shell/summary.ts
@@ -1,0 +1,31 @@
+import type { AnalysisReport } from '$lib/api';
+import { compactNumber, formatDuration, relativeAge } from '$lib/format';
+
+/** The last run, as the header prints it — strings, ready to paint. */
+export interface RunDisplay {
+  /** Branch of the analysed revision; `detached` when the rev names no branch. */
+  branch: string;
+  /** Short revision, as everything else in the UI abbreviates it. */
+  rev: string;
+  files: string;
+  duration: string;
+  age: string;
+}
+
+const SHORT_REV = 8;
+
+export function runDisplay(
+  report: AnalysisReport,
+  now: number = Date.now(),
+): RunDisplay {
+  // Every report the server sends carries a run summary; the fallbacks keep
+  // the header printable rather than blank if one ever arrives without.
+  const run = report.run as AnalysisReport['run'] | undefined;
+  return {
+    branch: run?.branch ?? 'detached',
+    rev: report.rev.slice(0, SHORT_REV),
+    files: compactNumber(run?.files ?? 0),
+    duration: formatDuration(run?.durationMs ?? Number.NaN),
+    age: run?.finishedAt ? relativeAge(run.finishedAt, now) : '—',
+  };
+}

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import '../app.css';
+  import { page } from '$app/state';
+  import { Shell } from '$lib/shell';
   import { theme } from '$lib/theme';
 
   let { children } = $props();
@@ -8,6 +10,6 @@
   $effect(() => theme.start());
 </script>
 
-<div class="min-h-screen bg-bg text-ink">
+<Shell pathname={page.url.pathname}>
   {@render children()}
-</div>
+</Shell>

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -1,45 +1,37 @@
 <script lang="ts">
   import Card from '$lib/components/Card.svelte';
   import ServerStatus from '$lib/components/ServerStatus.svelte';
-  import ThemeSwitch from '$lib/components/ThemeSwitch.svelte';
   import TokenPalette from '$lib/components/TokenPalette.svelte';
   import { theme } from '$lib/theme';
 </script>
 
 <svelte:head>
-  <title>Strata</title>
+  <title>Overview · Strata</title>
 </svelte:head>
 
-<main class="mx-auto max-w-5xl px-6 py-12">
-  <header class="mb-10 flex flex-wrap items-end justify-between gap-4">
-    <div>
-      <h1 class="text-2xl font-semibold">Strata</h1>
-      <p class="text-muted mt-1 text-sm">
-        Frontend scaffold — theme layer, API client and the first analysis
-        screen in place. The workbench shell comes next.
-      </p>
-      <p class="mt-3 flex flex-wrap gap-4 text-sm">
-        <a
-          class="text-accent underline-offset-4 hover:underline"
-          href="/hotspots"
-        >
-          Hotspots →
-        </a>
-        <a class="text-accent underline-offset-4 hover:underline" href="/graph">
-          Dependencies →
-        </a>
-      </p>
-    </div>
-    <ThemeSwitch />
-  </header>
+<header class="mb-8">
+  <h1 class="text-2xl font-semibold">Overview</h1>
+  <p class="text-muted mt-1 text-sm">
+    The shell is in place — rail, header and a scrolling pane. The overview's
+    stat cards, the commit analytics and the dead-code table land next; until
+    then, the workbench's own state.
+  </p>
+  <p class="mt-3 flex flex-wrap gap-4 text-sm">
+    <a class="text-accent underline-offset-4 hover:underline" href="/hotspots">
+      Hotspots →
+    </a>
+    <a class="text-accent underline-offset-4 hover:underline" href="/graph">
+      Dependencies →
+    </a>
+  </p>
+</header>
 
-  <div class="grid gap-6 md:grid-cols-2">
-    <Card title="Design tokens" hint={theme.resolved}>
-      <TokenPalette />
-    </Card>
+<div class="grid gap-6 md:grid-cols-2">
+  <Card title="Design tokens" hint={theme.resolved}>
+    <TokenPalette />
+  </Card>
 
-    <Card title="Server" hint="/health · /plugins">
-      <ServerStatus />
-    </Card>
-  </div>
-</main>
+  <Card title="Server" hint="/health · /plugins">
+    <ServerStatus />
+  </Card>
+</div>

--- a/apps/web/src/routes/graph/+page.svelte
+++ b/apps/web/src/routes/graph/+page.svelte
@@ -4,7 +4,6 @@
   import { analysis } from '$lib/analysis';
   import RunForm from '$lib/analysis/RunForm.svelte';
   import Card from '$lib/components/Card.svelte';
-  import ThemeSwitch from '$lib/components/ThemeSwitch.svelte';
   import { compactNumber } from '$lib/format';
   import CycleList from '$lib/graph/CycleList.svelte';
   import EdgeLegend from '$lib/graph/EdgeLegend.svelte';
@@ -162,24 +161,15 @@
   <title>Dependencies · Strata</title>
 </svelte:head>
 
-<main class="mx-auto max-w-6xl px-6 py-12">
-  <header class="mb-8 flex flex-wrap items-end justify-between gap-4">
-    <div>
-      <p class="text-subtle text-xs">
-        <a class="hover:text-ink underline-offset-4 hover:underline" href="/">
-          Strata
-        </a>
-        <span aria-hidden="true">/</span> Dependencies
-      </p>
-      <h1 class="mt-1 text-2xl font-semibold">Dependencies</h1>
-      <p class="text-muted mt-1 text-sm">
-        The import graph, grouped by folder. Closed folders are one node, so the
-        picture starts as the architecture; open the ones you care about to see
-        their files. A file inside an import cycle is red, and so is every edge
-        of that knot.
-      </p>
-    </div>
-    <ThemeSwitch />
+<div>
+  <header class="mb-8">
+    <h1 class="text-2xl font-semibold">Dependencies</h1>
+    <p class="text-muted mt-1 max-w-3xl text-sm">
+      The import graph, grouped by folder. Closed folders are one node, so the
+      picture starts as the architecture; open the ones you care about to see
+      their files. A file inside an import cycle is red, and so is every edge of
+      that knot.
+    </p>
   </header>
 
   <div class="mb-6">
@@ -273,4 +263,4 @@
       </div>
     </div>
   {/if}
-</main>
+</div>

--- a/apps/web/src/routes/hotspots/+page.svelte
+++ b/apps/web/src/routes/hotspots/+page.svelte
@@ -2,7 +2,6 @@
   import { analysis } from '$lib/analysis';
   import RunForm from '$lib/analysis/RunForm.svelte';
   import Card from '$lib/components/Card.svelte';
-  import ThemeSwitch from '$lib/components/ThemeSwitch.svelte';
   import { compactNumber } from '$lib/format';
   import HeatLegend from '$lib/hotspots/HeatLegend.svelte';
   import RankedTable from '$lib/hotspots/RankedTable.svelte';
@@ -33,23 +32,14 @@
   <title>Hotspots · Strata</title>
 </svelte:head>
 
-<main class="mx-auto max-w-6xl px-6 py-12">
-  <header class="mb-8 flex flex-wrap items-end justify-between gap-4">
-    <div>
-      <p class="text-subtle text-xs">
-        <a class="hover:text-ink underline-offset-4 hover:underline" href="/">
-          Strata
-        </a>
-        <span aria-hidden="true">/</span> Hotspots
-      </p>
-      <h1 class="mt-1 text-2xl font-semibold">Hotspots</h1>
-      <p class="text-muted mt-1 text-sm">
-        Churn × complexity: files that change often <em>and</em> are dense are
-        where maintenance cost concentrates. Tiles are sized by score and
-        coloured by complexity.
-      </p>
-    </div>
-    <ThemeSwitch />
+<div>
+  <header class="mb-8">
+    <h1 class="text-2xl font-semibold">Hotspots</h1>
+    <p class="text-muted mt-1 max-w-3xl text-sm">
+      Churn × complexity: files that change often <em>and</em> are dense are
+      where maintenance cost concentrates. Tiles are sized by score and coloured
+      by complexity.
+    </p>
   </header>
 
   <div class="mb-6">
@@ -118,4 +108,4 @@
       </Card>
     </div>
   {/if}
-</main>
+</div>


### PR DESCRIPTION
## What

The app shell: a left rail, a header that sticks to the content column, and one scrolling main pane.

- **Rail** (`md` and up) — logo, the analysed project, the analysis nav, the settings entries, and the plugin count from `GET /plugins`. Screens still on the backlog (*Commits*, *Dead code*, both settings scopes) are listed with the rest, disabled and marked `soon`.
- **Header** — breadcrumb (project › section), branch and revision chips, the last run's files / duration / age, *Re-analyze*, and the appearance switch. Below `md` it also carries the nav as a strip, since there is no room for the rail.
- **Main pane** — the only thing that scrolls, full width.

The two analysis screens drop their own breadcrumb, title row and appearance switch and render into the frame. New shared pieces: `lib/plugins` (the loaded plugins, fetched once for the app) and two formatters, `format/duration` and `format/age`.

## Why

Every screen was re-inventing the same header, and there was nowhere to put what belongs to the workbench rather than to a view — which project is open, what the last run did, and how to run it again.

Three decisions worth reviewing, recorded in `apps/web/ARCHITECTURE.md` (19–21):

- **Only the main pane scrolls.** A treemap or a graph canvas sizes itself against the room it is given; a page that scrolls as a whole moves that room out from under it. It also keeps *Re-analyze* reachable from the bottom of a long table.
- **The shell takes the route as a prop.** `+layout.svelte` is the only file that reads `$app/state`, so the whole frame mounts in vitest like every other component and the active-entry rule stays a pure function in `nav.ts`.
- **Backlog screens are listed, disabled.** The rail is the map of the workbench; hiding entries until they exist would make each one arrive as a surprise, and an inert entry cannot navigate to a route that is not there.

The rail's project block names the path the run form remembers — that is the project switcher's slot (#69), and the run form stays on the two screens until it lands.

Closes #68

## Type of change

- [x] feat / fix / perf / refactor
- [ ] docs / test / build / ci / chore

## Checklist

- [x] `pnpm build && pnpm test && pnpm lint` pass locally
- [x] Added/updated tests where it made sense — 37 new (nav, project label, run summary, duration, age, the plugin store's load-once, and the rail, header and frame end to end); 441 across the repo
- [x] Docs updated (`apps/web/ARCHITECTURE.md`, `apps/web/README.md`, `BACKLOG.md`)

## Not verified

No browser tooling in the environment I built this in: the shell is asserted structurally, not looked at. Worth a `make dev` + `make web` pass, especially the narrow-screen nav strip.