### PR TITLE
feat(web): settle a project's identity and window

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -240,7 +240,14 @@ Sans/Mono.
       workbench — and the section list. The landing screen of each scope prints
       the same sections with a line on what each one holds. Sections still on
       this list are listed disabled, as the analysis screens are.
-- [ ] **P0** General — display name, root path (read-only mount), revision, history limit
+- [x] General — `/settings/project/general`. The display name renames the
+      registry entry (`PATCH /projects/:id`) and the revision and history limit
+      are written to the project's config (`PATCH /projects/:id/config`), which
+      every run over that root already honours; the reader sees one form and
+      only the half they edited is sent. The root is printed as a read-only
+      mount: re-pointing an entry would keep its name, settings and last run
+      while all three now described another repository, so moving a project is
+      remove-and-add-again.
 - [ ] **P0** Analyze / run — root, revision, history limit, the plugin chips that
       will run, *Run analysis* (`POST /analyze`), and a recents list
 - [ ] **P1** Scope & ignore — ignore globs and analyze paths as editable chip lists

--- a/apps/web/ARCHITECTURE.md
+++ b/apps/web/ARCHITECTURE.md
@@ -2,9 +2,10 @@
 
 > Trimmed arc42, consistent with [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md).
 > Status: **in progress** — theme layer, API client, the workbench shell, the
-> project switcher, the overview, hotspot and dependency-graph screens and the
-> settings shell in place; the commit and dead-code screens, and every settings
-> section, are still to build.
+> project switcher, the overview, hotspot and dependency-graph screens, the
+> settings shell and its *Project settings → General* section in place; the
+> commit and dead-code screens, and the remaining settings sections, are still
+> to build.
 
 ## 1. Purpose & Goals
 
@@ -25,7 +26,7 @@ app-scoped settings screens. The face of Strata for browser/self-host use.
 ## 3. Interfaces (Context)
 
 - **Depends on:** the `@strata/server` REST API (`/health`, `/plugins`,
-  `/analyze`, `/cache`, `/projects`, `/browse`).
+  `/analyze`, `/cache`, `/projects`, `/projects/:id/config`, `/browse`).
 - **Consumed by:** end users (browser / desktop).
 
 ## 4. Building Blocks
