### PR TITLE
feat(web): swap the rail for a settings nav

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -233,8 +233,13 @@ Sans/Mono.
 
 ### Project settings
 
-- [ ] **P0** Settings shell — sidebar swaps to a settings nav with *Back to
-      workbench*, scoped title, and section list
+- [x] Settings shell — `/settings/project` and `/settings/app`. Inside either
+      one the rail (and, below `md`, the header's strip) swaps the switcher and
+      the analysis nav for that scope's nav: *Back to workbench*, the scope's
+      title over what it applies to — the project and its root, or the
+      workbench — and the section list. The landing screen of each scope prints
+      the same sections with a line on what each one holds. Sections still on
+      this list are listed disabled, as the analysis screens are.
 - [ ] **P0** General — display name, root path (read-only mount), revision, history limit
 - [ ] **P0** Analyze / run — root, revision, history limit, the plugin chips that
       will run, *Run analysis* (`POST /analyze`), and a recents list

--- a/apps/web/ARCHITECTURE.md
+++ b/apps/web/ARCHITECTURE.md
@@ -2,8 +2,9 @@
 
 > Trimmed arc42, consistent with [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md).
 > Status: **in progress** — theme layer, API client, the workbench shell, the
-> project switcher and the overview, hotspot and dependency-graph screens in
-> place; the commit, dead-code and settings screens are still to build.
+> project switcher, the overview, hotspot and dependency-graph screens and the
+> settings shell in place; the commit and dead-code screens, and every settings
+> section, are still to build.
 
 ## 1. Purpose & Goals
 
@@ -40,6 +41,7 @@ app-scoped settings screens. The face of Strata for browser/self-host use.
 | `src/lib/projects/*` | The project registry end to end: `store.svelte` (the registered projects and which one the workbench is on), `entries` (project → a switcher row), `label` (root → name), `crumbs` (path → the picker's steps), `selection` (the remembered choice), and the views — `ProjectSwitcher`, `ProjectList`, `AddProject`, `FolderPicker` |
 | `src/lib/plugins/*` | What the workbench loaded (`store.svelte`), fetched once for the whole app |
 | `src/lib/shell/*` | The frame: `nav` (the map of the workbench), `summary` (report → the header's chips), and the views — `Shell`, `Rail`, `Header`, `NavList`, `RunSummary`, `PluginCount`, `Logo` |
+| `src/lib/settings/*` | The settings area's frame: `scope` (path → project or app), `sections` (what each scope holds), `heading` (scope + project → what the area calls itself), and the views — `SettingsNav` (the rail in settings mode), `SettingsScreen` and `SectionList` (a scope's landing screen) |
 | `src/lib/format/*` | `number` (compact counts), `path` (repo path → dir + name), `duration` and `age`, used by every screen |
 | `src/lib/geometry/*` | `squarify` — the squarified treemap layout |
 | `src/lib/overview/*` | The overview feature end to end: `stats` (report + plugins → the six cards), `bars` (the hotspot head, as shares of the top file), `commits` (history → change types and totals), `dead-code` (findings, and the files holding them), and the six views |
@@ -95,6 +97,9 @@ what more than one screen uses moves up into `lib/components/`.
 | 25 | **A first analysis can be started from the switcher** | A project that has just been registered has nothing to show on any screen. *Project settings → Analyze / run* is where that run belongs, and the entry moves there when the screen lands; until then the switcher offers it, because the alternative is an empty workbench with no visible way out |
 | 26 | **The overview folds nothing of its own that another screen already folds** | Its cards read `hotspotRows`, `reportSummary` and `cycleViews` — the same functions the hotspot and dependency screens read. An overview is a second opinion about one run, and a second implementation of "how many cycles" would eventually be a *different* opinion. What is new here is only what no other screen needed: the six cards, the bar shares, the change types and the dead-code count |
 | 27 | **Change types are a bar list, not a coloured strip** | The mockup's commit strip wants six hues; the palette has none to give. `h1…h5` is a *sequential* ramp — validated as a categorical set it fails on adjacent pairs no reader can separate, colour-blind or not — and the status colours are reserved for status. Painting `docs` and `test` from a heat ramp would also say "hotter = worse" about neither. So identity is the label and magnitude is the bar, which is what the two facts are; breaking changes are marked with the danger token *and* the word, as a status should be |
+| 28 | **Settings is a place, so the rail swaps rather than grows** | A settings area with seven project sections and five app ones cannot hang off a nav entry, and hanging it under the analysis screens would make the rail a list of everything Strata can do. `settingsScope(pathname)` is the whole mechanism: inside `/settings/*` the rail — and the narrow-screen strip, for the same reason — shows *Back to workbench*, the scope's heading and its sections, and nothing else. The route decides, so a link into a section arrives with the right frame already up |
+| 29 | **The scoped heading replaces the switcher, it does not sit beside it** | Project settings belong to the project the workbench is on; leaving the switcher up would let a reader change *which* project while looking at its settings, and two ways to say which one is being configured eventually disagree. The heading names the project and prints its root, so the scope is visible without being changeable — and app settings say *This workbench* in the same slot, because that is what they reach |
+| 30 | **Each scope has a landing screen listing its own sections** | The rail lists section names; a name like *Scope & ignore* only means something with a line beside it. The landing screen is that line, and it is also what a scope's route can honestly show while every section is still on the backlog. `SettingsScreen` renders both scopes — the scope is the only thing that differs, and a second copy would be a second answer to "what can be configured here" |
 
 ## 7. Quality & Risks
 
@@ -112,6 +117,11 @@ what more than one screen uses moves up into `lib/components/`.
 - **Debt:** a project can be registered and removed from the switcher but not
   renamed or re-pointed — `PATCH /projects/:id` is wired on the server and
   waits for *Project settings → General*.
+- **Debt:** the settings area is a frame with nothing inside it yet: every
+  section is listed and inert, so `/settings/project` and `/settings/app` are
+  landing screens only. Each section is its own issue, and the day one lands it
+  becomes `ready` in `sections.ts` and the rail links to it — nothing else in
+  the shell has to change.
 - **Debt:** a treemap draws the top ~50 files; the rest of the ranking is only
   in the table. A zoom or a directory roll-up is the fix if it starts to bite.
 - **Decision:** the graph summary (nodes, edges, cycles, fan-in) is read, not
@@ -150,7 +160,10 @@ what more than one screen uses moves up into `lib/components/`.
   the header's breadcrumb and *Re-analyze*, and the frame itself), the project
   registry (its rows, the project label, the store's selection, adoption after
   a reload, add, remove and the fold of a finished run) with the switcher end
-  to end, the plugin store's load-once, the overview's pure layer (the six
+  to end, the settings shell (the scope a path is in, each scope's sections and
+  that every one of them stays inside its scope, the scoped heading with and
+  without a project, the rail in settings mode — both orientations — and the
+  two landing routes), the plugin store's load-once, the overview's pure layer (the six
   cards' order, values, tones and links, a clean report reading as *none*, bar
   shares held against the whole ranking, change types grouped and tied by name,
   and dead code counted per finding *and* per file) with its views — the stat

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -50,6 +50,7 @@ src/
     projects/         the registered projects and the switcher over them
     plugins/          what the workbench loaded, fetched once for the app
     shell/            the workbench frame: rail, sticky header, scrolling pane
+    settings/         the settings frame: the two scopes, their sections, the rail in settings mode
     format/           compact numbers, repo paths, durations and ages
     geometry/         squarify — the treemap layout
     overview/         the overview feature: stat cards, hotspot bars, cycles, plugins, commit types
@@ -81,8 +82,8 @@ storage key on purpose, so keep the two in step.
 
 ## Status
 
-The theme layer, the typed API client, the app shell, the project switcher and
-the first two analysis screens:
+The theme layer, the typed API client, the app shell, the project switcher, the
+analysis screens built so far and the settings shell:
 
 - **The shell** (`lib/shell`) — a left rail (logo, the project switcher, the
   analysis nav, the settings entries and the plugin count), a header that
@@ -114,6 +115,13 @@ the first two analysis screens:
   side panel carries the graph summary (nodes, edges, cycles, max fan-in) and
   every cycle as a path, `a.ts → b.ts → a.ts`. Selecting a card lights up its
   neighbourhood; selecting a cycle lights up the knot.
+- **Settings** (`lib/settings`) — two scopes, `/settings/project` and
+  `/settings/app`. Opening either swaps the rail (and, below `md`, the header's
+  strip) for that scope's nav: *Back to workbench*, the scope's heading over
+  what it applies to — the project and its root, or the workbench — and the
+  section list. Each scope's landing screen prints the same sections with a
+  line on what each one holds. The sections themselves are still to build, so
+  they are listed disabled, as the analysis screens on the backlog are.
 
 A repository is named once, in *Add project*; the screens then read whatever
 run the selected project last had, the header's *Re-analyze* repeats it, and a

--- a/apps/web/src/lib/settings/SectionList.svelte
+++ b/apps/web/src/lib/settings/SectionList.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+  import type { SettingsSection } from './sections';
+
+  /**
+   * The sections of a scope, with the line that says what each one holds. The
+   * rail lists the same sections by name; this is the landing screen, where
+   * there is room to say what a name means.
+   */
+
+  interface Props {
+    sections: readonly SettingsSection[];
+  }
+
+  let { sections }: Props = $props();
+</script>
+
+<ul class="grid gap-3 sm:grid-cols-2">
+  {#each sections as section (section.href)}
+    <li>
+      {#if section.status === 'planned'}
+        <!-- On the backlog: shown so the map is complete, inert so it cannot
+             lead anywhere that is not there yet. -->
+        <div
+          class="border-line bg-surface h-full rounded-xl border p-4 opacity-70"
+          aria-disabled="true"
+        >
+          <div class="flex items-baseline justify-between gap-3">
+            <h2 class="text-sm font-medium">{section.label}</h2>
+            <span
+              class="text-subtle shrink-0 text-[0.625rem] tracking-wide uppercase"
+            >
+              soon
+            </span>
+          </div>
+          <p class="text-muted mt-1 text-sm">{section.description}</p>
+        </div>
+      {:else}
+        <a
+          href={section.href}
+          class="border-line bg-surface hover:border-line-strong hover:bg-elevated block h-full rounded-xl border p-4 transition-colors"
+        >
+          <div class="flex items-baseline justify-between gap-3">
+            <h2 class="text-sm font-medium">{section.label}</h2>
+            <span class="text-subtle shrink-0" aria-hidden="true">→</span>
+          </div>
+          <p class="text-muted mt-1 text-sm">{section.description}</p>
+        </a>
+      {/if}
+    </li>
+  {/each}
+</ul>

--- a/apps/web/src/lib/settings/SettingsNav.svelte
+++ b/apps/web/src/lib/settings/SettingsNav.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+  import { projects as registry, type ProjectsStore } from '$lib/projects';
+  import NavList from '$lib/shell/NavList.svelte';
+  import { scopeHeading } from './heading';
+  import { sectionsFor } from './sections';
+  import type { SettingsScope } from './scope';
+
+  /**
+   * The rail, in settings mode: the way back to the workbench, the scope this
+   * is configuring, and the sections it holds. It replaces the switcher rather
+   * than sitting beside it — settings belong to the project that is open, and
+   * two ways to say which one that is would eventually disagree.
+   */
+
+  interface Props {
+    scope: SettingsScope;
+    /** The route the app is on; decides which section is current. */
+    pathname: string;
+    /** `column` in the rail, `row` in the narrow-screen strip. */
+    orientation?: 'column' | 'row';
+    /** The registry. Defaults to the app's, as the switcher's does. */
+    projects?: ProjectsStore;
+  }
+
+  let {
+    scope,
+    pathname,
+    orientation = 'column',
+    projects = registry,
+  }: Props = $props();
+
+  // The switcher is what usually loads the registry, and it is exactly what
+  // this replaces — so a reader who opened a settings route from a bookmark
+  // still gets the project's name in the heading. Load-once, as there too.
+  $effect(() => {
+    projects.load();
+  });
+
+  let heading = $derived(scopeHeading(scope, projects.current));
+  let sections = $derived(sectionsFor(scope));
+</script>
+
+{#snippet back()}
+  <!-- Back to the workbench, not back in history: a reader who landed here
+       from a link has nothing behind them, and the overview always exists. -->
+  <a
+    href="/"
+    class="text-muted hover:bg-elevated hover:text-ink flex items-center gap-2 rounded-lg px-3 py-2 text-sm transition-colors"
+  >
+    <svg width="12" height="12" viewBox="0 0 12 12" aria-hidden="true">
+      <path
+        d="M7.5 2.5 4 6l3.5 3.5"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+    <span class="truncate">Back to workbench</span>
+  </a>
+{/snippet}
+
+{#if orientation === 'row'}
+  <!-- Below `md` there is no rail: the same two things, laid across. -->
+  <div class="flex items-center gap-1 overflow-x-auto">
+    <div class="shrink-0">
+      {@render back()}
+    </div>
+    <span class="border-line h-5 shrink-0 border-l" aria-hidden="true"></span>
+    <NavList
+      items={sections}
+      {pathname}
+      orientation="row"
+      label={heading.title}
+    />
+  </div>
+{:else}
+  <div class="flex min-h-0 flex-1 flex-col">
+    <div class="px-3 pb-2">
+      {@render back()}
+    </div>
+
+    <div class="border-line mx-3 border-t pt-3 pb-1">
+      <p class="text-subtle px-3 text-[0.625rem] tracking-wide uppercase">
+        {heading.title}
+      </p>
+      <p class="truncate px-3 text-sm font-medium" title={heading.detail}>
+        {heading.subject}
+      </p>
+      {#if heading.detail}
+        <p
+          class="text-subtle truncate px-3 font-mono text-[0.6875rem]"
+          title={heading.detail}
+        >
+          {heading.detail}
+        </p>
+      {/if}
+    </div>
+
+    <nav class="min-h-0 flex-1 overflow-y-auto px-3 py-2" aria-label="Settings">
+      <NavList items={sections} {pathname} label="{heading.title} sections" />
+    </nav>
+  </div>
+{/if}

--- a/apps/web/src/lib/settings/SettingsNav.test.ts
+++ b/apps/web/src/lib/settings/SettingsNav.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Project } from '$lib/api';
+import { ProjectsStore, SELECTION_STORAGE_KEY } from '$lib/projects';
+import { stubApi } from '$lib/test/api';
+import { render } from '$lib/test/render';
+import SettingsNav from './SettingsNav.svelte';
+import { PROJECT_SECTIONS } from './sections';
+
+/**
+ * The rail in settings mode. Each test gets its own registry store — the nav
+ * loads it itself, because in settings mode the switcher that usually does is
+ * not on screen.
+ */
+
+const strata: Project = {
+  id: 'strata',
+  name: 'Strata',
+  root: '/home/dev/workspace/strata',
+  addedAt: '2026-08-01T09:00:00.000Z',
+  lastAnalysis: null,
+};
+
+const link = (ui: ReturnType<typeof render>, text: string) =>
+  [...ui.container.querySelectorAll('a, span[aria-disabled]')].find((element) =>
+    element.textContent?.trim().startsWith(text),
+  );
+
+/** Mount the nav over a registry, and let the project's name arrive. */
+async function mount(
+  props: { scope: 'project' | 'app'; pathname: string; orientation?: 'row' },
+  registered: Project[] = [strata],
+) {
+  // The workbench comes back to the project it was on; the nav reads whichever
+  // one that is, exactly as the switcher it replaces would.
+  const first = registered[0];
+  if (first) localStorage.setItem(SELECTION_STORAGE_KEY, first.id);
+  stubApi({ '/projects': { projects: registered } });
+  const projects = new ProjectsStore();
+  const ui = render(SettingsNav, { ...props, projects });
+
+  await vi.waitFor(() => {
+    expect(projects.status).toBe('ready');
+  });
+  return ui;
+}
+
+let ui: ReturnType<typeof render>;
+
+afterEach(() => {
+  ui?.destroy();
+  vi.unstubAllGlobals();
+  localStorage.clear();
+});
+
+describe('SettingsNav', () => {
+  it('offers the way back to the workbench', async () => {
+    ui = await mount({ scope: 'project', pathname: '/settings/project' });
+
+    expect(link(ui, 'Back to workbench')?.getAttribute('href')).toBe('/');
+  });
+
+  it('scopes the title to the project the workbench is on', async () => {
+    ui = await mount({ scope: 'project', pathname: '/settings/project' });
+
+    await vi.waitFor(() => {
+      expect(ui.container.textContent).toContain('Strata');
+    });
+    const text = ui.container.textContent ?? '';
+    expect(text).toContain('Project settings');
+    expect(text).toContain('/home/dev/workspace/strata');
+  });
+
+  it('scopes the app settings to the workbench, with no root behind them', async () => {
+    ui = await mount({ scope: 'app', pathname: '/settings/app' });
+
+    const text = ui.container.textContent ?? '';
+    expect(text).toContain('App settings');
+    expect(text).toContain('This workbench');
+    expect(text).not.toContain('/home/dev/workspace/strata');
+  });
+
+  it('says when there is no project to configure', async () => {
+    ui = await mount({ scope: 'project', pathname: '/settings/project' }, []);
+
+    expect(ui.container.textContent).toContain('No project selected');
+  });
+
+  it('lists the sections of the scope it is in, and only those', async () => {
+    ui = await mount({ scope: 'project', pathname: '/settings/project' });
+
+    const text = ui.container.textContent ?? '';
+    for (const section of PROJECT_SECTIONS) {
+      expect(text).toContain(section.label);
+    }
+    expect(text).not.toContain('AI providers');
+  });
+
+  it('shows a section that is not built yet without linking to it', async () => {
+    ui = await mount({ scope: 'project', pathname: '/settings/project' });
+
+    const general = link(ui, 'General');
+    expect(general?.tagName).toBe('SPAN');
+    expect(general?.getAttribute('aria-disabled')).toBe('true');
+  });
+
+  it('lays the same two things across on a narrow screen', async () => {
+    ui = await mount({
+      scope: 'app',
+      pathname: '/settings/app',
+      orientation: 'row',
+    });
+
+    const text = ui.container.textContent ?? '';
+    expect(text).toContain('Back to workbench');
+    expect(text).toContain('AI providers');
+    // The scope's heading is the rail's; the strip has no room for it.
+    expect(text).not.toContain('This workbench');
+  });
+});

--- a/apps/web/src/lib/settings/SettingsScreen.svelte
+++ b/apps/web/src/lib/settings/SettingsScreen.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import { projects as registry, type ProjectsStore } from '$lib/projects';
+  import SectionList from './SectionList.svelte';
+  import { scopeHeading } from './heading';
+  import { sectionsFor } from './sections';
+  import type { SettingsScope } from './scope';
+
+  /**
+   * The landing screen of a settings scope: what is being configured, how far
+   * it reaches, and the sections it is divided into. Both scopes render it —
+   * the scope is the only thing that differs, and a second copy of this page
+   * would be a second answer to "what can be configured here".
+   */
+
+  interface Props {
+    scope: SettingsScope;
+    /** The registry. Defaults to the app's, as the switcher's does. */
+    projects?: ProjectsStore;
+  }
+
+  let { scope, projects = registry }: Props = $props();
+
+  // Mounted without the frame — in a test, or on a direct load — the screen
+  // still knows which project it is scoped to.
+  $effect(() => {
+    projects.load();
+  });
+
+  let heading = $derived(scopeHeading(scope, projects.current));
+  let sections = $derived(sectionsFor(scope));
+</script>
+
+<svelte:head>
+  <title>{heading.title} · Strata</title>
+</svelte:head>
+
+<div>
+  <header class="mb-8">
+    <h1 class="text-2xl font-semibold">{heading.title}</h1>
+    <p class="text-muted mt-1 max-w-3xl text-sm">{heading.summary}</p>
+    {#if heading.detail}
+      <p class="text-subtle mt-1 font-mono text-xs">{heading.detail}</p>
+    {/if}
+  </header>
+
+  <SectionList {sections} />
+</div>

--- a/apps/web/src/lib/settings/heading.test.ts
+++ b/apps/web/src/lib/settings/heading.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { scopeHeading } from './heading';
+
+const strata = { name: 'Strata', root: '/home/dev/workspace/strata' };
+
+describe('scopeHeading', () => {
+  it('names the project the settings belong to, and its root', () => {
+    const heading = scopeHeading('project', strata);
+
+    expect(heading.title).toBe('Project settings');
+    expect(heading.subject).toBe('Strata');
+    expect(heading.detail).toBe('/home/dev/workspace/strata');
+    expect(heading.summary).toContain('Strata');
+  });
+
+  it('says so when there is no project to scope to', () => {
+    const heading = scopeHeading('project', null);
+
+    expect(heading.subject).toBe('No project selected');
+    expect(heading.detail).toBe('');
+    expect(heading.summary).toContain('switcher');
+  });
+
+  it('scopes the app settings to the workbench, whatever project is open', () => {
+    const heading = scopeHeading('app', strata);
+
+    expect(heading.title).toBe('App settings');
+    expect(heading.subject).toBe('This workbench');
+    // The project is open, but it is not what these settings reach.
+    expect(heading.detail).toBe('');
+    expect(heading.summary).not.toContain('Strata');
+  });
+});

--- a/apps/web/src/lib/settings/heading.ts
+++ b/apps/web/src/lib/settings/heading.ts
@@ -1,0 +1,52 @@
+import type { Project } from '$lib/api';
+import type { SettingsScope } from './scope';
+
+/**
+ * What a settings scope calls itself, and what it says it reaches over. The
+ * rail's switcher is gone in settings mode — this is what replaces it, so it
+ * has to name the thing being configured rather than only the screen.
+ */
+export interface ScopeHeading {
+  /** What the rail and the screen call this scope. */
+  title: string;
+  /** What the settings apply to: the project, or the workbench itself. */
+  subject: string;
+  /** The line under the subject — the repository path, when there is one. */
+  detail: string;
+  /** How far the scope reaches, said in a sentence. */
+  summary: string;
+}
+
+/** The heading for a scope, given the project the workbench is pointed at. */
+export function scopeHeading(
+  scope: SettingsScope,
+  project: Pick<Project, 'name' | 'root'> | null,
+): ScopeHeading {
+  if (scope === 'app') {
+    return {
+      title: 'App settings',
+      subject: 'This workbench',
+      detail: '',
+      summary: 'Applies to every project this workbench opens.',
+    };
+  }
+
+  // Project settings without a project would be a form with nothing behind it,
+  // so the heading says so rather than the sections failing one by one.
+  if (!project) {
+    return {
+      title: 'Project settings',
+      subject: 'No project selected',
+      detail: '',
+      summary:
+        'These settings belong to one repository — pick a project in the switcher first.',
+    };
+  }
+
+  return {
+    title: 'Project settings',
+    subject: project.name,
+    detail: project.root,
+    summary: `Applies to ${project.name} alone; every other project keeps its own.`,
+  };
+}

--- a/apps/web/src/lib/settings/index.ts
+++ b/apps/web/src/lib/settings/index.ts
@@ -1,0 +1,15 @@
+export { default as SettingsNav } from './SettingsNav.svelte';
+export { default as SettingsScreen } from './SettingsScreen.svelte';
+export { scopeHeading, type ScopeHeading } from './heading';
+export {
+  APP_SECTIONS,
+  PROJECT_SECTIONS,
+  sectionsFor,
+  type SettingsSection,
+} from './sections';
+export {
+  settingsScope,
+  SETTINGS_ROOTS,
+  SETTINGS_SCOPES,
+  type SettingsScope,
+} from './scope';

--- a/apps/web/src/lib/settings/scope.test.ts
+++ b/apps/web/src/lib/settings/scope.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { settingsScope, SETTINGS_ROOTS } from './scope';
+
+describe('settingsScope', () => {
+  it('names the scope a settings route is in', () => {
+    expect(settingsScope(SETTINGS_ROOTS.project)).toBe('project');
+    expect(settingsScope(SETTINGS_ROOTS.app)).toBe('app');
+  });
+
+  it('holds the scope across its sections and a trailing slash', () => {
+    expect(settingsScope('/settings/project/scope')).toBe('project');
+    expect(settingsScope('/settings/app/appearance')).toBe('app');
+    expect(settingsScope('/settings/project/')).toBe('project');
+  });
+
+  it('leaves every workbench screen alone', () => {
+    expect(settingsScope('/')).toBeNull();
+    expect(settingsScope('/hotspots')).toBeNull();
+    expect(settingsScope('/graph')).toBeNull();
+  });
+
+  it('claims nothing on a path that only looks like one', () => {
+    expect(settingsScope('/settings')).toBeNull();
+    expect(settingsScope('/settings/nowhere')).toBeNull();
+    // A sibling route, not a section of the project scope.
+    expect(settingsScope('/settings/projects')).toBeNull();
+  });
+});

--- a/apps/web/src/lib/settings/scope.ts
+++ b/apps/web/src/lib/settings/scope.ts
@@ -1,0 +1,25 @@
+/**
+ * Settings are two scopes rather than one screen: what a single project does,
+ * and what the workbench does for every project. Which scope a route is in
+ * decides what the rail lists, so it is a pure function of the path — the
+ * frame asks it on every navigation and nothing else needs to be told.
+ */
+export type SettingsScope = 'project' | 'app';
+
+/** Where each scope roots; its sections hang below it. */
+export const SETTINGS_ROOTS: Readonly<Record<SettingsScope, string>> = {
+  project: '/settings/project',
+  app: '/settings/app',
+};
+
+export const SETTINGS_SCOPES = ['project', 'app'] as const;
+
+/** The scope a path sits in — `null` on every workbench screen. */
+export function settingsScope(pathname: string): SettingsScope | null {
+  const path = pathname.replace(/\/+$/, '') || '/';
+  for (const scope of SETTINGS_SCOPES) {
+    const root = SETTINGS_ROOTS[scope];
+    if (path === root || path.startsWith(`${root}/`)) return scope;
+  }
+  return null;
+}

--- a/apps/web/src/lib/settings/sections.test.ts
+++ b/apps/web/src/lib/settings/sections.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { settingsScope } from './scope';
+import { APP_SECTIONS, PROJECT_SECTIONS, sectionsFor } from './sections';
+
+describe('settings sections', () => {
+  it('lists the project scope in the order the settings area is read', () => {
+    expect(PROJECT_SECTIONS.map((section) => section.label)).toEqual([
+      'General',
+      'Analyze / run',
+      'Scope & ignore',
+      'Language plugins',
+      'Metrics & convention',
+      'Architecture rules',
+      'Danger zone',
+    ]);
+  });
+
+  it('lists the app scope', () => {
+    expect(APP_SECTIONS.map((section) => section.label)).toEqual([
+      'Appearance',
+      'Plugins & engine',
+      'CI gates',
+      'AI providers',
+      'About',
+    ]);
+  });
+
+  it('hands each scope its own sections', () => {
+    expect(sectionsFor('project')).toBe(PROJECT_SECTIONS);
+    expect(sectionsFor('app')).toBe(APP_SECTIONS);
+  });
+
+  it('keeps every section inside the scope that lists it', () => {
+    for (const section of PROJECT_SECTIONS) {
+      expect(settingsScope(section.href)).toBe('project');
+    }
+    for (const section of APP_SECTIONS) {
+      expect(settingsScope(section.href)).toBe('app');
+    }
+  });
+
+  it('says what each section holds, and none is built yet', () => {
+    for (const section of [...PROJECT_SECTIONS, ...APP_SECTIONS]) {
+      expect(section.description.length).toBeGreaterThan(0);
+      expect(section.status).toBe('planned');
+    }
+  });
+});

--- a/apps/web/src/lib/settings/sections.ts
+++ b/apps/web/src/lib/settings/sections.ts
@@ -1,0 +1,111 @@
+import type { NavStatus } from '$lib/shell/nav';
+import type { SettingsScope } from './scope';
+
+/**
+ * The sections each scope holds. Like the workbench nav, sections that are on
+ * the backlog are listed and inert: the settings area is a map of what can be
+ * configured, and a map with holes in it reads as something broken rather than
+ * something coming.
+ */
+export interface SettingsSection {
+  /** Route the section will live at; also its identity in the list. */
+  href: string;
+  label: string;
+  /** One line on what it holds — the landing screen prints it. */
+  description: string;
+  status: NavStatus;
+}
+
+/** Everything scoped to one repository. */
+export const PROJECT_SECTIONS: readonly SettingsSection[] = [
+  {
+    href: '/settings/project/general',
+    label: 'General',
+    description:
+      'Display name, the root it is mounted at, the revision to analyse and how far back the history is read.',
+    status: 'planned',
+  },
+  {
+    href: '/settings/project/analyze',
+    label: 'Analyze / run',
+    description:
+      'Start a run over this project, see which plugins will take part, and what the recent runs found.',
+    status: 'planned',
+  },
+  {
+    href: '/settings/project/scope',
+    label: 'Scope & ignore',
+    description:
+      'The paths that are analysed and the globs that are skipped, as editable lists.',
+    status: 'planned',
+  },
+  {
+    href: '/settings/project/languages',
+    label: 'Language plugins',
+    description:
+      'Which language modules run over this project, and the extensions each one claims.',
+    status: 'planned',
+  },
+  {
+    href: '/settings/project/metrics',
+    label: 'Metrics & convention',
+    description:
+      'Which metrics are computed, and the commit convention the history is read with.',
+    status: 'planned',
+  },
+  {
+    href: '/settings/project/rules',
+    label: 'Architecture rules',
+    description:
+      'The import rules this project is held to — “ui may not import db” — and which of them are enforced.',
+    status: 'planned',
+  },
+  {
+    href: '/settings/project/danger',
+    label: 'Danger zone',
+    description:
+      'Remove the project from Strata. The repository on disk is left untouched.',
+    status: 'planned',
+  },
+];
+
+/** Everything that holds for the workbench, whatever project is open. */
+export const APP_SECTIONS: readonly SettingsSection[] = [
+  {
+    href: '/settings/app/appearance',
+    label: 'Appearance',
+    description: 'Theme — dark, light or system — and the density of a screen.',
+    status: 'planned',
+  },
+  {
+    href: '/settings/app/plugins',
+    label: 'Plugins & engine',
+    description:
+      'The plugins directory, whether third-party plugins load, and the incremental cache.',
+    status: 'planned',
+  },
+  {
+    href: '/settings/app/gates',
+    label: 'CI gates',
+    description:
+      'What a headless run fails on: new import cycles, a hotspot regression past a threshold.',
+    status: 'planned',
+  },
+  {
+    href: '/settings/app/ai',
+    label: 'AI providers',
+    description:
+      'The coding agents Strata may talk to, how each one is launched, and how often it is health-checked.',
+    status: 'planned',
+  },
+  {
+    href: '/settings/app/about',
+    label: 'About',
+    description: 'Version, licence, and the links to the docs.',
+    status: 'planned',
+  },
+];
+
+export function sectionsFor(scope: SettingsScope): readonly SettingsSection[] {
+  return scope === 'project' ? PROJECT_SECTIONS : APP_SECTIONS;
+}

--- a/apps/web/src/lib/shell/Header.svelte
+++ b/apps/web/src/lib/shell/Header.svelte
@@ -2,6 +2,7 @@
   import { analysis } from '$lib/analysis';
   import ThemeSwitch from '$lib/components/ThemeSwitch.svelte';
   import { projectLabel, projects, ProjectSwitcher } from '$lib/projects';
+  import { SettingsNav, settingsScope } from '$lib/settings';
   import NavList from './NavList.svelte';
   import RunSummary from './RunSummary.svelte';
   import { ANALYSIS_NAV, sectionLabel, SETTINGS_NAV } from './nav';
@@ -16,12 +17,16 @@
   // remembered path even on a reload that has not run anything yet.
   analysis.init();
 
+  let scope = $derived(settingsScope(pathname));
   let section = $derived(sectionLabel(pathname));
   // What the switcher calls the project, falling back to the folder's name for
   // a repository that was analysed without being registered.
   let project = $derived(
     projects.current?.name ?? projectLabel(analysis.root),
   );
+  // The app-wide settings are not the project's, so the crumb above them is
+  // the workbench rather than whichever repository happens to be open.
+  let owner = $derived(scope === 'app' ? 'Strata' : project || 'Strata');
   let running = $derived(analysis.status === 'running');
 </script>
 
@@ -35,8 +40,11 @@
   <div class="flex flex-wrap items-center gap-x-4 gap-y-2 px-4 py-3 sm:px-6">
     <nav class="min-w-0 flex-1" aria-label="Breadcrumb">
       <ol class="flex min-w-0 items-center gap-2 text-sm">
-        <li class="text-muted min-w-0 truncate" title={analysis.root}>
-          {project || 'Strata'}
+        <li
+          class="text-muted min-w-0 truncate"
+          title={scope === 'app' ? undefined : analysis.root}
+        >
+          {owner}
         </li>
         <li class="text-subtle" aria-hidden="true">/</li>
         <li class="truncate font-medium" aria-current="page">{section}</li>
@@ -63,16 +71,21 @@
   <!--
     No room for the rail on a narrow screen: the same nav, laid across, and the
     same switcher above it — it is the only way to point the workbench at a
-    project, so it cannot be the one thing the rail takes away with it.
+    project, so it cannot be the one thing the rail takes away with it. Inside
+    settings the strip swaps with the rail, for the same reason the rail does.
   -->
   <div class="border-line space-y-2 border-t px-2 py-2 md:hidden">
-    <ProjectSwitcher />
+    {#if scope}
+      <SettingsNav {scope} {pathname} orientation="row" />
+    {:else}
+      <ProjectSwitcher />
 
-    <NavList
-      items={[...ANALYSIS_NAV, ...SETTINGS_NAV]}
-      {pathname}
-      orientation="row"
-      label="Workbench"
-    />
+      <NavList
+        items={[...ANALYSIS_NAV, ...SETTINGS_NAV]}
+        {pathname}
+        orientation="row"
+        label="Workbench"
+      />
+    {/if}
   </div>
 </header>

--- a/apps/web/src/lib/shell/Header.test.ts
+++ b/apps/web/src/lib/shell/Header.test.ts
@@ -119,4 +119,23 @@ describe('Header', () => {
 
     expect(crumbs(ui)).toEqual(['Strata workbench', '/', 'Dependencies']);
   });
+
+  it('swaps the narrow-screen strip for the settings sections', () => {
+    ui = render(Header, { pathname: '/settings/project' });
+
+    const text = ui.container.textContent ?? '';
+    expect(text).toContain('Back to workbench');
+    expect(text).toContain('Danger zone');
+    // The strip's own nav and switcher go with the rail's.
+    expect(text).not.toContain('Dead code');
+    expect(
+      ui.container.querySelector('[aria-label="Current project"]'),
+    ).toBeNull();
+  });
+
+  it('breadcrumbs the app settings under the workbench, not the project', () => {
+    ui = render(Header, { pathname: '/settings/app' });
+
+    expect(crumbs(ui)).toEqual(['Strata', '/', 'App settings']);
+  });
 });

--- a/apps/web/src/lib/shell/NavList.svelte
+++ b/apps/web/src/lib/shell/NavList.svelte
@@ -12,7 +12,9 @@
 
   let { items, pathname, orientation = 'column', label }: Props = $props();
 
-  let current = $derived(activeNav(pathname)?.href ?? null);
+  // Against the items it renders, not the whole map: the settings sections are
+  // a list of their own, and asking the workbench nav about them finds nothing.
+  let current = $derived(activeNav(pathname, items)?.href ?? null);
   let base = $derived(
     orientation === 'column'
       ? 'w-full justify-between px-3 py-2'

--- a/apps/web/src/lib/shell/Rail.svelte
+++ b/apps/web/src/lib/shell/Rail.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { ProjectSwitcher } from '$lib/projects';
+  import { SettingsNav, settingsScope } from '$lib/settings';
   import Logo from './Logo.svelte';
   import NavList from './NavList.svelte';
   import PluginCount from './PluginCount.svelte';
@@ -10,6 +11,10 @@
   }
 
   let { pathname }: Props = $props();
+
+  // Settings is a place, not a screen: the rail swaps to that scope's sections
+  // for as long as the reader is inside it, with the way back at the top.
+  let scope = $derived(settingsScope(pathname));
 </script>
 
 <!--
@@ -24,21 +29,27 @@
     <Logo />
   </div>
 
-  <div class="px-3 pb-2">
-    <ProjectSwitcher />
-  </div>
+  {#if scope}
+    <SettingsNav {scope} {pathname} />
+  {:else}
+    <div class="px-3 pb-2">
+      <ProjectSwitcher />
+    </div>
 
-  <nav class="min-h-0 flex-1 overflow-y-auto px-3 py-3" aria-label="Workbench">
-    <p class="text-subtle px-3 pb-1 text-[0.625rem] tracking-wide uppercase">
-      Analysis
-    </p>
-    <NavList items={ANALYSIS_NAV} {pathname} label="Analysis" />
+    <nav class="min-h-0 flex-1 overflow-y-auto px-3 py-3" aria-label="Workbench">
+      <p class="text-subtle px-3 pb-1 text-[0.625rem] tracking-wide uppercase">
+        Analysis
+      </p>
+      <NavList items={ANALYSIS_NAV} {pathname} label="Analysis" />
 
-    <p class="text-subtle px-3 pt-5 pb-1 text-[0.625rem] tracking-wide uppercase">
-      Settings
-    </p>
-    <NavList items={SETTINGS_NAV} {pathname} label="Settings" />
-  </nav>
+      <p
+        class="text-subtle px-3 pt-5 pb-1 text-[0.625rem] tracking-wide uppercase"
+      >
+        Settings
+      </p>
+      <NavList items={SETTINGS_NAV} {pathname} label="Settings" />
+    </nav>
+  {/if}
 
   <div class="border-line border-t px-4 py-3">
     <PluginCount />

--- a/apps/web/src/lib/shell/Rail.test.ts
+++ b/apps/web/src/lib/shell/Rail.test.ts
@@ -99,4 +99,34 @@ describe('Rail', () => {
     });
     expect(ui.container.textContent).toContain('/home/dev/workspace/strata');
   });
+
+  it('swaps to the settings nav of the scope the reader is in', async () => {
+    ui = render(Rail, { pathname: '/settings/project/general' });
+
+    await vi.waitFor(() => {
+      expect(ui.container.textContent).toContain('Strata');
+    });
+    const text = ui.container.textContent ?? '';
+    expect(text).toContain('Back to workbench');
+    expect(text).toContain('Project settings');
+    expect(text).toContain('Danger zone');
+    // The workbench nav — and the switcher it sits under — is gone with it.
+    expect(text).not.toContain('Hotspots');
+    expect(
+      ui.container.querySelector('[aria-label="Current project"]'),
+    ).toBeNull();
+    // The plugin count is the frame's, so it stays.
+    await vi.waitFor(() => {
+      expect(ui.container.textContent).toContain('plugins loaded');
+    });
+  });
+
+  it('lists the sections of whichever scope the reader is in', () => {
+    ui = render(Rail, { pathname: '/settings/app' });
+
+    const text = ui.container.textContent ?? '';
+    expect(text).toContain('App settings');
+    expect(text).toContain('AI providers');
+    expect(text).not.toContain('Danger zone');
+  });
 });

--- a/apps/web/src/lib/shell/nav.test.ts
+++ b/apps/web/src/lib/shell/nav.test.ts
@@ -25,6 +25,10 @@ describe('nav', () => {
     );
   });
 
+  it('opens both settings scopes', () => {
+    expect(SETTINGS_NAV.every((item) => item.status === 'ready')).toBe(true);
+  });
+
   it('finds the entry a path is on', () => {
     expect(activeNav('/hotspots')?.label).toBe('Hotspots');
     expect(activeNav('/hotspots/')?.label).toBe('Hotspots');
@@ -39,6 +43,17 @@ describe('nav', () => {
     expect(activeNav('/settings/project/scope')?.label).toBe(
       'Project settings',
     );
+  });
+
+  it('answers within the list it is given', () => {
+    const sections = [
+      { href: '/settings/app/appearance', label: 'Appearance' },
+      { href: '/settings/app/about', label: 'About' },
+    ].map((item) => ({ ...item, status: 'planned' as const }));
+
+    expect(activeNav('/settings/app/about', sections)?.label).toBe('About');
+    // The scope's own route is not one of its sections.
+    expect(activeNav('/settings/app', sections)).toBeNull();
   });
 
   it('names the section, and falls back on an unknown path', () => {

--- a/apps/web/src/lib/shell/nav.ts
+++ b/apps/web/src/lib/shell/nav.ts
@@ -23,8 +23,8 @@ export const ANALYSIS_NAV: readonly NavItem[] = [
 
 /** The two settings scopes: what this project does, and what the app does. */
 export const SETTINGS_NAV: readonly NavItem[] = [
-  { href: '/settings/project', label: 'Project settings', status: 'planned' },
-  { href: '/settings/app', label: 'App settings', status: 'planned' },
+  { href: '/settings/project', label: 'Project settings', status: 'ready' },
+  { href: '/settings/app', label: 'App settings', status: 'ready' },
 ];
 
 export const NAV_ITEMS: readonly NavItem[] = [
@@ -33,14 +33,21 @@ export const NAV_ITEMS: readonly NavItem[] = [
 ];
 
 /**
- * The entry a path sits inside. The longest matching href wins, so a future
+ * The entry a path sits inside. The longest matching href wins, so
  * `/settings/project/scope` highlights *Project settings* rather than falling
  * back to the root entry.
+ *
+ * The list is a parameter because the settings area lists its own sections:
+ * a list highlights the entry the reader is on *within itself*, rather than
+ * asking a map it is not part of.
  */
-export function activeNav(pathname: string): NavItem | null {
+export function activeNav(
+  pathname: string,
+  items: readonly NavItem[] = NAV_ITEMS,
+): NavItem | null {
   const path = normalise(pathname);
   let best: NavItem | null = null;
-  for (const item of NAV_ITEMS) {
+  for (const item of items) {
     if (!contains(item.href, path)) continue;
     if (!best || item.href.length > best.href.length) best = item;
   }

--- a/apps/web/src/routes/settings/app/+page.svelte
+++ b/apps/web/src/routes/settings/app/+page.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  import { SettingsScreen } from '$lib/settings';
+</script>
+
+<!-- Everything that holds for the workbench, whatever project is open. -->
+<SettingsScreen scope="app" />

--- a/apps/web/src/routes/settings/app/page.test.ts
+++ b/apps/web/src/routes/settings/app/page.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { projects, SELECTION_STORAGE_KEY } from '$lib/projects';
+import { APP_SECTIONS } from '$lib/settings';
+import { stubApi } from '$lib/test/api';
+import { render } from '$lib/test/render';
+import Page from './+page.svelte';
+
+/**
+ * The landing screen of the app scope. A project is open on purpose: these
+ * settings hold for the workbench, so the screen must not describe itself
+ * with whichever repository happens to be selected.
+ */
+
+const strata = {
+  id: 'strata',
+  name: 'Strata',
+  root: '/home/dev/workspace/strata',
+  addedAt: '2026-08-01T09:00:00.000Z',
+  lastAnalysis: null,
+};
+
+let ui: ReturnType<typeof render>;
+
+beforeEach(async () => {
+  localStorage.setItem(SELECTION_STORAGE_KEY, 'strata');
+  stubApi({ '/projects': { projects: [strata] } });
+  await projects.reload();
+});
+
+afterEach(() => {
+  ui?.destroy();
+  vi.unstubAllGlobals();
+  localStorage.clear();
+});
+
+describe('app settings page', () => {
+  it('scopes itself to the workbench, not to the open project', () => {
+    ui = render(Page);
+
+    const text = ui.container.textContent ?? '';
+    expect(text).toContain('App settings');
+    expect(text).toContain('every project');
+    expect(text).not.toContain('/home/dev/workspace/strata');
+  });
+
+  it('lists every section with what it holds', () => {
+    ui = render(Page);
+
+    const text = ui.container.textContent ?? '';
+    for (const section of APP_SECTIONS) {
+      expect(text).toContain(section.label);
+      expect(text).toContain(section.description);
+    }
+  });
+
+  it('links to no section that is not built yet', () => {
+    ui = render(Page);
+
+    expect(ui.container.querySelectorAll('a')).toHaveLength(0);
+    expect(ui.container.querySelectorAll('[aria-disabled="true"]')).toHaveLength(
+      APP_SECTIONS.length,
+    );
+  });
+});

--- a/apps/web/src/routes/settings/project/+page.svelte
+++ b/apps/web/src/routes/settings/project/+page.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  import { SettingsScreen } from '$lib/settings';
+</script>
+
+<!-- Everything scoped to the project the workbench is pointed at. -->
+<SettingsScreen scope="project" />

--- a/apps/web/src/routes/settings/project/page.test.ts
+++ b/apps/web/src/routes/settings/project/page.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { projects, SELECTION_STORAGE_KEY } from '$lib/projects';
+import { PROJECT_SECTIONS } from '$lib/settings';
+import { stubApi } from '$lib/test/api';
+import { render } from '$lib/test/render';
+import Page from './+page.svelte';
+
+/**
+ * The landing screen of the project scope: what is being configured, and the
+ * sections it is divided into. It reads the app-wide registry, so the choice
+ * is in place before the first mount.
+ */
+
+const strata = {
+  id: 'strata',
+  name: 'Strata',
+  root: '/home/dev/workspace/strata',
+  addedAt: '2026-08-01T09:00:00.000Z',
+  lastAnalysis: null,
+};
+
+let ui: ReturnType<typeof render>;
+
+beforeEach(async () => {
+  localStorage.setItem(SELECTION_STORAGE_KEY, 'strata');
+  stubApi({ '/projects': { projects: [strata] } });
+  await projects.reload();
+});
+
+afterEach(() => {
+  ui?.destroy();
+  vi.unstubAllGlobals();
+  localStorage.clear();
+});
+
+describe('project settings page', () => {
+  it('names the project the settings are scoped to', () => {
+    ui = render(Page);
+
+    const text = ui.container.textContent ?? '';
+    expect(text).toContain('Project settings');
+    expect(text).toContain('Strata');
+    expect(text).toContain('/home/dev/workspace/strata');
+  });
+
+  it('lists every section with what it holds', () => {
+    ui = render(Page);
+
+    const text = ui.container.textContent ?? '';
+    for (const section of PROJECT_SECTIONS) {
+      expect(text).toContain(section.label);
+      expect(text).toContain(section.description);
+    }
+  });
+
+  it('links to no section that is not built yet', () => {
+    ui = render(Page);
+
+    expect(ui.container.querySelectorAll('a')).toHaveLength(0);
+    expect(ui.container.querySelectorAll('[aria-disabled="true"]')).toHaveLength(
+      PROJECT_SECTIONS.length,
+    );
+  });
+});


### PR DESCRIPTION
## What

The settings shell: `/settings/project` and `/settings/app`. Inside either scope the rail — and, below `md`, the header's nav strip — swaps the project switcher and the analysis nav for that scope's nav: *Back to workbench*, the scoped heading, and the section list. `settingsScope(pathname)` is the whole mechanism, so a link straight into a section arrives with the right frame up.

The heading replaces the switcher rather than sitting beside it: it names the project and prints its root for the project scope, and says *This workbench* for the app scope. The breadcrumb follows — above app settings it reads *Strata*, not whichever repository is open.

Each scope lands on a screen listing its own sections with a line on what each one holds. The sections themselves are listed disabled, as the analysis screens on the backlog are; landing one (#76–#86) is a `status` flip in `sections.ts` and nothing in the shell changes.

New feature folder `apps/web/src/lib/settings`: `scope` (path → project or app), `sections` (what each scope holds), `heading` (scope + project → what the area calls itself), and the views `SettingsNav`, `SettingsScreen`, `SectionList`. `activeNav` now takes the list to search, so a nav highlights within its own items.

## Why

Closes #75. From `BACKLOG.md` → *Web UI → Project settings*; the frame every settings section hangs off.

## Type of change

- [x] feat / fix / perf / refactor
- [ ] docs / test / build / ci / chore

## Checklist

- [x] `pnpm build && pnpm test && pnpm lint` pass locally (plus `svelte-check`: 0 errors)
- [x] Added/updated tests where it made sense — the scope a path is in, each scope's sections and that every one stays inside its scope, the heading with and without a project, the rail in settings mode in both orientations, the two landing routes, and the swap in `Rail`/`Header`
- [x] Docs updated — `BACKLOG.md`, `apps/web/ARCHITECTURE.md` (building blocks, decisions 28–30, tests, one debt note) and `apps/web/README.md`