### PR TITLE
feat(web): open the workbench on an overview

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -203,9 +203,14 @@ Sans/Mono.
 
 ### Analysis screens
 
-- [ ] **P0** Overview — six stat cards (files, top hotspot, import cycles, commits,
-      dead code, plugins), top-hotspot bar list, import-cycle alert card with the
-      cycle path, loaded-plugins list, commit-type strip
+- [x] Overview (`/`) — six stat cards (files, top hotspot, import cycles,
+      commits, dead code, plugins), top-hotspot bar list, import-cycle alert
+      card with the cycle path, loaded-plugins list, commit-type strip. The
+      hotspot and cycle cards link to the screens that show those numbers in
+      full; the commit types are a bar list rather than a stacked strip, because
+      the palette is a heat ramp with no categorical set (`apps/web` decision
+      26). Reads the run the project switcher's project last had, and lists the
+      loaded plugins even before one.
 - [x] Hotspot treemap (`/hotspots`) — heat legend, squarified tiles sized by
       score and coloured by complexity, the ranked table (churn / complexity /
       LOC / score), and a shared selection between the two. Reads the run the

--- a/apps/web/ARCHITECTURE.md
+++ b/apps/web/ARCHITECTURE.md
@@ -2,8 +2,8 @@
 
 > Trimmed arc42, consistent with [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md).
 > Status: **in progress** — theme layer, API client, the workbench shell, the
-> project switcher and the hotspot and dependency-graph screens in place; the
-> remaining analysis and settings screens are still to build.
+> project switcher and the overview, hotspot and dependency-graph screens in
+> place; the commit, dead-code and settings screens are still to build.
 
 ## 1. Purpose & Goals
 