@@ -41,7 +42,7 @@ app-scoped settings screens. The face of Strata for browser/self-host use.
 | `src/lib/projects/*` | The project registry end to end: `store.svelte` (the registered projects and which one the workbench is on), `entries` (project → a switcher row), `label` (root → name), `crumbs` (path → the picker's steps), `selection` (the remembered choice), and the views — `ProjectSwitcher`, `ProjectList`, `AddProject`, `FolderPicker` |
 | `src/lib/plugins/*` | What the workbench loaded (`store.svelte`), fetched once for the whole app |
 | `src/lib/shell/*` | The frame: `nav` (the map of the workbench), `summary` (report → the header's chips), and the views — `Shell`, `Rail`, `Header`, `NavList`, `RunSummary`, `PluginCount`, `Logo` |
-| `src/lib/settings/*` | The settings area's frame: `scope` (path → project or app), `sections` (what each scope holds), `heading` (scope + project → what the area calls itself), and the views — `SettingsNav` (the rail in settings mode), `SettingsScreen` and `SectionList` (a scope's landing screen) |
+| `src/lib/settings/*` | The settings area's frame: `scope` (path → project or app), `sections` (what each scope holds), `heading` (scope + project → what the area calls itself), `config.svelte` (the open project's config, held for every project section), and the views — `SettingsNav` (the rail in settings mode), `SettingsScreen` and `SectionList` (a scope's landing screen). Then one section: `general` (the *General* form → the two patches a save sends) with `GeneralScreen` |
 | `src/lib/format/*` | `number` (compact counts), `path` (repo path → dir + name), `duration` and `age`, used by every screen |
 | `src/lib/geometry/*` | `squarify` — the squarified treemap layout |
 | `src/lib/overview/*` | The overview feature end to end: `stats` (report + plugins → the six cards), `bars` (the hotspot head, as shares of the top file), `commits` (history → change types and totals), `dead-code` (findings, and the files holding them), and the six views |
@@ -100,6 +101,9 @@ what more than one screen uses moves up into `lib/components/`.
 | 28 | **Settings is a place, so the rail swaps rather than grows** | A settings area with seven project sections and five app ones cannot hang off a nav entry, and hanging it under the analysis screens would make the rail a list of everything Strata can do. `settingsScope(pathname)` is the whole mechanism: inside `/settings/*` the rail — and the narrow-screen strip, for the same reason — shows *Back to workbench*, the scope's heading and its sections, and nothing else. The route decides, so a link into a section arrives with the right frame already up |
 | 29 | **The scoped heading replaces the switcher, it does not sit beside it** | Project settings belong to the project the workbench is on; leaving the switcher up would let a reader change *which* project while looking at its settings, and two ways to say which one is being configured eventually disagree. The heading names the project and prints its root, so the scope is visible without being changeable — and app settings say *This workbench* in the same slot, because that is what they reach |
 | 30 | **Each scope has a landing screen listing its own sections** | The rail lists section names; a name like *Scope & ignore* only means something with a line beside it. The landing screen is that line, and it is also what a scope's route can honestly show while every section is still on the backlog. `SettingsScreen` renders both scopes — the scope is the only thing that differs, and a second copy would be a second answer to "what can be configured here" |
+| 31 | **The root is shown, not edited** | `PATCH /projects/:id` can re-point a project, and *General* still prints the root as a read-only mount. A root is what makes a project *that* repository: moving it under the same entry would keep the name, the settings and the last run's summary while every one of them now describes something else. Removing and adding again says that plainly, costs a registry row, and touches nothing on disk. What the field is for is the opposite problem — an absolute server-side path is the one thing a reader of a web UI cannot see (decision 24), so it is worth printing where it can be read and copied |
+| 32 | **One config store behind every project section** | The revision *General* edits is the revision *Analyze / run* shows and the one *Scope & ignore* sits beside; `config.svelte` holds it once, keyed on the project it belongs to, so the sections are screens over one document rather than seven copies drifting apart. Keyed, because the workbench can be pointed at another project while a section is open — a revision read under one project must never be saved under another. It holds what the server answers rather than what was sent, since the server normalises on the way in |
+| 33 | **A section saves the two documents behind it as one screen** | *General* edits the display name, which is the registry entry, and the revision and history limit, which are the project's config — two endpoints, because the root has to stay unique across projects and the config is not the place that can promise that. `general.ts` turns the form into whichever halves changed, so an untouched half is not sent, and identity goes first: a config write that fails then leaves a screen whose own heading is still right |
 
 ## 7. Quality & Risks
 
@@ -114,14 +118,14 @@ what more than one screen uses moves up into `lib/components/`.
 - **Debt:** *Add project* should land on *Project settings → Analyze / run* for
   the first analysis; that screen is not built, so the switcher carries the run
   itself (decision 24) and the entry moves the day the screen exists.
-- **Debt:** a project can be registered and removed from the switcher but not
-  renamed or re-pointed — `PATCH /projects/:id` is wired on the server and
-  waits for *Project settings → General*.
-- **Debt:** the settings area is a frame with nothing inside it yet: every
-  section is listed and inert, so `/settings/project` and `/settings/app` are
-  landing screens only. Each section is its own issue, and the day one lands it
-  becomes `ready` in `sections.ts` and the rail links to it — nothing else in
-  the shell has to change.
+- **Debt:** every settings section but *Project settings → General* is still
+  listed and inert, so `/settings/app` is a landing screen only. Each section
+  is its own issue, and the day one lands it becomes `ready` in `sections.ts`
+  and the rail links to it — nothing else in the shell has to change.
+- **Decision:** re-pointing a project at another path is deliberately not
+  offered (decision 31), so the `root` half of `PATCH /projects/:id` is wired
+  through `lib/api` and the registry store but nothing in the UI sends it. It
+  stays because the store has to re-point the analysis if it ever does.
 - **Debt:** a treemap draws the top ~50 files; the rest of the ranking is only
   in the table. A zoom or a directory roll-up is the fix if it starts to bite.
 - **Decision:** the graph summary (nodes, edges, cycles, fan-in) is read, not
@@ -159,11 +163,22 @@ what more than one screen uses moves up into `lib/components/`.
   nav's active entry and its planned ones, the run summary's fold, the rail,
   the header's breadcrumb and *Re-analyze*, and the frame itself), the project
   registry (its rows, the project label, the store's selection, adoption after
-  a reload, add, remove and the fold of a finished run) with the switcher end
-  to end, the settings shell (the scope a path is in, each scope's sections and
+  a reload, add, rename, re-point, remove and the fold of a finished run) with
+  the switcher end
+  to end, the settings shell (the scope a path is in, each scope's sections,
+  which of them are built and
   that every one of them stays inside its scope, the scoped heading with and
   without a project, the rail in settings mode — both orientations — and the
-  two landing routes), the plugin store's load-once, the overview's pure layer (the six
+  two landing routes), the project config store (load-once per project, the
+  supersede when the workbench moves, and that a save holds the server's
+  answer and a refused one changes nothing), the *General* form's pure layer
+  (the stored values in, only the halves and fields that changed out, a blank
+  limit as the whole history, and each rule it refuses) with the screen end to
+  end — the values it opens on, the root as a read-only mount, nothing to save
+  until an edit, a rename through the registry, the window through the config,
+  a bad limit answered without a round-trip, a refusal from the server, discard,
+  no project, and a config that could not be read — and its
+  route, the plugin store's load-once, the overview's pure layer (the six
   cards' order, values, tones and links, a clean report reading as *none*, bar
   shares held against the whole ranking, change types grouped and tied by name,
   and dead code counted per finding *and* per file) with its views — the stat

--- a/apps/web/src/lib/api/index.ts
+++ b/apps/web/src/lib/api/index.ts
@@ -4,6 +4,12 @@ export { browseDirectory } from './browse';
 export { clearCache } from './cache';
 export { fetchHealth } from './health';
 export { fetchPlugins } from './plugins';
-export { addProject, fetchProjects, removeProject } from './projects';
+export { fetchProjectConfig, updateProjectConfig } from './project-config';
+export {
+  addProject,
+  fetchProjects,
+  removeProject,
+  updateProject,
+} from './projects';
 export { ApiError, apiRequest } from './request';
 export type * from './types';

--- a/apps/web/src/lib/api/project-config.ts
+++ b/apps/web/src/lib/api/project-config.ts
@@ -1,0 +1,35 @@
+import { apiRequest } from './request';
+import type { ProjectConfig, ProjectConfigPatch } from './types';
+
+/**
+ * `GET /projects/:id/config` — what an analysis of this project does. The
+ * server merges the stored (sparse) settings with its defaults, so what comes
+ * back is a whole config whichever fields were ever set.
+ */
+export function fetchProjectConfig(
+  id: string,
+  signal?: AbortSignal,
+): Promise<ProjectConfig> {
+  return apiRequest<ProjectConfig>(
+    `/projects/${encodeURIComponent(id)}/config`,
+    { signal },
+  );
+}
+
+/**
+ * `PATCH /projects/:id/config` — merge a patch and answer with the config as
+ * it now stands. The server normalises what it stores (trims, drops blanks,
+ * collapses duplicates), so its answer is the value to hold, not the patch.
+ * Fails with 400 on an empty patch or a value it cannot store, 404 for an
+ * unknown id.
+ */
+export function updateProjectConfig(
+  id: string,
+  patch: ProjectConfigPatch,
+  signal?: AbortSignal,
+): Promise<ProjectConfig> {
+  return apiRequest<ProjectConfig>(
+    `/projects/${encodeURIComponent(id)}/config`,
+    { method: 'PATCH', body: patch, signal },
+  );
+}

--- a/apps/web/src/lib/api/projects.ts
+++ b/apps/web/src/lib/api/projects.ts
@@ -4,6 +4,7 @@ import type {
   Project,
   ProjectsResponse,
   RemoveProjectResponse,
+  UpdateProjectRequest,
 } from './types';
 
 /** `GET /projects` — the registry, oldest registration first. */
@@ -22,6 +23,24 @@ export function addProject(
   return apiRequest<Project>('/projects', {
     method: 'POST',
     body: request,
+    signal,
+  });
+}
+
+/**
+ * `PATCH /projects/:id` — rename a project, or re-point it at another
+ * repository. Identity only; what an analysis of it *does* is its config.
+ * Fails with 400 on an empty patch or a path outside a repository, 404 for an
+ * unknown id and 409 when another project already holds the root.
+ */
+export function updateProject(
+  id: string,
+  update: UpdateProjectRequest,
+  signal?: AbortSignal,
+): Promise<Project> {
+  return apiRequest<Project>(`/projects/${encodeURIComponent(id)}`, {
+    method: 'PATCH',
+    body: update,
     signal,
   });
 }

--- a/apps/web/src/lib/api/request.ts
+++ b/apps/web/src/lib/api/request.ts
@@ -15,7 +15,7 @@ export class ApiError extends Error {
 }
 
 interface RequestOptions {
-  method?: 'GET' | 'POST' | 'DELETE';
+  method?: 'GET' | 'POST' | 'PATCH' | 'DELETE';
   /** Serialised as JSON; sets the content-type. */
   body?: unknown;
   signal?: AbortSignal;

--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -97,9 +97,60 @@ export interface AddProjectRequest {
   root: string;
 }
 
+/**
+ * What *Project settings → General* sends. Both fields are optional and a
+ * field left out keeps its value; the server refuses a patch that names
+ * neither.
+ */
+export interface UpdateProjectRequest {
+  name?: string;
+  root?: string;
+}
+
 export interface RemoveProjectResponse {
   removed: boolean;
 }
+
+/** One architecture fitness rule: `from` may not import `to`. */
+export interface ArchitectureRule {
+  /** Path glob the rule constrains, e.g. `src/ui/**`. */
+  from: string;
+  /** Path glob it may not reach, e.g. `src/db/**`. */
+  to: string;
+  /** Enforced rules are meant to fail a CI gate; the rest only report. */
+  enforced: boolean;
+}
+
+/**
+ * What an analysis of one project *does* — everything the *Project settings*
+ * sections configure except identity, which belongs to the registry entry.
+ * The server stores it sparsely and answers with the defaults filled in, so
+ * every field here always has a value.
+ */
+export interface ProjectConfig {
+  /** Revision to analyse; `HEAD` follows whatever is checked out. */
+  rev: string;
+  /** Cap on the history window, in commits; `null` for the whole history. */
+  historyLimit: number | null;
+  /** Globs excluded from the analysis. */
+  ignore: string[];
+  /** Repo-relative paths to analyse; empty means the whole repository. */
+  paths: string[];
+  /** Ids of the language plugins that may run, or `null` for every one. */
+  languages: string[] | null;
+  /** Ids of the git-metric plugins that may run, or `null` for all of them. */
+  metrics: string[] | null;
+  /** Id of the commit-convention plugin to parse with, or `null` for the first. */
+  convention: string | null;
+  rules: ArchitectureRule[];
+}
+
+/**
+ * A partial update. A field left out keeps its value and one that is sent
+ * replaces it whole — an array field is the new list, not an addition to the
+ * old one — so a screen can send back exactly what it shows.
+ */
+export type ProjectConfigPatch = Partial<ProjectConfig>;
 
 /** One subdirectory, as the folder picker lists it. */
 export interface DirectoryEntry {

--- a/apps/web/src/lib/projects/store.svelte.ts
+++ b/apps/web/src/lib/projects/store.svelte.ts
@@ -4,9 +4,11 @@ import {
   ApiError,
   fetchProjects,
   removeProject,
+  updateProject,
   type AddProjectRequest,
   type AnalysisReport,
   type Project,
+  type UpdateProjectRequest,
 } from '$lib/api';
 import { readSelection, storeSelection } from './selection';
 
@@ -89,6 +91,26 @@ export class ProjectsStore {
     this.#projects = [...this.#projects, project];
     this.select(project.id);
     return project;
+  }
+
+  /**
+   * Rename a project, or re-point it — what *Project settings → General*
+   * writes. The entry the server hands back replaces the one held here, so the
+   * switcher and the settings heading are renamed by the same round-trip.
+   *
+   * A root that moved re-points the analysis too: the report on screen
+   * describes the repository that was analysed, and `analysis.select` drops it
+   * for the same reason picking another project does. Throws what the server
+   * said — an unknown id, a path outside a repository, a root another project
+   * already holds — for the form to show next to the field.
+   */
+  async update(id: string, input: UpdateProjectRequest): Promise<Project> {
+    const updated = await updateProject(id, input);
+    this.#projects = this.#projects.map((project) =>
+      project.id === id ? updated : project,
+    );
+    if (this.#selected === id) analysis.select(updated.root);
+    return updated;
   }
 
   /**

--- a/apps/web/src/lib/projects/store.test.ts
+++ b/apps/web/src/lib/projects/store.test.ts
@@ -155,6 +155,31 @@ describe('projects store', () => {
     expect(store.projects).toHaveLength(2);
   });
 
+  it('renames a project to what the registry kept', async () => {
+    const store = await loaded({
+      'PATCH /projects/strata': { ...strata, name: 'Strata core' },
+    });
+    store.select('strata');
+
+    await store.update('strata', { name: 'Strata core' });
+
+    expect(store.current?.name).toBe('Strata core');
+    // A rename is identity only: the repository it points at is untouched.
+    expect(analysis.root).toBe('/home/dev/workspace/strata');
+  });
+
+  it('re-points the workbench when the selected project moves', async () => {
+    const store = await loaded({
+      'PATCH /projects/strata': { ...strata, root: '/mnt/repos/strata' },
+    });
+    store.select('strata');
+
+    await store.update('strata', { root: '/mnt/repos/strata' });
+
+    expect(store.current?.root).toBe('/mnt/repos/strata');
+    expect(analysis.root).toBe('/mnt/repos/strata');
+  });
+
   it('removes the selected project and points the workbench at nothing', async () => {
     const store = await loaded({
       'DELETE /projects/kernel': { removed: true },

--- a/apps/web/src/lib/settings/GeneralScreen.svelte
+++ b/apps/web/src/lib/settings/GeneralScreen.svelte
@@ -1,0 +1,268 @@
+<script lang="ts">
+  import { ApiError } from '$lib/api';
+  import Card from '$lib/components/Card.svelte';
+  import { projects as registry, type ProjectsStore } from '$lib/projects';
+  import {
+    projectConfig as store,
+    type ProjectConfigStore,
+  } from './config.svelte';
+  import {
+    checkGeneral,
+    generalChanged,
+    generalForm,
+    NAME_MAX,
+    type GeneralForm,
+  } from './general';
+
+  /**
+   * *Project settings → General*: what the open project is called, where it is
+   * mounted, and the window an analysis of it reads.
+   *
+   * The four values live in two places — the name is the registry entry, the
+   * revision and the history limit are the project's config — so a save is two
+   * requests, and only for the half that changed. The reader is told about one
+   * screen, not about that split.
+   */
+
+  interface Props {
+    /** The registry. Defaults to the app's, as the switcher's does. */
+    projects?: ProjectsStore;
+    /** The open project's config. Defaults to the app's. */
+    config?: ProjectConfigStore;
+  }
+
+  let { projects = registry, config = store }: Props = $props();
+
+  let form = $state<GeneralForm>({ name: '', rev: '', historyLimit: '' });
+  let busy = $state(false);
+  let error = $state('');
+  let notice = $state('');
+
+  // Mounted without the frame — in a test, or on a direct load — the screen
+  // still finds the project it is scoped to, and its config.
+  $effect(() => {
+    projects.load();
+  });
+
+  let project = $derived(projects.current);
+
+  $effect(() => {
+    if (project) config.load(project.id);
+  });
+
+  // Only the config that belongs to the open project: the workbench can be
+  // pointed elsewhere while this screen is up, and a revision read under one
+  // project must never be saved under another.
+  let stored = $derived(
+    project && config.config && config.projectId === project.id
+      ? config.config
+      : null,
+  );
+  let saved = $derived(project && stored ? generalForm(project, stored) : null);
+  let dirty = $derived(saved !== null && generalChanged(form, saved));
+  // An error belongs to the project it was raised for: switching project asks
+  // again, and the old failure must not be what the new one is described by.
+  let failed = $derived(
+    config.status === 'error' && config.projectId === project?.id,
+  );
+
+  // Seed the fields from what is stored, and re-seed whenever that changes
+  // underneath — a save included, so the form shows what the server kept
+  // rather than what was typed at it.
+  $effect(() => {
+    if (saved) form = { ...saved };
+  });
+
+  // Any edit retires the last save's confirmation; it described the values
+  // that were sent, and those are no longer what is on screen.
+  $effect(() => {
+    if (dirty) notice = '';
+  });
+
+  async function submit(): Promise<void> {
+    if (!project || !saved) return;
+
+    const check = checkGeneral(form, saved);
+    if (!check.ok) {
+      error = check.error;
+      notice = '';
+      return;
+    }
+
+    const { identity, config: patch } = check.patch;
+    if (!identity && !patch) {
+      error = '';
+      return;
+    }
+
+    busy = true;
+    error = '';
+    try {
+      // Identity first: it is the half the rail and the switcher show, so a
+      // config write that fails still leaves a screen whose heading is right.
+      if (identity) await projects.update(project.id, identity);
+      if (patch) await config.save(project.id, patch);
+      notice = 'Saved.';
+    } catch (err) {
+      // The server owns the rules — a name already taken, a revision it cannot
+      // store — so its message is the one worth showing.
+      error = err instanceof ApiError ? err.message : 'Unexpected client error.';
+      notice = '';
+    } finally {
+      busy = false;
+    }
+  }
+</script>
+
+<svelte:head>
+  <title>General · Project settings · Strata</title>
+</svelte:head>
+
+<div class="max-w-3xl">
+  <header class="mb-8">
+    <h1 class="text-2xl font-semibold">General</h1>
+    <p class="text-muted mt-1 text-sm">
+      What this project is called, where it is mounted, and the slice of history
+      every analysis of it reads.
+    </p>
+  </header>
+
+  {#if !project}
+    <p class="text-muted text-sm">
+      These settings belong to one repository — pick a project in the switcher,
+      or add one, first.
+    </p>
+  {:else if failed}
+    {@const id = project.id}
+    <p class="text-danger text-sm">{config.error}</p>
+    <button
+      type="button"
+      class="border-line bg-surface hover:bg-elevated mt-3 rounded-md border px-3 py-1.5 text-xs font-medium transition-colors"
+      onclick={() => void config.reload(id)}
+    >
+      Try again
+    </button>
+  {:else if !saved}
+    <p class="text-muted text-sm">Reading this project's settings…</p>
+  {:else}
+    <form
+      class="space-y-6"
+      onsubmit={(event) => {
+        event.preventDefault();
+        void submit();
+      }}
+    >
+      <Card title="Identity" hint="registered project">
+        <div class="space-y-4">
+          <label class="block">
+            <span class="text-subtle mb-1 block text-xs">Display name</span>
+            <input
+              class="border-line bg-bg text-ink placeholder:text-subtle w-full rounded-md border px-2 py-1.5 text-sm"
+              type="text"
+              name="name"
+              autocomplete="off"
+              maxlength={NAME_MAX}
+              bind:value={form.name}
+            />
+            <span class="text-subtle mt-1 block text-[0.6875rem]">
+              What the switcher, the breadcrumb and this heading call the
+              project. It renames nothing on disk.
+            </span>
+          </label>
+
+          <div>
+            <span class="text-subtle mb-1 block text-xs" id="general-root">
+              Repository root
+            </span>
+            <input
+              class="border-line bg-elevated text-muted w-full cursor-default rounded-md border px-2 py-1.5 font-mono text-xs"
+              type="text"
+              name="root"
+              aria-labelledby="general-root"
+              readonly
+              spellcheck="false"
+              value={project.root}
+            />
+            <span class="text-subtle mt-1 block text-[0.6875rem]">
+              Where the working tree sits on the machine running the server —
+              the mount Strata reads, and only ever reads. To point Strata at a
+              different path, remove the project and add it again.
+            </span>
+          </div>
+        </div>
+      </Card>
+
+      <Card title="Analysis window" hint="every run over this project">
+        <div class="space-y-4">
+          <label class="block">
+            <span class="text-subtle mb-1 block text-xs">Revision</span>
+            <input
+              class="border-line bg-bg text-ink placeholder:text-subtle w-full rounded-md border px-2 py-1.5 font-mono text-xs"
+              type="text"
+              name="rev"
+              autocomplete="off"
+              spellcheck="false"
+              placeholder="HEAD"
+              bind:value={form.rev}
+            />
+            <span class="text-subtle mt-1 block text-[0.6875rem]">
+              A branch, tag or commit sha. <code class="font-mono">HEAD</code>
+              follows whatever is checked out in the working tree.
+            </span>
+          </label>
+
+          <label class="block">
+            <span class="text-subtle mb-1 block text-xs">History limit</span>
+            <input
+              class="border-line bg-bg text-ink placeholder:text-subtle w-full rounded-md border px-2 py-1.5 font-mono text-xs sm:w-48"
+              type="text"
+              name="historyLimit"
+              inputmode="numeric"
+              autocomplete="off"
+              placeholder="Whole history"
+              bind:value={form.historyLimit}
+            />
+            <span class="text-subtle mt-1 block text-[0.6875rem]">
+              How many commits back churn and the commit analytics are read.
+              Leave it blank for the whole history; a cap keeps a first run over
+              a long-lived repository short.
+            </span>
+          </label>
+        </div>
+      </Card>
+
+      {#if error}
+        <p class="text-danger text-sm" role="alert">{error}</p>
+      {/if}
+
+      <div class="flex items-center gap-3">
+        <button
+          type="submit"
+          class="bg-accent text-accent-ink hover:bg-accent-strong rounded-md px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-60"
+          disabled={busy || !dirty}
+        >
+          {busy ? 'Saving…' : 'Save changes'}
+        </button>
+        <button
+          type="button"
+          class="text-muted hover:bg-elevated rounded-md px-3 py-1.5 text-sm transition-colors disabled:opacity-60"
+          disabled={busy || !dirty}
+          onclick={() => {
+            if (saved) form = { ...saved };
+            error = '';
+          }}
+        >
+          Discard
+        </button>
+        {#if notice}
+          <p class="text-ok text-xs" role="status">{notice}</p>
+        {/if}
+      </div>
+
+      <p class="text-subtle text-[0.6875rem]">
+        The revision and the limit are what a run uses unless the request names
+        its own — <em>Re-analyze</em> and a headless run both read them.
+      </p>
+    </form>
+  {/if}
+</div>

--- a/apps/web/src/lib/settings/GeneralScreen.test.ts
+++ b/apps/web/src/lib/settings/GeneralScreen.test.ts
@@ -1,0 +1,277 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { analysis } from '$lib/analysis';
+import type { Project, ProjectConfig } from '$lib/api';
+import { ProjectsStore, SELECTION_STORAGE_KEY } from '$lib/projects';
+import { stubApi } from '$lib/test/api';
+import { render } from '$lib/test/render';
+import { ProjectConfigStore } from './config.svelte';
+import GeneralScreen from './GeneralScreen.svelte';
+
+/**
+ * The *General* section end to end, against a stubbed API. Each test gets its
+ * own registry and config store; the analysis store the registry points is the
+ * app's single instance, so that one is cleared first.
+ */
+
+const strata: Project = {
+  id: 'strata',
+  name: 'Strata',
+  root: '/home/dev/workspace/strata',
+  addedAt: '2026-08-01T09:00:00.000Z',
+  lastAnalysis: null,
+};
+
+const config: ProjectConfig = {
+  rev: 'HEAD',
+  historyLimit: null,
+  ignore: [],
+  paths: [],
+  languages: null,
+  metrics: null,
+  convention: null,
+  rules: [],
+};
+
+const field = (container: HTMLElement, name: string) =>
+  container.querySelector<HTMLInputElement>(`input[name="${name}"]`)!;
+
+const button = (container: HTMLElement, text: string) =>
+  [...container.querySelectorAll('button')].find((element) =>
+    element.textContent?.includes(text),
+  )!;
+
+/** What the form is refusing to send, or what the server said about it. */
+const alert = (container: HTMLElement) =>
+  container.querySelector('[role="alert"]')?.textContent ?? '';
+
+/** Type into a field, as a reader would. */
+function type(container: HTMLElement, name: string, value: string): void {
+  const input = field(container, name);
+  input.value = value;
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+function save(container: HTMLElement): void {
+  container
+    .querySelector('form')!
+    .dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+}
+
+/** Mount the screen over a registry and a config, and let both arrive. */
+async function open(
+  routes: Record<string, unknown> = {},
+  registered: Project[] = [strata],
+) {
+  const first = registered[0];
+  if (first) localStorage.setItem(SELECTION_STORAGE_KEY, first.id);
+  const fetchMock = stubApi({
+    '/projects': { projects: registered },
+    '/projects/strata/config': config,
+    ...routes,
+  });
+  const projects = new ProjectsStore();
+  const configStore = new ProjectConfigStore();
+  const ui = render(GeneralScreen, { projects, config: configStore });
+
+  await vi.waitFor(() => {
+    expect(projects.status).toBe('ready');
+  });
+  return { ui, projects, config: configStore, fetchMock };
+}
+
+let ui: ReturnType<typeof render>;
+
+beforeEach(() => {
+  analysis.select('');
+  localStorage.clear();
+});
+
+afterEach(() => {
+  ui?.destroy();
+  vi.unstubAllGlobals();
+  localStorage.clear();
+});
+
+describe('GeneralScreen', () => {
+  it('shows the project as the registry and its config have it', async () => {
+    const opened = await open();
+    ui = opened.ui;
+
+    await vi.waitFor(() => {
+      expect(field(ui.container, 'name').value).toBe('Strata');
+    });
+    expect(field(ui.container, 'root').value).toBe('/home/dev/workspace/strata');
+    expect(field(ui.container, 'rev').value).toBe('HEAD');
+    // The whole history is an empty box, with the placeholder saying so.
+    expect(field(ui.container, 'historyLimit').value).toBe('');
+  });
+
+  it('shows the root as a mount, not as a field', async () => {
+    const opened = await open();
+    ui = opened.ui;
+
+    await vi.waitFor(() => {
+      expect(field(ui.container, 'root')).toBeTruthy();
+    });
+    expect(field(ui.container, 'root').readOnly).toBe(true);
+  });
+
+  it('offers nothing to save until something is edited', async () => {
+    const opened = await open();
+    ui = opened.ui;
+
+    await vi.waitFor(() => {
+      expect(button(ui.container, 'Save changes')).toBeTruthy();
+    });
+    expect(button(ui.container, 'Save changes').disabled).toBe(true);
+
+    type(ui.container, 'rev', 'main');
+
+    await vi.waitFor(() => {
+      expect(button(ui.container, 'Save changes').disabled).toBe(false);
+    });
+  });
+
+  it('renames the project through the registry', async () => {
+    const opened = await open({
+      'PATCH /projects/strata': { ...strata, name: 'Strata core' },
+    });
+    ui = opened.ui;
+    await vi.waitFor(() => {
+      expect(field(ui.container, 'name').value).toBe('Strata');
+    });
+
+    type(ui.container, 'name', 'Strata core');
+    save(ui.container);
+
+    await vi.waitFor(() => {
+      expect(opened.projects.current?.name).toBe('Strata core');
+    });
+    // The name is registry-side, so the config was left alone.
+    expect(opened.fetchMock).not.toHaveBeenCalledWith(
+      expect.stringContaining('/projects/strata/config'),
+      expect.objectContaining({ method: 'PATCH' }),
+    );
+  });
+
+  it('writes the revision and the limit to the project config', async () => {
+    const saved = { ...config, rev: 'main', historyLimit: 500 };
+    const opened = await open({ 'PATCH /projects/strata/config': saved });
+    ui = opened.ui;
+    await vi.waitFor(() => {
+      expect(field(ui.container, 'rev').value).toBe('HEAD');
+    });
+
+    type(ui.container, 'rev', 'main');
+    type(ui.container, 'historyLimit', '500');
+    save(ui.container);
+
+    await vi.waitFor(() => {
+      expect(opened.config.config?.historyLimit).toBe(500);
+    });
+    expect(opened.config.config?.rev).toBe('main');
+    expect(ui.container.textContent).toContain('Saved.');
+  });
+
+  it('sends the whole history as no limit at all', async () => {
+    // A project that has a limit today, whose box the reader clears.
+    const opened = await open({
+      '/projects/strata/config': { ...config, historyLimit: 500 },
+      'PATCH /projects/strata/config': config,
+    });
+    ui = opened.ui;
+    await vi.waitFor(() => {
+      expect(field(ui.container, 'historyLimit').value).toBe('500');
+    });
+
+    type(ui.container, 'historyLimit', '');
+    save(ui.container);
+
+    const body = JSON.stringify({ historyLimit: null });
+    await vi.waitFor(() => {
+      expect(opened.fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining('/projects/strata/config'),
+        expect.objectContaining({ body }),
+      );
+    });
+  });
+
+  it('answers a limit that is not a count without asking the server', async () => {
+    const opened = await open();
+    ui = opened.ui;
+    await vi.waitFor(() => {
+      expect(field(ui.container, 'historyLimit')).toBeTruthy();
+    });
+    const calls = opened.fetchMock.mock.calls.length;
+
+    type(ui.container, 'historyLimit', 'lots');
+    save(ui.container);
+
+    await vi.waitFor(() => {
+      expect(alert(ui.container)).toContain('whole number of commits');
+    });
+    expect(opened.fetchMock.mock.calls.length).toBe(calls);
+  });
+
+  it('shows what the server refused', async () => {
+    const opened = await open({
+      'PATCH /projects/strata': Response.json(
+        { message: 'No project "strata".' },
+        { status: 404 },
+      ),
+    });
+    ui = opened.ui;
+    await vi.waitFor(() => {
+      expect(field(ui.container, 'name').value).toBe('Strata');
+    });
+
+    type(ui.container, 'name', 'Gone');
+    save(ui.container);
+
+    await vi.waitFor(() => {
+      expect(alert(ui.container)).toContain('No project');
+    });
+    expect(opened.projects.current?.name).toBe('Strata');
+  });
+
+  it('puts the fields back the way they are stored', async () => {
+    const opened = await open();
+    ui = opened.ui;
+    await vi.waitFor(() => {
+      expect(field(ui.container, 'rev').value).toBe('HEAD');
+    });
+
+    type(ui.container, 'rev', 'main');
+    await vi.waitFor(() => {
+      expect(button(ui.container, 'Discard').disabled).toBe(false);
+    });
+    button(ui.container, 'Discard').click();
+
+    await vi.waitFor(() => {
+      expect(field(ui.container, 'rev').value).toBe('HEAD');
+    });
+  });
+
+  it('says there is nothing to configure without a project', async () => {
+    const opened = await open({}, []);
+    ui = opened.ui;
+
+    expect(ui.container.textContent).toContain('pick a project');
+    expect(ui.container.querySelector('form')).toBeNull();
+  });
+
+  it('surfaces a config it could not read, and offers the retry', async () => {
+    const opened = await open({
+      '/projects/strata/config': Response.json(
+        { message: 'projects.db is not readable.' },
+        { status: 500 },
+      ),
+    });
+    ui = opened.ui;
+
+    await vi.waitFor(() => {
+      expect(ui.container.textContent).toContain('not readable');
+    });
+    expect(button(ui.container, 'Try again')).toBeTruthy();
+  });
+});

--- a/apps/web/src/lib/settings/SettingsNav.test.ts
+++ b/apps/web/src/lib/settings/SettingsNav.test.ts
@@ -95,12 +95,29 @@ describe('SettingsNav', () => {
     expect(text).not.toContain('AI providers');
   });
 
-  it('shows a section that is not built yet without linking to it', async () => {
+  it('links to a section that is built', async () => {
     ui = await mount({ scope: 'project', pathname: '/settings/project' });
 
     const general = link(ui, 'General');
-    expect(general?.tagName).toBe('SPAN');
-    expect(general?.getAttribute('aria-disabled')).toBe('true');
+    expect(general?.tagName).toBe('A');
+    expect(general?.getAttribute('href')).toBe('/settings/project/general');
+  });
+
+  it('shows a section that is not built yet without linking to it', async () => {
+    ui = await mount({ scope: 'project', pathname: '/settings/project' });
+
+    const danger = link(ui, 'Danger zone');
+    expect(danger?.tagName).toBe('SPAN');
+    expect(danger?.getAttribute('aria-disabled')).toBe('true');
+  });
+
+  it('marks the section the reader is inside as the current one', async () => {
+    ui = await mount({
+      scope: 'project',
+      pathname: '/settings/project/general',
+    });
+
+    expect(link(ui, 'General')?.getAttribute('aria-current')).toBe('page');
   });
 
   it('lays the same two things across on a narrow screen', async () => {

--- a/apps/web/src/lib/settings/config.svelte.ts
+++ b/apps/web/src/lib/settings/config.svelte.ts
@@ -1,0 +1,101 @@
+import {
+  ApiError,
+  fetchProjectConfig,
+  updateProjectConfig,
+  type ProjectConfig,
+  type ProjectConfigPatch,
+} from '$lib/api';
+
+export type ProjectConfigStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+/**
+ * What an analysis of the open project does — the settings behind every
+ * *Project settings* section but identity, which is the registry entry the
+ * switcher already holds.
+ *
+ * One config, held for the app: the sections are separate screens over the
+ * same document, so *General* and *Scope & ignore* must not each keep their
+ * own copy of the revision. It is keyed on the project it belongs to, because
+ * the workbench can be pointed somewhere else while a screen is open.
+ *
+ * Exported as a class as well as the singleton below: a test wants its own
+ * instance, the app wants one.
+ */
+export class ProjectConfigStore {
+  #status = $state<ProjectConfigStatus>('idle');
+  #config = $state<ProjectConfig | null>(null);
+  #error = $state('');
+  #project = $state<string | null>(null);
+  /** Lets a superseded load drop its result instead of overwriting a newer one. */
+  #run = 0;
+
+  get status(): ProjectConfigStatus {
+    return this.#status;
+  }
+
+  /** The config held, or `null` until one has arrived. */
+  get config(): ProjectConfig | null {
+    return this.#config;
+  }
+
+  get error(): string {
+    return this.#error;
+  }
+
+  /** Whose config this is — a screen reads it before trusting `config`. */
+  get projectId(): string | null {
+    return this.#project;
+  }
+
+  /**
+   * Load a project's config once. Safe to call from every section that mounts;
+   * a different project supersedes whatever is held, because a config read
+   * under one project must never be shown — or saved — under another.
+   */
+  load(id: string): void {
+    if (this.#project === id && this.#status !== 'idle') return;
+    void this.reload(id);
+  }
+
+  async reload(id: string): Promise<void> {
+    const run = ++this.#run;
+    this.#project = id;
+    this.#status = 'loading';
+    this.#config = null;
+    this.#error = '';
+    try {
+      const config = await fetchProjectConfig(id);
+      if (run !== this.#run) return;
+      this.#config = config;
+      this.#status = 'ready';
+    } catch (err) {
+      if (run !== this.#run) return;
+      this.#error = message(err);
+      this.#status = 'error';
+    }
+  }
+
+  /**
+   * Write a patch and hold what came back. The server normalises what it
+   * stores, so its answer is the config — holding the patch instead would show
+   * the reader their own input rather than the setting. Throws for the form to
+   * show; a rejected save leaves what is held untouched.
+   */
+  async save(id: string, patch: ProjectConfigPatch): Promise<ProjectConfig> {
+    const config = await updateProjectConfig(id, patch);
+    // A save that lands after the workbench moved on belongs to a project this
+    // store no longer holds; the write stands, the screen's copy does not.
+    if (this.#project === id) {
+      this.#config = config;
+      this.#error = '';
+      this.#status = 'ready';
+    }
+    return config;
+  }
+}
+
+function message(err: unknown): string {
+  return err instanceof ApiError ? err.message : 'Unexpected client error.';
+}
+
+export const projectConfig = new ProjectConfigStore();

--- a/apps/web/src/lib/settings/config.test.ts
+++ b/apps/web/src/lib/settings/config.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ProjectConfig } from '$lib/api';
+import { stubApi } from '$lib/test/api';
+import { ProjectConfigStore } from './config.svelte';
+
+/** The open project's config against a stubbed API. */
+
+const stored: ProjectConfig = {
+  rev: 'HEAD',
+  historyLimit: null,
+  ignore: [],
+  paths: [],
+  languages: null,
+  metrics: null,
+  convention: null,
+  rules: [],
+};
+
+const kernel: ProjectConfig = { ...stored, rev: 'main', historyLimit: 500 };
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('project config store', () => {
+  it('reads the config of the project it is given', async () => {
+    stubApi({ '/projects/strata/config': stored });
+    const store = new ProjectConfigStore();
+
+    await store.reload('strata');
+
+    expect(store.status).toBe('ready');
+    expect(store.projectId).toBe('strata');
+    expect(store.config).toEqual(stored);
+  });
+
+  it('loads once per project', async () => {
+    const fetchMock = stubApi({ '/projects/strata/config': stored });
+    const store = new ProjectConfigStore();
+
+    store.load('strata');
+    store.load('strata');
+    await vi.waitFor(() => {
+      expect(store.status).toBe('ready');
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops what it holds when the workbench moves to another project', async () => {
+    stubApi({
+      '/projects/strata/config': stored,
+      '/projects/kernel/config': kernel,
+    });
+    const store = new ProjectConfigStore();
+    await store.reload('strata');
+
+    store.load('kernel');
+    // Mid-flight the old project's config is already gone: showing it under
+    // the new project's name would be worse than showing nothing.
+    expect(store.config).toBeNull();
+    await vi.waitFor(() => {
+      expect(store.status).toBe('ready');
+    });
+
+    expect(store.projectId).toBe('kernel');
+    expect(store.config?.rev).toBe('main');
+  });
+
+  it('holds what the server kept, not what was sent', async () => {
+    stubApi({
+      '/projects/strata/config': stored,
+      // The server normalises on the way in; its answer is the config.
+      'PATCH /projects/strata/config': { ...stored, rev: 'main' },
+    });
+    const store = new ProjectConfigStore();
+    await store.reload('strata');
+
+    const saved = await store.save('strata', { rev: '  main  ' });
+
+    expect(saved.rev).toBe('main');
+    expect(store.config?.rev).toBe('main');
+  });
+
+  it('leaves what it holds alone when a save is refused', async () => {
+    stubApi({
+      '/projects/strata/config': stored,
+      'PATCH /projects/strata/config': Response.json(
+        { message: 'The revision cannot be blank.' },
+        { status: 400 },
+      ),
+    });
+    const store = new ProjectConfigStore();
+    await store.reload('strata');
+
+    await expect(store.save('strata', { rev: ' ' })).rejects.toThrow(
+      'cannot be blank',
+    );
+    expect(store.config).toEqual(stored);
+    expect(store.status).toBe('ready');
+  });
+
+  it('surfaces a config it cannot read', async () => {
+    stubApi({});
+    const store = new ProjectConfigStore();
+
+    await store.reload('gone');
+
+    expect(store.status).toBe('error');
+    expect(store.error).toBeTruthy();
+    expect(store.config).toBeNull();
+  });
+});

--- a/apps/web/src/lib/settings/general.test.ts
+++ b/apps/web/src/lib/settings/general.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+import {
+  checkGeneral,
+  generalChanged,
+  generalForm,
+  NAME_MAX,
+  type GeneralForm,
+} from './general';
+
+/**
+ * The *General* form's pure layer: stored values in, two patches out — or the
+ * reason a save cannot be sent.
+ */
+
+const project = { name: 'Strata' };
+
+const config = {
+  rev: 'HEAD',
+  historyLimit: null as number | null,
+};
+
+const saved: GeneralForm = generalForm(project, config);
+
+/** The stored form with one field edited. */
+const edited = (change: Partial<GeneralForm>): GeneralForm => ({
+  ...saved,
+  ...change,
+});
+
+describe('generalForm', () => {
+  it('takes the name from the registry and the window from the config', () => {
+    expect(generalForm({ name: 'Kernel' }, { rev: 'main', historyLimit: 500 }))
+      .toEqual({ name: 'Kernel', rev: 'main', historyLimit: '500' });
+  });
+
+  it('shows the whole history as an empty field', () => {
+    expect(saved.historyLimit).toBe('');
+  });
+});
+
+describe('generalChanged', () => {
+  it('is quiet until something is edited', () => {
+    expect(generalChanged(saved, saved)).toBe(false);
+  });
+
+  it('does not count whitespace a save would drop as an edit', () => {
+    expect(generalChanged(edited({ name: ' Strata ' }), saved)).toBe(false);
+  });
+
+  it('notices each field', () => {
+    expect(generalChanged(edited({ name: 'Strata core' }), saved)).toBe(true);
+    expect(generalChanged(edited({ rev: 'main' }), saved)).toBe(true);
+    expect(generalChanged(edited({ historyLimit: '500' }), saved)).toBe(true);
+  });
+});
+
+describe('checkGeneral', () => {
+  it('sends only the half that changed', () => {
+    const check = checkGeneral(edited({ name: 'Strata core' }), saved);
+
+    expect(check).toEqual({
+      ok: true,
+      patch: { identity: { name: 'Strata core' }, config: null },
+    });
+  });
+
+  it('sends only the fields that changed inside a half', () => {
+    const check = checkGeneral(edited({ rev: 'main' }), saved);
+
+    expect(check.ok && check.patch.config).toEqual({ rev: 'main' });
+    expect(check.ok && check.patch.identity).toBeNull();
+  });
+
+  it('sends both halves when both were edited', () => {
+    const check = checkGeneral(
+      edited({ name: 'Kernel', historyLimit: '500' }),
+      saved,
+    );
+
+    expect(check).toEqual({
+      ok: true,
+      patch: { identity: { name: 'Kernel' }, config: { historyLimit: 500 } },
+    });
+  });
+
+  it('sends nothing when the form still says what is stored', () => {
+    expect(checkGeneral(saved, saved)).toEqual({
+      ok: true,
+      patch: { identity: null, config: null },
+    });
+  });
+
+  it('trims what it sends', () => {
+    const check = checkGeneral(
+      edited({ name: '  Kernel  ', rev: '  main  ' }),
+      saved,
+    );
+
+    expect(check).toEqual({
+      ok: true,
+      patch: { identity: { name: 'Kernel' }, config: { rev: 'main' } },
+    });
+  });
+
+  it('reads a blank limit as the whole history', () => {
+    const stored = generalForm(project, { rev: 'HEAD', historyLimit: 500 });
+
+    const check = checkGeneral(edited({ ...stored, historyLimit: '' }), stored);
+
+    expect(check.ok && check.patch.config).toEqual({ historyLimit: null });
+  });
+
+  it('refuses a project with no name', () => {
+    const check = checkGeneral(edited({ name: '   ' }), saved);
+
+    expect(check.ok).toBe(false);
+    expect(!check.ok && check.error).toContain('display name');
+  });
+
+  it('refuses a name the registry would not store', () => {
+    const long = 'x'.repeat(NAME_MAX + 1);
+
+    const check = checkGeneral(edited({ name: long }), saved);
+
+    expect(check.ok).toBe(false);
+  });
+
+  it('refuses a blank revision', () => {
+    const check = checkGeneral(edited({ rev: ' ' }), saved);
+
+    expect(check.ok).toBe(false);
+    expect(!check.ok && check.error).toContain('revision');
+  });
+
+  it('refuses a limit that is not a whole number of commits', () => {
+    for (const historyLimit of ['0', '-5', '1.5', 'many', '1e3']) {
+      expect(checkGeneral(edited({ historyLimit }), saved).ok).toBe(false);
+    }
+  });
+});

--- a/apps/web/src/lib/settings/general.ts
+++ b/apps/web/src/lib/settings/general.ts
@@ -1,0 +1,130 @@
+import type {
+  Project,
+  ProjectConfig,
+  ProjectConfigPatch,
+  UpdateProjectRequest,
+} from '$lib/api';
+
+/**
+ * The *General* form: what a project is called, and the window an analysis of
+ * it reads. Everything here is a string, because that is what a field holds —
+ * "the whole history" is an empty box, not a number — and turning the boxes
+ * back into a patch is this module's whole job.
+ *
+ * The root is not among them: it is the mount the server resolved, shown and
+ * not edited (`ARCHITECTURE.md` decision 31).
+ */
+export interface GeneralForm {
+  name: string;
+  rev: string;
+  /** Blank means the whole history. */
+  historyLimit: string;
+}
+
+/**
+ * A save, split the way the server is: identity is the registry entry
+ * (`PATCH /projects/:id`), the rest is the project's config one level down.
+ * `null` is "this half did not change" — the server refuses a patch that
+ * names nothing, and rightly so.
+ */
+export interface GeneralPatch {
+  identity: UpdateProjectRequest | null;
+  config: ProjectConfigPatch | null;
+}
+
+export type GeneralCheck =
+  | { ok: true; patch: GeneralPatch }
+  | { ok: false; error: string };
+
+/** The longest display name the registry accepts. */
+export const NAME_MAX = 100;
+
+/** What the fields hold when the screen opens, and what a save resets them to. */
+export function generalForm(
+  project: Pick<Project, 'name'>,
+  config: Pick<ProjectConfig, 'rev' | 'historyLimit'>,
+): GeneralForm {
+  return {
+    name: project.name,
+    rev: config.rev,
+    historyLimit:
+      config.historyLimit === null ? '' : String(config.historyLimit),
+  };
+}
+
+/**
+ * Whether the form still says what is stored. Compared trimmed, so trailing
+ * whitespace is not an edit — it is not something a save would keep either.
+ */
+export function generalChanged(form: GeneralForm, saved: GeneralForm): boolean {
+  return (
+    form.name.trim() !== saved.name.trim() ||
+    form.rev.trim() !== saved.rev.trim() ||
+    form.historyLimit.trim() !== saved.historyLimit.trim()
+  );
+}
+
+/**
+ * Read the form against what is stored: either the two patches a save sends —
+ * holding only the fields that changed — or the first reason it cannot be
+ * sent. The rules are the server's own (a name and a revision cannot be blank,
+ * a limit is a whole number of commits); checking them here means a typo is
+ * answered under the field rather than by a round-trip.
+ */
+export function checkGeneral(
+  form: GeneralForm,
+  saved: GeneralForm,
+): GeneralCheck {
+  const name = form.name.trim();
+  if (!name) {
+    return { ok: false, error: 'Give the project a display name.' };
+  }
+  if (name.length > NAME_MAX) {
+    return {
+      ok: false,
+      error: `A display name is at most ${NAME_MAX} characters.`,
+    };
+  }
+
+  const rev = form.rev.trim();
+  if (!rev) {
+    return {
+      ok: false,
+      error:
+        'Name the revision to analyse — HEAD follows whatever is checked out.',
+    };
+  }
+
+  const limit = historyLimit(form.historyLimit);
+  if (limit === undefined) {
+    return {
+      ok: false,
+      error:
+        'The history limit is a whole number of commits, at least 1 — leave ' +
+        'it blank to read the whole history.',
+    };
+  }
+
+  const config: ProjectConfigPatch = {};
+  if (rev !== saved.rev) config.rev = rev;
+  if (form.historyLimit.trim() !== saved.historyLimit) {
+    config.historyLimit = limit;
+  }
+
+  return {
+    ok: true,
+    patch: {
+      identity: name === saved.name ? null : { name },
+      config: Object.keys(config).length > 0 ? config : null,
+    },
+  };
+}
+
+/** `null` for the whole history, `undefined` when the text is not a limit. */
+function historyLimit(text: string): number | null | undefined {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+  if (!/^\d+$/.test(trimmed)) return undefined;
+  const value = Number(trimmed);
+  return Number.isSafeInteger(value) && value >= 1 ? value : undefined;
+}

--- a/apps/web/src/lib/settings/index.ts
+++ b/apps/web/src/lib/settings/index.ts
@@ -1,5 +1,20 @@
+export { default as GeneralScreen } from './GeneralScreen.svelte';
 export { default as SettingsNav } from './SettingsNav.svelte';
 export { default as SettingsScreen } from './SettingsScreen.svelte';
+export {
+  projectConfig,
+  ProjectConfigStore,
+  type ProjectConfigStatus,
+} from './config.svelte';
+export {
+  checkGeneral,
+  generalChanged,
+  generalForm,
+  NAME_MAX,
+  type GeneralCheck,
+  type GeneralForm,
+  type GeneralPatch,
+} from './general';
 export { scopeHeading, type ScopeHeading } from './heading';
 export {
   APP_SECTIONS,

--- a/apps/web/src/lib/settings/sections.test.ts
+++ b/apps/web/src/lib/settings/sections.test.ts
@@ -39,10 +39,19 @@ describe('settings sections', () => {
     }
   });
 
-  it('says what each section holds, and none is built yet', () => {
+  it('says what each section holds', () => {
     for (const section of [...PROJECT_SECTIONS, ...APP_SECTIONS]) {
       expect(section.description.length).toBeGreaterThan(0);
-      expect(section.status).toBe('planned');
     }
+  });
+
+  it('marks the sections that are built, and only those', () => {
+    const ready = [...PROJECT_SECTIONS, ...APP_SECTIONS].filter(
+      (section) => section.status === 'ready',
+    );
+
+    expect(ready.map((section) => section.href)).toEqual([
+      '/settings/project/general',
+    ]);
   });
 });

--- a/apps/web/src/lib/settings/sections.ts
+++ b/apps/web/src/lib/settings/sections.ts
@@ -23,7 +23,7 @@ export const PROJECT_SECTIONS: readonly SettingsSection[] = [
     label: 'General',
     description:
       'Display name, the root it is mounted at, the revision to analyse and how far back the history is read.',
-    status: 'planned',
+    status: 'ready',
   },
   {
     href: '/settings/project/analyze',

--- a/apps/web/src/routes/settings/project/general/+page.svelte
+++ b/apps/web/src/routes/settings/project/general/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import { GeneralScreen } from '$lib/settings';
+</script>
+
+<!-- What the open project is called, where it is mounted, and the window
+     every analysis of it reads. -->
+<GeneralScreen />

--- a/apps/web/src/routes/settings/project/general/page.test.ts
+++ b/apps/web/src/routes/settings/project/general/page.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { analysis } from '$lib/analysis';
+import { projects, SELECTION_STORAGE_KEY } from '$lib/projects';
+import { stubApi } from '$lib/test/api';
+import { render } from '$lib/test/render';
+import Page from './+page.svelte';
+
+/**
+ * The route as the app mounts it: over the app-wide registry and the app-wide
+ * config store, with nothing handed in.
+ */
+
+const strata = {
+  id: 'strata',
+  name: 'Strata',
+  root: '/home/dev/workspace/strata',
+  addedAt: '2026-08-01T09:00:00.000Z',
+  lastAnalysis: null,
+};
+
+const config = {
+  rev: 'main',
+  historyLimit: 500,
+  ignore: [],
+  paths: [],
+  languages: null,
+  metrics: null,
+  convention: null,
+  rules: [],
+};
+
+let ui: ReturnType<typeof render>;
+
+beforeEach(async () => {
+  analysis.select('');
+  localStorage.setItem(SELECTION_STORAGE_KEY, 'strata');
+  stubApi({
+    '/projects': { projects: [strata] },
+    '/projects/strata/config': config,
+  });
+  await projects.reload();
+});
+
+afterEach(() => {
+  ui?.destroy();
+  vi.unstubAllGlobals();
+  localStorage.clear();
+});
+
+describe('project general settings page', () => {
+  it('opens on the project the workbench is pointed at', async () => {
+    ui = render(Page);
+
+    await vi.waitFor(() => {
+      const name = ui.container.querySelector<HTMLInputElement>(
+        'input[name="name"]',
+      );
+      expect(name?.value).toBe('Strata');
+    });
+
+    const value = (field: string) =>
+      ui.container.querySelector<HTMLInputElement>(`input[name="${field}"]`)
+        ?.value;
+    expect(value('root')).toBe('/home/dev/workspace/strata');
+    expect(value('rev')).toBe('main');
+    expect(value('historyLimit')).toBe('500');
+  });
+});

--- a/apps/web/src/routes/settings/project/page.test.ts
+++ b/apps/web/src/routes/settings/project/page.test.ts
@@ -53,12 +53,19 @@ describe('project settings page', () => {
     }
   });
 
-  it('links to no section that is not built yet', () => {
+  it('links to the sections that are built, and to no other', () => {
     ui = render(Page);
 
-    expect(ui.container.querySelectorAll('a')).toHaveLength(0);
+    const built = PROJECT_SECTIONS.filter(
+      (section) => section.status === 'ready',
+    );
+    expect(
+      [...ui.container.querySelectorAll('a')].map((link) =>
+        link.getAttribute('href'),
+      ),
+    ).toEqual(built.map((section) => section.href));
     expect(ui.container.querySelectorAll('[aria-disabled="true"]')).toHaveLength(
-      PROJECT_SECTIONS.length,
+      PROJECT_SECTIONS.length - built.length,
     );
   });
 });


### PR DESCRIPTION
## What

The first settings section with something in it: **Project settings → General**
at `/settings/project/general`, over the project the workbench is pointed at.

- *Identity* — **display name** (editable) and **repository root** (read-only
  mount).
- *Analysis window* — **revision** (`HEAD` by default) and **history limit**
  (blank = whole history).
- One *Save changes* / *Discard* pair, inert until something is actually
  edited, with the server's refusal shown under the form.

The four values live in two documents, so a save is two requests and only for
the half that was edited: the name is the registry entry (`PATCH /projects/:id`
— wired on the server since the registry landed, unreachable until now), the
revision and the limit are the project's config (`PATCH /projects/:id/config`),
which every run over that root already honours. So what this screen writes is
what *Re-analyze* and a headless run use. Identity goes first: a config write
that fails then leaves a screen whose own heading is still right.

Behind it: `lib/api/project-config` and `updateProject`, a `ProjectConfigStore`
keyed on the project (the remaining six project sections are screens over the
same document), `general.ts` as the form's pure layer, and
`ProjectsStore.update` — the rename `ARCHITECTURE.md` listed as debt.

The section flips to `ready` in `sections.ts` and the rail links to it; nothing
else in the shell changed, which is what that list was for.

## Why

Closes #76.

Two calls worth reviewing:

- **The root is shown, not edited**, though `PATCH /projects/:id` would take a
  new one. A root is what makes a project *that* repository — re-pointing an
  entry would keep its name, settings and last-run summary while all three now
  described something else. Remove-and-add-again says that plainly and costs a
  registry row. It is still printed, because an absolute server-side path is
  the one thing a reader of a web UI cannot see.
- **One config store per project, not per section.** The revision *General*
  edits is the one *Analyze / run* will show and *Scope & ignore* will sit
  beside; seven copies would drift. Keyed on the project, because the workbench
  can be pointed elsewhere while a section is open. It holds the server's
  answer rather than the patch, since the server normalises on the way in.

Recorded as decisions 31–33 in `apps/web/ARCHITECTURE.md`.

## Type of change

- [x] feat / fix / perf / refactor
- [ ] docs / test / build / ci / chore

## Checklist

- [x] `pnpm build && pnpm test && pnpm lint` pass locally (plus `svelte-check`,
      clean)
- [x] Added/updated tests where it made sense — the form's pure layer, the
      config store (load-once, supersede on a project switch, a refused save
      changing nothing), the screen end to end (opens on the stored values,
      root read-only, nothing to save until an edit, rename through the
      registry, window through the config, a bad limit answered without a
      round-trip, a server refusal, discard, no project, unreadable config) and
      the route. The three existing tests that asserted *General* was inert are
      updated.
- [x] Docs updated — `BACKLOG.md` ticks the item; `apps/web/ARCHITECTURE.md`
      gains decisions 31–33, an updated building-blocks row, debt list and test
      coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