@@ -42,6 +42,7 @@ app-scoped settings screens. The face of Strata for browser/self-host use.
 | `src/lib/shell/*` | The frame: `nav` (the map of the workbench), `summary` (report → the header's chips), and the views — `Shell`, `Rail`, `Header`, `NavList`, `RunSummary`, `PluginCount`, `Logo` |
 | `src/lib/format/*` | `number` (compact counts), `path` (repo path → dir + name), `duration` and `age`, used by every screen |
 | `src/lib/geometry/*` | `squarify` — the squarified treemap layout |
+| `src/lib/overview/*` | The overview feature end to end: `stats` (report + plugins → the six cards), `bars` (the hotspot head, as shares of the top file), `commits` (history → change types and totals), `dead-code` (findings, and the files holding them), and the six views |
 | `src/lib/hotspots/*` | The hotspot feature end to end: `rows` (report → rows), `heat` (ramp), and the three views |
 | `src/lib/graph/*` | The dependency feature end to end: `merge` (report → one graph), `summary` (report → the panel's numbers), `tree`/`rows` (the folder tree), `collapse` (closed folders), `rank` + `lanes` + `layered` (the columned layout), `edges`, `degree`, `cycles`, `focus`, `viewport` (pan/zoom), and the five views |
 | `src/lib/components/*` | Reusable UI pieces |
@@ -92,6 +93,8 @@ what more than one screen uses moves up into `lib/components/`.
 | 23 | **The registry replaces the repo-path form** | Every screen used to run its own *Repository path* field, which made the typed path and the registered projects two answers to the same question. The path is now typed once, in *Add project*, and the screens read whatever the switcher is on |
 | 24 | **The path is browsed, not only typed** | An absolute server-side path is the one thing a reader of a web UI cannot see, and on a remote or containerised workbench they may never have seen it at all. `FolderPicker` walks `GET /browse` and marks the repositories, so *Add project* is a tree with the answers already highlighted; the field stays beside it, because pasting a path is faster when you know it |
 | 25 | **A first analysis can be started from the switcher** | A project that has just been registered has nothing to show on any screen. *Project settings → Analyze / run* is where that run belongs, and the entry moves there when the screen lands; until then the switcher offers it, because the alternative is an empty workbench with no visible way out |
+| 26 | **The overview folds nothing of its own that another screen already folds** | Its cards read `hotspotRows`, `reportSummary` and `cycleViews` — the same functions the hotspot and dependency screens read. An overview is a second opinion about one run, and a second implementation of "how many cycles" would eventually be a *different* opinion. What is new here is only what no other screen needed: the six cards, the bar shares, the change types and the dead-code count |
+| 27 | **Change types are a bar list, not a coloured strip** | The mockup's commit strip wants six hues; the palette has none to give. `h1…h5` is a *sequential* ramp — validated as a categorical set it fails on adjacent pairs no reader can separate, colour-blind or not — and the status colours are reserved for status. Painting `docs` and `test` from a heat ramp would also say "hotter = worse" about neither. So identity is the label and magnitude is the bar, which is what the two facts are; breaking changes are marked with the danger token *and* the word, as a status should be |
 
 ## 7. Quality & Risks
 
@@ -120,6 +123,15 @@ what more than one screen uses moves up into `lib/components/`.
   synthesises the node the day a plugin does emit one.
 - **Debt:** ESLint skips this app (`apps/web/**` is ignored at the root) —
   `svelte-check` is the only static gate until `eslint-plugin-svelte` is wired in.
+- **Risk:** the overview's dead-code card counts the findings the language
+  modules report, and those are still approximate — entry points and
+  resolution are exact only once tree-sitter lands. The card prints findings
+  *and* the files holding them, so a barrel of unused exports does not read as
+  twenty separate problems; the *preview* framing belongs on the dead-code
+  screen, where the findings themselves are listed.
+- **Debt:** `TokenPalette` and `ServerStatus` are now unmounted: the real
+  overview replaced the workbench's own state, and `/health` has no screen
+  until *App settings*. Both keep their place in `lib/components` for it.
 - **Tests:** `vitest` with the plain Svelte plugin and a `happy-dom`
   environment (`vitest.config.ts`), wired into the root run as a second
   project. Covered: theme resolution, storage, the appearance controller, the
@@ -138,7 +150,13 @@ what more than one screen uses moves up into `lib/components/`.
   the header's breadcrumb and *Re-analyze*, and the frame itself), the project
   registry (its rows, the project label, the store's selection, adoption after
   a reload, add, remove and the fold of a finished run) with the switcher end
-  to end, the plugin store's load-once, plus the `/hotspots` and `/graph`
+  to end, the plugin store's load-once, the overview's pure layer (the six
+  cards' order, values, tones and links, a clean report reading as *none*, bar
+  shares held against the whole ranking, change types grouped and tied by name,
+  and dead code counted per finding *and* per file) with its views — the stat
+  grid through its cards, the hotspot bars, the change types, the cycle alert
+  and the plugin list — plus
+  the `/`, `/hotspots` and `/graph`
   routes end to end, and the folder picker (listing, walking in and back out,
   the path bar, picking a repository or the current folder, the hidden toggle,
   a refusal from the server, and a server that browses nothing) including the

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -52,6 +52,7 @@ src/
     shell/            the workbench frame: rail, sticky header, scrolling pane
     format/           compact numbers, repo paths, durations and ages
     geometry/         squarify — the treemap layout
+    overview/         the overview feature: stat cards, hotspot bars, cycles, plugins, commit types
     hotspots/         the hotspot feature: report → rows, heat, views
     graph/            the dependency feature: folder tree, collapse, rank, layered, views
     components/       reusable UI pieces

--- a/apps/web/src/lib/overview/CommitTypes.svelte
+++ b/apps/web/src/lib/overview/CommitTypes.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+  import type { CommitTypeRow } from './commits';
+
+  interface Props {
+    types: CommitTypeRow[];
+    /** Types listed before the tail becomes the commit screen's job. */
+    limit?: number;
+  }
+
+  let { types, limit = 6 }: Props = $props();
+
+  let shown = $derived(types.slice(0, limit));
+
+  const width = (share: number) => `${(share * 100).toFixed(1)}%`;
+  const percent = (share: number) => `${Math.round(share * 100)}%`;
+</script>
+
+{#if shown.length === 0}
+  <p class="text-muted text-sm">
+    No commits in the analysed history window.
+  </p>
+{:else}
+  <!--
+    One bar per type rather than one strip in six colours: the palette here is
+    a heat ramp — a *sequential* scale — and the app has no categorical set to
+    tell six change types apart. Colouring them from the ramp anyway would pair
+    hues no reader can separate (and no colour-blind reader can separate at
+    all), and would say "hotter = worse" about `docs`. So identity is the label
+    and magnitude is the bar, which is what the two facts actually are.
+  -->
+  <ul class="flex flex-col gap-3">
+    {#each shown as row (row.type)}
+      <li>
+        <div class="flex items-baseline justify-between gap-3">
+          <span class="text-ink truncate font-mono text-xs">{row.type}</span>
+          <span class="shrink-0 font-mono text-xs">
+            {#if row.breaking > 0}
+              <span class="text-danger">{row.breaking} breaking</span>
+              <span class="text-subtle">·</span>
+            {/if}
+            <span class="text-muted">{row.count}</span>
+            <span class="text-subtle">{percent(row.share)}</span>
+          </span>
+        </div>
+        <div
+          class="bg-elevated mt-1 h-1.5 overflow-hidden rounded-full"
+          aria-hidden="true"
+        >
+          <div
+            class="bg-accent h-full rounded-full"
+            style="width: {width(row.share)};"
+          ></div>
+        </div>
+      </li>
+    {/each}
+  </ul>
+
+  {#if types.length > shown.length}
+    <p class="text-subtle mt-3 text-xs">
+      {shown.length} of {types.length} change types.
+    </p>
+  {/if}
+{/if}

--- a/apps/web/src/lib/overview/CommitTypes.test.ts
+++ b/apps/web/src/lib/overview/CommitTypes.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { render } from '$lib/test/render';
+import type { CommitTypeRow } from './commits';
+import CommitTypes from './CommitTypes.svelte';
+
+const types: CommitTypeRow[] = [
+  { type: 'feat', count: 3, share: 0.6, breaking: 0 },
+  { type: 'fix', count: 1, share: 0.2, breaking: 1 },
+  { type: 'other', count: 1, share: 0.2, breaking: 0 },
+];
+
+let ui: ReturnType<typeof render>;
+
+afterEach(() => ui?.destroy());
+
+describe('CommitTypes', () => {
+  it('names each type and prints its count and share', () => {
+    ui = render(CommitTypes, { types });
+
+    expect(ui.container.textContent).toContain('feat');
+    expect(ui.container.textContent).toContain('3');
+    expect(ui.container.textContent).toContain('60%');
+  });
+
+  it('marks the types that carry a breaking change', () => {
+    ui = render(CommitTypes, { types });
+
+    expect(ui.container.querySelector('.text-danger')?.textContent).toContain(
+      '1 breaking',
+    );
+  });
+
+  it('sizes each bar by its share of the window', () => {
+    ui = render(CommitTypes, { types });
+
+    const widths = [...ui.container.querySelectorAll('li div[style]')].map(
+      (fill) => (fill as HTMLElement).style.width,
+    );
+    expect(widths).toEqual(['60.0%', '20.0%', '20.0%']);
+  });
+
+  it('cuts a long tail and says how much it cut', () => {
+    ui = render(CommitTypes, { types, limit: 2 });
+
+    expect(ui.container.querySelectorAll('li')).toHaveLength(2);
+    expect(ui.container.textContent).toContain('2 of 3 change types');
+  });
+
+  it('says so when the window holds no commits', () => {
+    ui = render(CommitTypes, { types: [] });
+
+    expect(ui.container.textContent).toContain('No commits');
+  });
+});

--- a/apps/web/src/lib/overview/CycleAlert.svelte
+++ b/apps/web/src/lib/overview/CycleAlert.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  import { fileName } from '$lib/format';
+  import type { CycleView } from '$lib/graph';
+
+  interface Props {
+    cycles: CycleView[];
+    /** Knots printed here; the rest are on the dependency screen. */
+    limit?: number;
+  }
+
+  let { cycles, limit = 3 }: Props = $props();
+
+  let shown = $derived(cycles.slice(0, limit));
+
+  /** `a → b → a`, on file names; the full paths stay in the tooltip. */
+  const arrow = (path: readonly string[]) => path.map(fileName).join(' → ');
+</script>
+
+{#if cycles.length === 0}
+  <p class="text-muted text-sm">
+    No import cycles — every dependency in this report runs one way.
+  </p>
+{:else}
+  <!-- The alert says what is wrong in words as well as in red: a colour is not
+       the finding, the cycle path is. -->
+  <p class="text-danger text-sm font-medium">
+    {cycles.length}
+    {cycles.length === 1 ? 'import cycle' : 'import cycles'} — files that import
+    each other, directly or around a loop.
+  </p>
+
+  <ul class="mt-3 flex flex-col gap-2">
+    {#each shown as cycle (cycle.index)}
+      <li
+        class="border-line bg-elevated rounded-lg border p-2"
+        title={cycle.path.join(' → ')}
+      >
+        <span class="flex items-baseline justify-between gap-3">
+          <span class="text-danger font-mono text-xs">#{cycle.index}</span>
+          <span class="text-subtle text-xs">{cycle.members.length} files</span>
+        </span>
+        <span class="text-ink mt-1 block font-mono text-xs break-all">
+          {arrow(cycle.path)}
+        </span>
+      </li>
+    {/each}
+  </ul>
+
+  <p class="mt-3 text-xs">
+    <a class="text-accent underline-offset-4 hover:underline" href="/graph">
+      {cycles.length > shown.length
+        ? `All ${cycles.length} on the dependency graph →`
+        : 'Open the dependency graph →'}
+    </a>
+  </p>
+{/if}

--- a/apps/web/src/lib/overview/CycleAlert.test.ts
+++ b/apps/web/src/lib/overview/CycleAlert.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import type { CycleView } from '$lib/graph';
+import { render } from '$lib/test/render';
+import CycleAlert from './CycleAlert.svelte';
+
+const cycle = (index: number, members: string[]): CycleView => ({
+  index,
+  members,
+  path: [...members, members[0]!],
+});
+
+const cycles = [
+  cycle(1, ['src/a.ts', 'src/b.ts']),
+  cycle(2, ['src/c.ts', 'src/d.ts']),
+  cycle(3, ['src/e.ts', 'src/f.ts']),
+  cycle(4, ['src/g.ts', 'src/h.ts']),
+];
+
+/** The rendered text on one line — the markup wraps where a sentence does not. */
+const flat = (container: HTMLElement) =>
+  container.textContent?.replace(/\s+/g, ' ') ?? '';
+
+let ui: ReturnType<typeof render>;
+
+afterEach(() => ui?.destroy());
+
+describe('CycleAlert', () => {
+  it('prints the knot as a path of file names', () => {
+    ui = render(CycleAlert, { cycles: [cycles[0]!] });
+
+    expect(ui.container.textContent).toContain('a.ts → b.ts → a.ts');
+    expect(ui.container.textContent).toContain('2 files');
+    // The full paths stay reachable without widening the card.
+    expect(ui.container.querySelector('li')!.title).toBe(
+      'src/a.ts → src/b.ts → src/a.ts',
+    );
+  });
+
+  it('says how many there are in words, not only in red', () => {
+    ui = render(CycleAlert, { cycles });
+
+    expect(flat(ui.container)).toContain('4 import cycles');
+  });
+
+  it('shows the biggest few and sends the rest to the graph', () => {
+    ui = render(CycleAlert, { cycles });
+
+    expect(ui.container.querySelectorAll('li')).toHaveLength(3);
+    expect(ui.container.querySelector('a')?.textContent).toContain(
+      'All 4 on the dependency graph',
+    );
+    expect(ui.container.querySelector('a')?.getAttribute('href')).toBe('/graph');
+  });
+
+  it('says so when the graph is acyclic', () => {
+    ui = render(CycleAlert, { cycles: [] });
+
+    expect(ui.container.textContent).toContain('No import cycles');
+    expect(ui.container.querySelector('a')).toBeNull();
+  });
+});

--- a/apps/web/src/lib/overview/HotspotBars.svelte
+++ b/apps/web/src/lib/overview/HotspotBars.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  import { compactNumber, dirName, fileName } from '$lib/format';
+  import { heatColor, heatLevel, type HeatScale } from '$lib/hotspots';
+  import type { HotspotBar } from './bars';
+
+  interface Props {
+    bars: HotspotBar[];
+    /** The ramp fitted on the whole ranking, as the treemap fits it. */
+    scale: HeatScale;
+  }
+
+  let { bars, scale }: Props = $props();
+
+  const width = (share: number) => `${(share * 100).toFixed(1)}%`;
+</script>
+
+{#if bars.length === 0}
+  <p class="text-muted text-sm">
+    No hotspot scores in this report — nothing changed inside the analysed
+    history window.
+  </p>
+{:else}
+  <ul class="flex flex-col gap-3">
+    {#each bars as bar (bar.path)}
+      <li>
+        <div class="flex items-baseline justify-between gap-3">
+          <span class="truncate font-mono text-xs" title={bar.path}>
+            <span class="text-subtle">{dirName(bar.path)}</span><span
+              class="text-ink">{fileName(bar.path)}</span
+            >
+          </span>
+          <span class="text-muted shrink-0 font-mono text-xs">
+            {compactNumber(bar.score)}
+          </span>
+        </div>
+        <!-- The number is printed beside it, so the bar is the comparison and
+             nothing is said in colour alone. -->
+        <div
+          class="bg-elevated mt-1 h-1.5 overflow-hidden rounded-full"
+          aria-hidden="true"
+        >
+          <div
+            class="h-full rounded-full"
+            style="width: {width(bar.share)}; background: {heatColor(
+              heatLevel(scale, bar.complexity),
+            )};"
+          ></div>
+        </div>
+      </li>
+    {/each}
+  </ul>
+{/if}

--- a/apps/web/src/lib/overview/HotspotBars.test.ts
+++ b/apps/web/src/lib/overview/HotspotBars.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { heatScale } from '$lib/hotspots';
+import { render } from '$lib/test/render';
+import type { HotspotBar } from './bars';
+import HotspotBars from './HotspotBars.svelte';
+
+const bars: HotspotBar[] = [
+  { path: 'src/lib/big.ts', score: 1900, complexity: 100, share: 1 },
+  { path: 'src/mid.ts', score: 475, complexity: 30, share: 0.25 },
+];
+
+const scale = heatScale([100, 30]);
+
+let ui: ReturnType<typeof render>;
+
+afterEach(() => ui?.destroy());
+
+describe('HotspotBars', () => {
+  it('prints the file apart from its directory, with the score beside it', () => {
+    ui = render(HotspotBars, { bars, scale });
+
+    expect(ui.container.textContent).toContain('src/lib/');
+    expect(ui.container.textContent).toContain('big.ts');
+    expect(ui.container.textContent).toContain('1.9k');
+    expect(ui.container.querySelector('[title]')?.getAttribute('title')).toBe(
+      'src/lib/big.ts',
+    );
+  });
+
+  it('sizes each bar by its share of the top file', () => {
+    ui = render(HotspotBars, { bars, scale });
+
+    const widths = [...ui.container.querySelectorAll('li div[style]')].map(
+      (fill) => (fill as HTMLElement).style.width,
+    );
+    expect(widths).toEqual(['100.0%', '25.0%']);
+  });
+
+  it('says so when nothing scored', () => {
+    ui = render(HotspotBars, { bars: [], scale });
+
+    expect(ui.container.textContent).toContain('No hotspot scores');
+    expect(ui.container.querySelectorAll('li')).toHaveLength(0);
+  });
+});

--- a/apps/web/src/lib/overview/PluginList.svelte
+++ b/apps/web/src/lib/overview/PluginList.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+  import type { LoadedPluginInfo } from '$lib/api';
+
+  interface Props {
+    plugins: LoadedPluginInfo[];
+    /** Plugins that were found but could not be loaded. */
+    failures?: number;
+    /** True while the first response is still on the way. */
+    loading?: boolean;
+    /** Why the list is empty, when the server said so. */
+    error?: string;
+  }
+
+  let {
+    plugins,
+    failures = 0,
+    loading = false,
+    error = '',
+  }: Props = $props();
+</script>
+
+{#if error}
+  <p class="text-warn text-sm">{error}</p>
+{:else if loading && plugins.length === 0}
+  <p class="text-muted text-sm">Loading plugins…</p>
+{:else if plugins.length === 0}
+  <p class="text-muted text-sm">
+    No plugins loaded — an analysis over this workbench would find nothing.
+  </p>
+{:else}
+  <ul class="divide-line flex flex-col divide-y">
+    {#each plugins as plugin (plugin.id)}
+      <li class="flex items-baseline justify-between gap-3 py-2 first:pt-0">
+        <span class="min-w-0">
+          <span class="block truncate text-sm">{plugin.name}</span>
+          <span
+            class="text-subtle block truncate font-mono text-xs"
+            title={plugin.id}
+          >
+            {plugin.id}
+          </span>
+        </span>
+        <span class="flex shrink-0 items-baseline gap-2">
+          {#if plugin.source === 'user'}
+            <span class="text-accent text-xs">user</span>
+          {/if}
+          <span
+            class="border-line bg-elevated text-muted rounded-md border px-1.5 py-0.5 text-xs"
+          >
+            {plugin.kind}
+          </span>
+          <span class="text-subtle font-mono text-xs">v{plugin.version}</span>
+        </span>
+      </li>
+    {/each}
+  </ul>
+{/if}
+
+{#if failures > 0}
+  <p class="text-warn mt-3 text-xs">
+    {failures}
+    {failures === 1 ? 'plugin was' : 'plugins were'} found but could not be loaded.
+  </p>
+{/if}

--- a/apps/web/src/lib/overview/PluginList.test.ts
+++ b/apps/web/src/lib/overview/PluginList.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import type { LoadedPluginInfo } from '$lib/api';
+import { render } from '$lib/test/render';
+import PluginList from './PluginList.svelte';
+
+const plugins: LoadedPluginInfo[] = [
+  {
+    id: 'strata-language-typescript',
+    name: 'TypeScript',
+    kind: 'language',
+    version: '0.4.0',
+    sdk: '0',
+    main: 'dist/index.js',
+    source: 'builtin',
+  },
+  {
+    id: 'acme-metric-coupling',
+    name: 'Change coupling',
+    kind: 'git-metric',
+    version: '1.2.0',
+    sdk: '0',
+    main: 'dist/index.js',
+    source: 'user',
+  },
+];
+
+/** The rendered text on one line — the markup wraps where a sentence does not. */
+const flat = (node: Element | null) =>
+  node?.textContent?.replace(/\s+/g, ' ') ?? '';
+
+let ui: ReturnType<typeof render>;
+
+afterEach(() => ui?.destroy());
+
+describe('PluginList', () => {
+  it('lists what loaded, with its kind and version', () => {
+    ui = render(PluginList, { plugins });
+
+    expect(ui.container.querySelectorAll('li')).toHaveLength(2);
+    expect(ui.container.textContent).toContain('TypeScript');
+    expect(ui.container.textContent).toContain('strata-language-typescript');
+    expect(ui.container.textContent).toContain('language');
+    expect(ui.container.textContent).toContain('v0.4.0');
+  });
+
+  it('marks the ones that came from outside the image', () => {
+    ui = render(PluginList, { plugins });
+
+    expect(ui.container.textContent).toContain('user');
+  });
+
+  it('reports plugins that were found but could not be loaded', () => {
+    ui = render(PluginList, { plugins, failures: 2 });
+
+    expect(flat(ui.container.querySelector('.text-warn'))).toContain(
+      '2 plugins were found but could not be loaded',
+    );
+  });
+
+  it('waits rather than claiming an empty workbench', () => {
+    ui = render(PluginList, { plugins: [], loading: true });
+
+    expect(ui.container.textContent).toContain('Loading plugins…');
+  });
+
+  it('says an empty workbench is empty once the answer is in', () => {
+    ui = render(PluginList, { plugins: [] });
+
+    expect(ui.container.textContent).toContain('No plugins loaded');
+  });
+
+  it('surfaces a server that would not answer', () => {
+    ui = render(PluginList, { plugins: [], error: 'Server unreachable' });
+
+    expect(ui.container.textContent).toContain('Server unreachable');
+  });
+});

--- a/apps/web/src/lib/overview/StatCard.svelte
+++ b/apps/web/src/lib/overview/StatCard.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import type { StatCard, StatTone } from './stats';
+
+  interface Props {
+    card: StatCard;
+  }
+
+  let { card }: Props = $props();
+
+  const INK: Record<StatTone, string> = {
+    plain: 'text-ink',
+    warn: 'text-warn',
+    danger: 'text-danger',
+  };
+
+  const SHELL =
+    'bg-surface border-line shadow-card block min-w-0 rounded-xl border p-4';
+</script>
+
+{#snippet body()}
+  <p class="text-subtle text-xs">{card.label}</p>
+  <p
+    class="mt-1 truncate font-mono text-2xl {INK[card.tone]}"
+    title={card.title ?? card.value}
+  >
+    {card.value}
+  </p>
+  <p class="text-muted mt-0.5 truncate text-xs">{card.hint}</p>
+{/snippet}
+
+<!-- A card links to the screen that shows its number in full, where that
+     screen exists; the rest are plain, because an inert link is worse than
+     none (see the rail's planned entries). -->
+{#if card.href}
+  <a class="{SHELL} hover:border-line-strong" href={card.href}>
+    {@render body()}
+  </a>
+{:else}
+  <div class={SHELL}>
+    {@render body()}
+  </div>
+{/if}

--- a/apps/web/src/lib/overview/StatGrid.svelte
+++ b/apps/web/src/lib/overview/StatGrid.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import StatCardView from './StatCard.svelte';
+  import type { StatCard } from './stats';
+
+  interface Props {
+    cards: StatCard[];
+  }
+
+  let { cards }: Props = $props();
+</script>
+
+<!-- Six across on a wide screen, folding to three and then two: the row is a
+     row, and a card that has to wrap is still a card rather than a table. -->
+<div class="grid grid-cols-2 gap-4 lg:grid-cols-3 xl:grid-cols-6">
+  {#each cards as card (card.key)}
+    <StatCardView {card} />
+  {/each}
+</div>

--- a/apps/web/src/lib/overview/StatGrid.test.ts
+++ b/apps/web/src/lib/overview/StatGrid.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { render } from '$lib/test/render';
+import StatGrid from './StatGrid.svelte';
+import type { StatCard } from './stats';
+
+const cards: StatCard[] = [
+  { key: 'files', label: 'Files', value: '1.2k', hint: 'typescript', tone: 'plain' },
+  {
+    key: 'hotspot',
+    label: 'Top hotspot',
+    value: 'big.ts',
+    hint: 'score 1.9k',
+    tone: 'plain',
+    title: 'src/big.ts',
+    href: '/hotspots',
+  },
+  {
+    key: 'cycles',
+    label: 'Import cycles',
+    value: '2',
+    hint: '5 files',
+    tone: 'danger',
+    href: '/graph',
+  },
+];
+
+let ui: ReturnType<typeof render>;
+
+afterEach(() => ui?.destroy());
+
+describe('StatGrid', () => {
+  it('prints a label, a value and a hint per card', () => {
+    ui = render(StatGrid, { cards });
+
+    expect(ui.container.textContent).toContain('Files');
+    expect(ui.container.textContent).toContain('1.2k');
+    expect(ui.container.textContent).toContain('typescript');
+  });
+
+  it('links the cards whose screen is built, and only those', () => {
+    ui = render(StatGrid, { cards });
+
+    const links = [...ui.container.querySelectorAll('a')];
+    expect(links.map((link) => link.getAttribute('href'))).toEqual([
+      '/hotspots',
+      '/graph',
+    ]);
+  });
+
+  it('keeps the full text of a truncated value in the tooltip', () => {
+    ui = render(StatGrid, { cards });
+
+    const values = [...ui.container.querySelectorAll('[title]')];
+    expect(values.map((value) => value.getAttribute('title'))).toContain(
+      'src/big.ts',
+    );
+  });
+
+  it('says a bad number in words as well as in colour', () => {
+    ui = render(StatGrid, { cards });
+
+    // The tone paints the value; the label beside it is what names the number.
+    expect(ui.container.querySelector('.text-danger')?.textContent).toContain(
+      '2',
+    );
+    expect(ui.container.textContent).toContain('Import cycles');
+  });
+});

--- a/apps/web/src/lib/overview/bars.test.ts
+++ b/apps/web/src/lib/overview/bars.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import type { HotspotRow } from '$lib/hotspots';
+import { hotspotBars } from './bars';
+
+const row = (path: string, score: number): HotspotRow => ({
+  path,
+  score,
+  churn: 1,
+  complexity: score,
+  loc: null,
+});
+
+describe('hotspotBars', () => {
+  it('measures every bar against the top-ranked file', () => {
+    const bars = hotspotBars([row('a.ts', 400), row('b.ts', 100)]);
+
+    expect(bars.map((bar) => bar.share)).toEqual([1, 0.25]);
+  });
+
+  it('keeps the widths of the report when the list is cut short', () => {
+    const rows = [row('a.ts', 400), row('b.ts', 100), row('c.ts', 40)];
+
+    // Two rows of the same three: the head keeps the width it had, so a short
+    // list does not promote the runner-up to a full bar.
+    expect(hotspotBars(rows, 2).map((bar) => bar.share)).toEqual([1, 0.25]);
+  });
+
+  it('carries the complexity the ramp colours by', () => {
+    expect(hotspotBars([row('a.ts', 400)])[0]).toMatchObject({
+      path: 'a.ts',
+      score: 400,
+      complexity: 400,
+    });
+  });
+
+  it('has no widths at all when nothing scored', () => {
+    expect(hotspotBars([])).toEqual([]);
+    expect(hotspotBars([row('a.ts', 0)])[0]!.share).toBe(0);
+  });
+});

--- a/apps/web/src/lib/overview/bars.ts
+++ b/apps/web/src/lib/overview/bars.ts
@@ -1,0 +1,38 @@
+import type { HotspotRow } from '$lib/hotspots';
+
+/** One row of the overview's hotspot list: a name, a number and a bar. */
+export interface HotspotBar {
+  path: string;
+  score: number;
+  /** What the bar is coloured by, on the same ramp the treemap uses. */
+  complexity: number;
+  /** 0–1 against the top-ranked file, which is the bar's width. */
+  share: number;
+}
+
+/** How many files the overview lists before the ranking becomes the treemap's job. */
+export const BAR_LIMIT = 8;
+
+/**
+ * The head of the hotspot ranking, with each score as a share of the top one.
+ *
+ * Widths are relative to the highest score in the *report*, not to the highest
+ * one shown, so the list says the same thing whether it prints eight rows or
+ * three: a full bar is the worst file in the repository.
+ *
+ * Expects the ranking `hotspotRows` produces — it takes the head of the list
+ * as given rather than sorting again.
+ */
+export function hotspotBars(
+  rows: readonly HotspotRow[],
+  limit: number = BAR_LIMIT,
+): HotspotBar[] {
+  const top = rows.reduce((max, row) => Math.max(max, row.score), 0);
+
+  return rows.slice(0, limit).map((row) => ({
+    path: row.path,
+    score: row.score,
+    complexity: row.complexity,
+    share: top > 0 ? row.score / top : 0,
+  }));
+}

--- a/apps/web/src/lib/overview/commits.test.ts
+++ b/apps/web/src/lib/overview/commits.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import type { ParsedCommit } from '@strata/sdk';
+import { commitTotals, commitTypes } from './commits';
+
+const commit = (
+  type: string | null,
+  extra: Partial<ParsedCommit> = {},
+): ParsedCommit => ({
+  type,
+  scope: null,
+  breaking: false,
+  subject: 'a change',
+  tags: {},
+  valid: type !== null,
+  ...extra,
+});
+
+const history = [
+  commit('feat'),
+  commit('feat'),
+  commit('fix', { breaking: true }),
+  commit('feat'),
+  commit(null, { valid: false }),
+];
+
+describe('commitTypes', () => {
+  it('groups the window by type, biggest first', () => {
+    expect(commitTypes(history)).toEqual([
+      { type: 'feat', count: 3, share: 0.6, breaking: 0 },
+      { type: 'fix', count: 1, share: 0.2, breaking: 1 },
+      { type: 'other', count: 1, share: 0.2, breaking: 0 },
+    ]);
+  });
+
+  it('orders ties by name so two runs print the same list', () => {
+    const tied = [commit('test'), commit('chore'), commit('docs')];
+
+    expect(commitTypes(tied).map((row) => row.type)).toEqual([
+      'chore',
+      'docs',
+      'test',
+    ]);
+  });
+
+  it('files a commit the convention did not recognise rather than dropping it', () => {
+    expect(commitTypes([commit(null, { valid: false })])).toEqual([
+      { type: 'other', count: 1, share: 1, breaking: 0 },
+    ]);
+  });
+
+  it('is empty for a report with no history', () => {
+    expect(commitTypes([])).toEqual([]);
+  });
+});
+
+describe('commitTotals', () => {
+  it('counts the window, what parsed, and what breaks', () => {
+    expect(commitTotals(history)).toEqual({
+      total: 5,
+      valid: 4,
+      breaking: 1,
+    });
+  });
+
+  it('is zeroes for a report with no history', () => {
+    expect(commitTotals([])).toEqual({ total: 0, valid: 0, breaking: 0 });
+  });
+});

--- a/apps/web/src/lib/overview/commits.ts
+++ b/apps/web/src/lib/overview/commits.ts
@@ -1,0 +1,65 @@
+import type { ParsedCommit } from '@strata/sdk';
+
+/** What a commit with no recognised type is filed under. */
+export const OTHER_TYPE = 'other';
+
+/** One change type in the analysed history window. */
+export interface CommitTypeRow {
+  /** The convention's type — `feat`, `fix`, … — or `other`. */
+  type: string;
+  count: number;
+  /** 0–1 of every commit in the window. */
+  share: number;
+  /** How many of them announced a breaking change. */
+  breaking: number;
+}
+
+/** The commit stat card's three numbers. */
+export interface CommitTotals {
+  total: number;
+  /** Commits the convention plugin could parse at all. */
+  valid: number;
+  breaking: number;
+}
+
+/**
+ * The history window, grouped by change type.
+ *
+ * Biggest first, ties by name, so two runs of the same analysis print the same
+ * order. A commit the convention did not recognise has no type by contract, so
+ * it lands in `other` rather than being dropped — a repository where half the
+ * history is unconventional should say so.
+ */
+export function commitTypes(commits: readonly ParsedCommit[]): CommitTypeRow[] {
+  const counts = new Map<string, { count: number; breaking: number }>();
+
+  for (const commit of commits) {
+    const type = commit.type ?? OTHER_TYPE;
+    const entry = counts.get(type) ?? { count: 0, breaking: 0 };
+    entry.count += 1;
+    if (commit.breaking) entry.breaking += 1;
+    counts.set(type, entry);
+  }
+
+  return [...counts]
+    .map(([type, entry]) => ({
+      type,
+      count: entry.count,
+      share: commits.length > 0 ? entry.count / commits.length : 0,
+      breaking: entry.breaking,
+    }))
+    .sort((a, b) => b.count - a.count || a.type.localeCompare(b.type));
+}
+
+/** The same window, folded to what one stat card prints. */
+export function commitTotals(commits: readonly ParsedCommit[]): CommitTotals {
+  let valid = 0;
+  let breaking = 0;
+
+  for (const commit of commits) {
+    if (commit.valid) valid += 1;
+    if (commit.breaking) breaking += 1;
+  }
+
+  return { total: commits.length, valid, breaking };
+}

--- a/apps/web/src/lib/overview/dead-code.test.ts
+++ b/apps/web/src/lib/overview/dead-code.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import type { AnalysisReport } from '$lib/api';
+import { deadCodeCount } from './dead-code';
+
+const report = (
+  deadCode: Record<string, { path: string; reason: string }[]>,
+): AnalysisReport =>
+  ({
+    languages: Object.fromEntries(
+      Object.entries(deadCode).map(([name, findings]) => [
+        name,
+        { graph: { nodes: [], edges: [], cycles: [] }, deadCode: findings },
+      ]),
+    ),
+  }) as unknown as AnalysisReport;
+
+describe('deadCodeCount', () => {
+  it('counts every language', () => {
+    expect(
+      deadCodeCount(
+        report({
+          typescript: [
+            { path: 'src/a.ts', reason: 'unreferenced-export' },
+            { path: 'src/b.ts', reason: 'unreachable-file' },
+          ],
+          python: [{ path: 'lib/c.py', reason: 'unreferenced-export' }],
+        }),
+      ),
+    ).toEqual({ findings: 3, files: 3 });
+  });
+
+  it('counts a file once however many symbols it is holding', () => {
+    expect(
+      deadCodeCount(
+        report({
+          typescript: [
+            { path: 'src/barrel.ts', reason: 'unreferenced-export' },
+            { path: 'src/barrel.ts', reason: 'unreferenced-export' },
+            { path: 'src/barrel.ts', reason: 'unreferenced-export' },
+          ],
+        }),
+      ),
+    ).toEqual({ findings: 3, files: 1 });
+  });
+
+  it('is zero for a report with no language results', () => {
+    expect(deadCodeCount(report({}))).toEqual({ findings: 0, files: 0 });
+  });
+});

--- a/apps/web/src/lib/overview/dead-code.ts
+++ b/apps/web/src/lib/overview/dead-code.ts
@@ -1,0 +1,29 @@
+import type { AnalysisReport } from '$lib/api';
+
+/** What the dead-code stat card prints: how much, and over how many files. */
+export interface DeadCodeCount {
+  findings: number;
+  /** Distinct files at least one finding names. */
+  files: number;
+}
+
+/**
+ * Every language's dead-code findings, counted.
+ *
+ * A finding is per *symbol*, so a barrel exporting twenty unused names is
+ * twenty findings in one file — the card prints both numbers rather than
+ * letting one file read as twenty problems.
+ */
+export function deadCodeCount(report: AnalysisReport): DeadCodeCount {
+  const files = new Set<string>();
+  let findings = 0;
+
+  for (const language of Object.values(report.languages)) {
+    for (const finding of language.deadCode) {
+      findings += 1;
+      files.add(finding.path);
+    }
+  }
+
+  return { findings, files: files.size };
+}

--- a/apps/web/src/lib/overview/index.ts
+++ b/apps/web/src/lib/overview/index.ts
@@ -1,0 +1,15 @@
+export { hotspotBars, BAR_LIMIT, type HotspotBar } from './bars';
+export {
+  commitTotals,
+  commitTypes,
+  OTHER_TYPE,
+  type CommitTotals,
+  type CommitTypeRow,
+} from './commits';
+export { deadCodeCount, type DeadCodeCount } from './dead-code';
+export {
+  overviewStats,
+  type PluginTally,
+  type StatCard,
+  type StatTone,
+} from './stats';

--- a/apps/web/src/lib/overview/stats.test.ts
+++ b/apps/web/src/lib/overview/stats.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+import type { AnalysisReport } from '$lib/api';
+import { overviewStats, type StatCard } from './stats';
+
+const report = {
+  rev: '4fea7c5deadbeef',
+  run: {
+    branch: 'main',
+    files: 1240,
+    durationMs: 2440,
+    finishedAt: '2026-08-15T11:55:00.000Z',
+  },
+  languages: {
+    typescript: {
+      graph: { nodes: [], edges: [], cycles: [] },
+      deadCode: [
+        { path: 'src/barrel.ts', reason: 'unreferenced-export' },
+        { path: 'src/old.ts', reason: 'unreachable-file' },
+      ],
+      metrics: [{ path: 'src/big.ts', loc: 940 }],
+      summary: {
+        nodes: 120,
+        edges: 300,
+        cycles: 2,
+        cycleNodes: 5,
+        maxFanIn: null,
+        maxFanOut: null,
+      },
+    },
+  },
+  metrics: [
+    {
+      id: 'hotspots',
+      label: 'Hotspots (churn × complexity)',
+      points: [
+        { subject: 'src/big.ts', value: 1900, meta: { churn: 19, complexity: 100 } },
+        { subject: 'src/mid.ts', value: 300, meta: { churn: 10, complexity: 30 } },
+      ],
+    },
+  ],
+  commits: [
+    { type: 'feat', scope: null, breaking: false, subject: 'a', tags: {}, valid: true },
+    { type: 'fix', scope: null, breaking: true, subject: 'b', tags: {}, valid: true },
+  ],
+  cache: {
+    enabled: false,
+    hits: 0,
+    misses: 0,
+    runHits: 0,
+    runMisses: 0,
+    writes: 0,
+  },
+} as unknown as AnalysisReport;
+
+const cardsOf = (over: AnalysisReport = report, loaded: number | null = 4) =>
+  new Map<string, StatCard>(
+    overviewStats(over, { loaded, failures: 0 }).map((card) => [
+      card.key,
+      card,
+    ]),
+  );
+
+describe('overviewStats', () => {
+  it('is the six cards, in the order the row prints them', () => {
+    expect(overviewStats(report, { loaded: 4, failures: 0 }).map((c) => c.key))
+      .toEqual([
+        'files',
+        'hotspot',
+        'cycles',
+        'commits',
+        'dead-code',
+        'plugins',
+      ]);
+  });
+
+  it('prints the run, the top hotspot and the cycle count', () => {
+    const cards = cardsOf();
+
+    expect(cards.get('files')).toMatchObject({
+      value: '1.2k',
+      hint: 'typescript',
+    });
+    // The name is what fits on a card; the path stays in the tooltip.
+    expect(cards.get('hotspot')).toMatchObject({
+      value: 'big.ts',
+      hint: 'score 1.9k',
+      title: 'src/big.ts',
+      href: '/hotspots',
+    });
+    expect(cards.get('cycles')).toMatchObject({
+      value: '2',
+      hint: '5 files',
+      tone: 'danger',
+      href: '/graph',
+    });
+  });
+
+  it('leads the commit card with what breaks and the dead-code card with files', () => {
+    const cards = cardsOf();
+
+    expect(cards.get('commits')).toMatchObject({
+      value: '2',
+      hint: '1 breaking',
+      tone: 'warn',
+    });
+    expect(cards.get('dead-code')).toMatchObject({
+      value: '2',
+      hint: '2 files',
+      tone: 'warn',
+    });
+  });
+
+  it('counts conventional commits when nothing breaks', () => {
+    const calm = {
+      ...report,
+      commits: report.commits.map((commit) => ({ ...commit, breaking: false })),
+    } as AnalysisReport;
+
+    expect(cardsOf(calm).get('commits')).toMatchObject({
+      hint: '2 conventional',
+      tone: 'plain',
+    });
+  });
+
+  it('reads a clean report as none rather than as nothing', () => {
+    const clean = {
+      ...report,
+      languages: {},
+      metrics: [],
+      commits: [],
+    } as unknown as AnalysisReport;
+    const cards = cardsOf(clean);
+
+    expect(cards.get('files')!.hint).toBe('no language analysed');
+    expect(cards.get('hotspot')).toMatchObject({ value: '—', hint: 'no scores' });
+    expect(cards.get('cycles')).toMatchObject({
+      value: '0',
+      hint: 'none',
+      tone: 'plain',
+    });
+    expect(cards.get('dead-code')).toMatchObject({ hint: 'none', tone: 'plain' });
+  });
+
+  it('names every language when more than one ran', () => {
+    const polyglot = {
+      ...report,
+      languages: { ...report.languages, python: report.languages.typescript },
+    } as AnalysisReport;
+
+    expect(cardsOf(polyglot).get('files')!.hint).toBe('2 languages');
+  });
+
+  it('waits for the plugin response rather than printing a zero', () => {
+    expect(cardsOf(report, null).get('plugins')).toMatchObject({
+      value: '—',
+      hint: 'loading…',
+    });
+  });
+
+  it('warns about plugins that were found but not loaded', () => {
+    const [card] = overviewStats(report, { loaded: 4, failures: 1 }).filter(
+      (entry) => entry.key === 'plugins',
+    );
+
+    expect(card).toMatchObject({ value: '4', hint: '1 skipped', tone: 'warn' });
+  });
+
+  it('stays printable when a report carries no run summary', () => {
+    const bare = { ...report, run: undefined } as unknown as AnalysisReport;
+
+    expect(cardsOf(bare).get('files')!.value).toBe('0');
+  });
+});

--- a/apps/web/src/lib/overview/stats.ts
+++ b/apps/web/src/lib/overview/stats.ts
@@ -1,0 +1,120 @@
+import type { AnalysisReport } from '$lib/api';
+import { compactNumber, fileName } from '$lib/format';
+import { reportSummary } from '$lib/graph';
+import { hotspotRows } from '$lib/hotspots';
+import { commitTotals } from './commits';
+import { deadCodeCount } from './dead-code';
+
+/** How a card's number reads: plainly, as something to watch, as a problem. */
+export type StatTone = 'plain' | 'warn' | 'danger';
+
+/** One of the six cards across the top of the overview. */
+export interface StatCard {
+  /** Stable identity: what `each` keys on and what a test looks a card up by. */
+  key: string;
+  label: string;
+  /** Already formatted — a card prints strings, it never does arithmetic. */
+  value: string;
+  hint: string;
+  tone: StatTone;
+  /** The full text behind a truncated value, when there is more of it. */
+  title?: string;
+  /** The screen that shows this number in full, where one is built. */
+  href?: string;
+}
+
+/** What the plugin store knows, as the last card reads it. */
+export interface PluginTally {
+  /** How many loaded; `null` until the response arrives. */
+  loaded: number | null;
+  failures: number;
+}
+
+/**
+ * The report, folded into the six numbers the overview leads with.
+ *
+ * One function rather than six, because the cards are one row: they are
+ * ordered, they share a shape, and a screen that prints them should not have
+ * to know which part of the report each one came from.
+ *
+ * Plugins are the exception the signature makes explicit — how many loaded is
+ * a fact about the workbench, not about the analysed repository, so it arrives
+ * as an argument instead of being dug out of the report.
+ */
+export function overviewStats(
+  report: AnalysisReport,
+  plugins: PluginTally,
+): StatCard[] {
+  // Every report the server sends carries a run summary; the fallback keeps the
+  // card printable rather than blank if one ever arrives without.
+  const run = report.run as AnalysisReport['run'] | undefined;
+  const graph = reportSummary(report);
+  const top = hotspotRows(report)[0];
+  const commits = commitTotals(report.commits);
+  const dead = deadCodeCount(report);
+
+  return [
+    {
+      key: 'files',
+      label: 'Files',
+      value: compactNumber(run?.files ?? 0),
+      hint: languageHint(report),
+      tone: 'plain',
+    },
+    {
+      key: 'hotspot',
+      label: 'Top hotspot',
+      value: top ? fileName(top.path) : '—',
+      hint: top ? `score ${compactNumber(top.score)}` : 'no scores',
+      tone: 'plain',
+      title: top?.path,
+      href: '/hotspots',
+    },
+    {
+      key: 'cycles',
+      label: 'Import cycles',
+      value: compactNumber(graph.cycles),
+      hint: graph.cycles > 0 ? `${graph.cycleNodes} files` : 'none',
+      tone: graph.cycles > 0 ? 'danger' : 'plain',
+      href: '/graph',
+    },
+    {
+      key: 'commits',
+      label: 'Commits',
+      value: compactNumber(commits.total),
+      hint:
+        commits.breaking > 0
+          ? `${commits.breaking} breaking`
+          : `${commits.valid} conventional`,
+      tone: commits.breaking > 0 ? 'warn' : 'plain',
+    },
+    {
+      key: 'dead-code',
+      label: 'Dead code',
+      value: compactNumber(dead.findings),
+      hint: dead.findings > 0 ? `${dead.files} files` : 'none',
+      tone: dead.findings > 0 ? 'warn' : 'plain',
+    },
+    {
+      key: 'plugins',
+      label: 'Plugins',
+      value: plugins.loaded === null ? '—' : compactNumber(plugins.loaded),
+      hint: pluginHint(plugins),
+      tone: plugins.failures > 0 ? 'warn' : 'plain',
+    },
+  ];
+}
+
+/** Which languages the run had a plugin for — the file count's context. */
+function languageHint(report: AnalysisReport): string {
+  const names = Object.keys(report.languages);
+  if (names.length === 0) return 'no language analysed';
+  if (names.length === 1) return names[0]!;
+  return `${names.length} languages`;
+}
+
+function pluginHint(plugins: PluginTally): string {
+  if (plugins.loaded === null) return 'loading…';
+  if (plugins.failures > 0) return `${plugins.failures} skipped`;
+  return 'all loaded';
+}

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -1,37 +1,123 @@
 <script lang="ts">
+  import { analysis } from '$lib/analysis';
   import Card from '$lib/components/Card.svelte';
-  import ServerStatus from '$lib/components/ServerStatus.svelte';
-  import TokenPalette from '$lib/components/TokenPalette.svelte';
-  import { theme } from '$lib/theme';
+  import { cycleViews, mergedGraph } from '$lib/graph';
+  import { heatScale, hotspotRows } from '$lib/hotspots';
+  import { plugins } from '$lib/plugins';
+  import { commitTypes, hotspotBars, overviewStats } from '$lib/overview';
+  import CommitTypes from '$lib/overview/CommitTypes.svelte';
+  import CycleAlert from '$lib/overview/CycleAlert.svelte';
+  import HotspotBars from '$lib/overview/HotspotBars.svelte';
+  import PluginList from '$lib/overview/PluginList.svelte';
+  import StatGrid from '$lib/overview/StatGrid.svelte';
+
+  // Load-once, and the rail has already asked: this is here so the screen
+  // stands on its own — mounted without the frame, it still knows its plugins.
+  $effect(() => {
+    plugins.load();
+  });
+
+  let report = $derived(analysis.report);
+
+  let rows = $derived(report ? hotspotRows(report) : []);
+  // The ramp is fitted to the whole ranking, as the treemap fits it, so a bar
+  // here and a tile there are the same colour for the same file.
+  let scale = $derived(heatScale(rows.map((row) => row.complexity)));
+  let bars = $derived(hotspotBars(rows));
+
+  let cycles = $derived(report ? cycleViews(mergedGraph(report)) : []);
+  let types = $derived(report ? commitTypes(report.commits) : []);
+  let stats = $derived(
+    report
+      ? overviewStats(report, {
+          loaded: plugins.count,
+          failures: plugins.failures,
+        })
+      : [],
+  );
+
+  let loaded = $derived(plugins.response?.plugins ?? []);
 </script>
 
 <svelte:head>
   <title>Overview · Strata</title>
 </svelte:head>
 
-<header class="mb-8">
-  <h1 class="text-2xl font-semibold">Overview</h1>
-  <p class="text-muted mt-1 text-sm">
-    The shell is in place — rail, header and a scrolling pane. The overview's
-    stat cards, the commit analytics and the dead-code table land next; until
-    then, the workbench's own state.
-  </p>
-  <p class="mt-3 flex flex-wrap gap-4 text-sm">
-    <a class="text-accent underline-offset-4 hover:underline" href="/hotspots">
-      Hotspots →
-    </a>
-    <a class="text-accent underline-offset-4 hover:underline" href="/graph">
-      Dependencies →
-    </a>
-  </p>
-</header>
-
-<div class="grid gap-6 md:grid-cols-2">
-  <Card title="Design tokens" hint={theme.resolved}>
-    <TokenPalette />
+<!-- What the workbench loaded is true with or without a report, so the card is
+     written once and stands in both states of the screen. -->
+{#snippet pluginCard()}
+  <Card
+    title="Plugins"
+    hint={loaded.length > 0 ? `${loaded.length} loaded` : ''}
+  >
+    <!-- `count` is null until the response lands, which covers the tick before
+         the effect above has even asked — an empty list is not yet an answer. -->
+    <PluginList
+      plugins={loaded}
+      failures={plugins.failures}
+      loading={plugins.count === null}
+      error={plugins.error}
+    />
   </Card>
+{/snippet}
 
-  <Card title="Server" hint="/health · /plugins">
-    <ServerStatus />
-  </Card>
+<div>
+  <header class="mb-8">
+    <h1 class="text-2xl font-semibold">Overview</h1>
+    <p class="text-muted mt-1 max-w-3xl text-sm">
+      The last run at a glance: how big the repository is, where maintenance
+      cost concentrates, whether the imports knot, and what the workbench
+      brought to the analysis.
+    </p>
+  </header>
+
+  {#if analysis.status === 'error'}
+    <p class="text-danger mb-6 text-sm">{analysis.error}</p>
+  {/if}
+
+  {#if report}
+    <StatGrid cards={stats} />
+
+    <div class="mt-6 grid gap-6 lg:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
+      <div class="flex flex-col gap-6">
+        <Card title="Top hotspots" hint="churn × complexity">
+          <HotspotBars {bars} {scale} />
+        </Card>
+
+        <Card
+          title="Commit types"
+          hint="{report.commits.length} {report.commits.length === 1
+            ? 'commit'
+            : 'commits'}"
+        >
+          <CommitTypes {types} />
+        </Card>
+      </div>
+
+      <div class="flex flex-col gap-6">
+        <Card
+          title="Import cycles"
+          hint={cycles.length > 0 ? 'biggest first' : 'none'}
+        >
+          <CycleAlert {cycles} />
+        </Card>
+
+        {@render pluginCard()}
+      </div>
+    </div>
+  {:else}
+    {#if analysis.status === 'running'}
+      <p class="text-muted mb-6 text-sm">Running the pipeline…</p>
+    {:else}
+      <p class="text-muted mb-6 text-sm">
+        Pick a project in the switcher — or add one — and analyse it to see its
+        overview.
+      </p>
+    {/if}
+
+    <!-- The plugins are the one thing an empty overview can honestly show. -->
+    <div class="max-w-xl">
+      {@render pluginCard()}
+    </div>
+  {/if}
 </div>

--- a/apps/web/src/routes/page.test.ts
+++ b/apps/web/src/routes/page.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { tick } from 'svelte';
+import { analysis } from '$lib/analysis';
+import { stubApi } from '$lib/test/api';
+import { render } from '$lib/test/render';
+import Page from './+page.svelte';
+
+/**
+ * The screen end to end: a run against the API folded into the six stat cards,
+ * the hotspot bars, the cycle alert and the commit strip, with the workbench's
+ * own plugins beside them.
+ *
+ * The repository is chosen in the switcher, which the shell holds — so a test
+ * of this screen runs the analysis on the store first and then mounts the page
+ * against the report that run left behind.
+ *
+ * `/plugins` answers the same thing in every test on purpose: the plugin store
+ * is app-wide and loads once, so whichever test mounts first is the one that
+ * fetches it.
+ */
+
+const PLUGINS = {
+  directory: '/home/dev/.strata/plugins',
+  plugins: [
+    {
+      id: 'strata-language-typescript',
+      name: 'TypeScript',
+      kind: 'language',
+      version: '0.4.0',
+      sdk: '0',
+      main: 'dist/index.js',
+      source: 'builtin',
+    },
+  ],
+  failures: [],
+};
+
+const report = {
+  rev: '4fea7c5deadbeef',
+  run: {
+    branch: 'main',
+    files: 1240,
+    durationMs: 2440,
+    finishedAt: '2026-08-15T11:55:00.000Z',
+  },
+  languages: {
+    typescript: {
+      graph: {
+        nodes: [
+          { id: 'src/a.ts', label: 'a.ts', kind: 'file' },
+          { id: 'src/b.ts', label: 'b.ts', kind: 'file' },
+        ],
+        edges: [
+          { from: 'src/a.ts', to: 'src/b.ts', kind: 'import' },
+          { from: 'src/b.ts', to: 'src/a.ts', kind: 'import' },
+        ],
+        cycles: [['src/a.ts', 'src/b.ts']],
+      },
+      deadCode: [{ path: 'src/old.ts', reason: 'unreachable-file' }],
+      metrics: [{ path: 'src/big.ts', loc: 940 }],
+      summary: {
+        nodes: 2,
+        edges: 2,
+        cycles: 1,
+        cycleNodes: 2,
+        maxFanIn: null,
+        maxFanOut: null,
+      },
+    },
+  },
+  metrics: [
+    {
+      id: 'hotspots',
+      label: 'Hotspots (churn × complexity)',
+      points: [
+        {
+          subject: 'src/big.ts',
+          value: 1900,
+          meta: { churn: 19, complexity: 100 },
+        },
+        {
+          subject: 'src/mid.ts',
+          value: 475,
+          meta: { churn: 10, complexity: 30 },
+        },
+      ],
+    },
+  ],
+  commits: [
+    { type: 'feat', scope: null, breaking: false, subject: 'a', tags: {}, valid: true },
+    { type: 'fix', scope: null, breaking: true, subject: 'b', tags: {}, valid: true },
+  ],
+  cache: {
+    enabled: false,
+    hits: 0,
+    misses: 0,
+    runHits: 0,
+    runMisses: 0,
+    writes: 0,
+  },
+};
+
+/** Analyse a repository, as picking a project and running it would. */
+async function run(): Promise<void> {
+  stubApi({ '/plugins': PLUGINS, '/analyze': report });
+  await analysis.run('/repo/strata');
+}
+
+let ui: ReturnType<typeof render>;
+
+afterEach(() => {
+  ui?.destroy();
+  vi.unstubAllGlobals();
+  localStorage.clear();
+});
+
+describe('overview page', () => {
+  it('asks for a project before anything has run, and still shows the workbench', async () => {
+    stubApi({ '/plugins': PLUGINS });
+    analysis.select('');
+
+    ui = render(Page);
+
+    expect(ui.container.textContent).toContain('Pick a project');
+    await vi.waitFor(() => {
+      expect(ui.container.textContent).toContain('TypeScript');
+    });
+  });
+
+  it('leads with the six stat cards of the last run', async () => {
+    await run();
+
+    ui = render(Page);
+    await tick();
+
+    for (const label of [
+      'Files',
+      'Top hotspot',
+      'Import cycles',
+      'Commits',
+      'Dead code',
+      'Plugins',
+    ]) {
+      expect(ui.container.textContent).toContain(label);
+    }
+    expect(ui.container.textContent).toContain('1.2k');
+    expect(ui.container.textContent).toContain('big.ts');
+  });
+
+  it('ranks the hotspots, alerts on the cycle and strips the commits', async () => {
+    await run();
+
+    ui = render(Page);
+    await tick();
+
+    // The bar list, measured against the top-ranked file.
+    const widths = [...ui.container.querySelectorAll('li div[style]')].map(
+      (fill) => (fill as HTMLElement).style.width,
+    );
+    expect(widths.slice(0, 2)).toEqual(['100.0%', '25.0%']);
+
+    // The cycle, as the path a reader can act on.
+    expect(ui.container.textContent).toContain('a.ts → b.ts → a.ts');
+
+    // The change types of the analysed window.
+    expect(ui.container.textContent).toContain('feat');
+    expect(ui.container.textContent).toContain('1 breaking');
+  });
+
+  it('sends a stat card to the screen that shows it in full', async () => {
+    await run();
+
+    ui = render(Page);
+    await tick();
+
+    const hrefs = [...ui.container.querySelectorAll('a')].map((link) =>
+      link.getAttribute('href'),
+    );
+    expect(hrefs).toContain('/hotspots');
+    expect(hrefs).toContain('/graph');
+  });
+
+  it('surfaces a failed run', async () => {
+    stubApi({
+      '/plugins': PLUGINS,
+      '/analyze': Response.json({ message: 'not a repository' }, { status: 400 }),
+    });
+    await analysis.run('/nope');
+
+    ui = render(Page);
+
+    expect(ui.container.textContent).toContain('not a repository');
+  });
+});


### PR DESCRIPTION
## What

The root route becomes the real overview screen. Six stat cards lead — files,
top hotspot, import cycles, commits, dead code, plugins — over the top-hotspot
bar list, an import-cycle alert card carrying the cycle path, the loaded-plugins
list and the commit types of the analysed window.

New feature folder `apps/web/src/lib/overview/`, split the way the others are:

| Module | Fold |
|---|---|
| `stats.ts` | report + plugin tally → the six cards (value, hint, tone, link) |
| `bars.ts` | the head of the hotspot ranking, as shares of the top-scoring file |
| `commits.ts` | history → change types and the totals one card prints |
| `dead-code.ts` | findings across languages, and the files holding them |

plus `StatCard` / `StatGrid`, `HotspotBars`, `CycleAlert`, `PluginList` and
`CommitTypes`.

The hotspot and cycle cards link to the screens that show those numbers in full;
the rest are plain, because an inert link is worse than none. The plugin list
stands with or without a report — what the workbench loaded is true either way,
and it is the one thing an empty overview can honestly show.

## Why

Closes #72. From `BACKLOG.md` → *Web UI → Analysis screens*, the last **P0**
analysis screen after the treemap and the dependency graph.

Two decisions are worth a reviewer's attention, both recorded in
`apps/web/ARCHITECTURE.md`:

- **26 — the overview folds nothing another screen already folds.** The cards
  read `hotspotRows`, `reportSummary` and `cycleViews`. An overview is a second
  opinion about one run, and a second implementation of "how many cycles" is
  eventually a *different* opinion.
- **27 — change types are a bar list, not a coloured strip.** The mockup wants a
  strip in six hues; `h1…h5` is a *sequential* heat ramp, and validated as a
  categorical set it fails on adjacent pairs no reader can separate (`#8f6300`
  against `#a94f1e` is 0.9 ΔE under deuteranopia), while the status colours are
  reserved for status. Identity is the label, magnitude is the bar; breaking
  changes are marked with the danger token *and* the word. Happy to build the
  stacked strip instead if the palette grows a categorical set.

## Type of change

- [x] feat / fix / perf / refactor
- [ ] docs / test / build / ci / chore

## Checklist

- [x] `pnpm build && pnpm test && pnpm lint` pass locally (544 tests, 33 new)
- [x] Added/updated tests where it made sense — the pure layer, the five views,
      and `/` end to end
- [x] Docs updated: `BACKLOG.md`, `apps/web/ARCHITECTURE.md` (status, building
      blocks, decisions 26–27, risks, coverage), `apps/web/README.md`

## Not verified

The screen is asserted against the DOM, not looked at in a browser — no visual
pass on the real layout.