### PR TITLE
feat(web): run an analysis from the project's settings

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -81,6 +81,11 @@ New area — the mockup's settings screens need somewhere to write to.
       written, so nothing sensitive belongs in it.
 - [ ] **P1** Config precedence + a checked-in `strata.config.*` file so a project's
       scope, rules, and gates travel with the repo and drive headless CI mode.
+- [ ] **P2** Run history per project — the registry keeps the *last* run of each
+      project, so *Analyze / run*'s recents list is the browser's own log
+      seeded with that one summary. A handful of runs kept server-side would
+      make it the same list on every machine, and is what a trend delta between
+      two runs would read.
 - [ ] **P2** Import/export a project config; per-project overrides of app defaults.
 
 ## Git / history intelligence
@@ -192,9 +197,10 @@ Sans/Mono.
       its last run: select, remove (registry only — the repo on disk is
       untouched), *Add project*. Picking a project points the workbench at it
       and drops a report belonging to another one. *Add project* lands on the
-      new project; until *Project settings → Analyze / run* exists, the
-      switcher offers the first analysis itself. It replaces the repo-path form
-      the hotspot and dependency screens used to carry. *Add project* also
+      new project, and a project that has never been analysed is pointed at
+      *Project settings → Analyze / run*, which owns the run. It replaces the
+      repo-path form the hotspot and dependency screens used to carry. *Add
+      project* also
       browses: `GET /browse` walks the server's folders inside
       `STRATA_BROWSE_ROOTS` and marks which are repositories.
 - [ ] **P1** Cycle count badge on the *Dependencies* nav item, driven by the last run
@@ -248,8 +254,15 @@ Sans/Mono.
       mount: re-pointing an entry would keep its name, settings and last run
       while all three now described another repository, so moving a project is
       remove-and-add-again.
-- [ ] **P0** Analyze / run — root, revision, history limit, the plugin chips that
-      will run, *Run analysis* (`POST /analyze`), and a recents list
+- [x] Analyze / run — `/settings/project/analyze`. The root, revision and
+      history limit a run reads, printed rather than edited (*General* owns
+      them, and this is where they are used); the plugins that will take part
+      as chips, with a line for every loaded plugin that stands by and why —
+      the orchestrator's own rule, so the first commit-convention plugin parses
+      and an AI provider never runs; *Run analysis* (`POST /analyze`); and the
+      recent runs. Strata keeps one run summary per project, so the list is
+      this browser's own log seeded with the registry's last one. The switcher
+      no longer carries the first run; it links here.
 - [ ] **P1** Scope & ignore — ignore globs and analyze paths as editable chip lists
 - [ ] **P1** Language plugins — per-project toggles with the extensions each one
       claims; *planned* modules (Angular, PHP) shown disabled

--- a/apps/web/ARCHITECTURE.md
+++ b/apps/web/ARCHITECTURE.md
@@ -3,9 +3,9 @@
 > Trimmed arc42, consistent with [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md).
 > Status: **in progress** — theme layer, API client, the workbench shell, the
 > project switcher, the overview, hotspot and dependency-graph screens, the
-> settings shell and its *Project settings → General* section in place; the
-> commit and dead-code screens, and the remaining settings sections, are still
-> to build.
+> settings shell and its *Project settings → General* and *Analyze / run*
+> sections in place; the commit and dead-code screens, and the remaining
+> settings sections, are still to build.
 
 ## 1. Purpose & Goals
 
@@ -42,7 +42,7 @@ app-scoped settings screens. The face of Strata for browser/self-host use.
 | `src/lib/projects/*` | The project registry end to end: `store.svelte` (the registered projects and which one the workbench is on), `entries` (project → a switcher row), `label` (root → name), `crumbs` (path → the picker's steps), `selection` (the remembered choice), and the views — `ProjectSwitcher`, `ProjectList`, `AddProject`, `FolderPicker` |
 | `src/lib/plugins/*` | What the workbench loaded (`store.svelte`), fetched once for the whole app |
 | `src/lib/shell/*` | The frame: `nav` (the map of the workbench), `summary` (report → the header's chips), and the views — `Shell`, `Rail`, `Header`, `NavList`, `RunSummary`, `PluginCount`, `Logo` |
-| `src/lib/settings/*` | The settings area's frame: `scope` (path → project or app), `sections` (what each scope holds), `heading` (scope + project → what the area calls itself), `config.svelte` (the open project's config, held for every project section), and the views — `SettingsNav` (the rail in settings mode), `SettingsScreen` and `SectionList` (a scope's landing screen). Then one section: `general` (the *General* form → the two patches a save sends) with `GeneralScreen` |
+| `src/lib/settings/*` | The settings area's frame: `scope` (path → project or app), `sections` (what each scope holds), `heading` (scope + project → what the area calls itself), `config.svelte` (the open project's config, held for every project section), and the views — `SettingsNav` (the rail in settings mode), `SettingsScreen` and `SectionList` (a scope's landing screen). Then the sections: `general` (the *General* form → the two patches a save sends) with `GeneralScreen`, and *Analyze / run* — `run-window` (project + config → what the next run reads), `run-plugins` (the loaded plugins → who takes part, and why the rest stand by), `recents` (the log's rules), `recents-storage` (where it is kept) and `recent-rows` (the log → strings) with `AnalyzeScreen`, `RunPlugins` and `RecentRuns` |
 | `src/lib/format/*` | `number` (compact counts), `path` (repo path → dir + name), `duration` and `age`, used by every screen |
 | `src/lib/geometry/*` | `squarify` — the squarified treemap layout |
 | `src/lib/overview/*` | The overview feature end to end: `stats` (report + plugins → the six cards), `bars` (the hotspot head, as shares of the top file), `commits` (history → change types and totals), `dead-code` (findings, and the files holding them), and the six views |
@@ -95,7 +95,7 @@ what more than one screen uses moves up into `lib/components/`.
 | 22 | **The switcher points the workbench; the analysis store runs it** | Which project is open is one fact, so one store owns it: `lib/projects` holds the registry and the choice, and hands `lib/analysis` the root. That is also why picking another project drops the report on screen — a report describes the repository that was analysed, and leaving it up would draw one project's graph under another project's name |
 | 23 | **The registry replaces the repo-path form** | Every screen used to run its own *Repository path* field, which made the typed path and the registered projects two answers to the same question. The path is now typed once, in *Add project*, and the screens read whatever the switcher is on |
 | 24 | **The path is browsed, not only typed** | An absolute server-side path is the one thing a reader of a web UI cannot see, and on a remote or containerised workbench they may never have seen it at all. `FolderPicker` walks `GET /browse` and marks the repositories, so *Add project* is a tree with the answers already highlighted; the field stays beside it, because pasting a path is faster when you know it |
-| 25 | **A first analysis can be started from the switcher** | A project that has just been registered has nothing to show on any screen. *Project settings → Analyze / run* is where that run belongs, and the entry moves there when the screen lands; until then the switcher offers it, because the alternative is an empty workbench with no visible way out |
+| 25 | **A first analysis is started where a run is configured** | A project that has just been registered has nothing to show on any screen, so the switcher says so — and links to *Project settings → Analyze / run*, which owns the run. It carried the run itself while that screen did not exist; keeping both would be two doors to one thing, and the one in a dropdown could not show what the run is about to read |
 | 26 | **The overview folds nothing of its own that another screen already folds** | Its cards read `hotspotRows`, `reportSummary` and `cycleViews` — the same functions the hotspot and dependency screens read. An overview is a second opinion about one run, and a second implementation of "how many cycles" would eventually be a *different* opinion. What is new here is only what no other screen needed: the six cards, the bar shares, the change types and the dead-code count |
 | 27 | **Change types are a bar list, not a coloured strip** | The mockup's commit strip wants six hues; the palette has none to give. `h1…h5` is a *sequential* ramp — validated as a categorical set it fails on adjacent pairs no reader can separate, colour-blind or not — and the status colours are reserved for status. Painting `docs` and `test` from a heat ramp would also say "hotter = worse" about neither. So identity is the label and magnitude is the bar, which is what the two facts are; breaking changes are marked with the danger token *and* the word, as a status should be |
 | 28 | **Settings is a place, so the rail swaps rather than grows** | A settings area with seven project sections and five app ones cannot hang off a nav entry, and hanging it under the analysis screens would make the rail a list of everything Strata can do. `settingsScope(pathname)` is the whole mechanism: inside `/settings/*` the rail — and the narrow-screen strip, for the same reason — shows *Back to workbench*, the scope's heading and its sections, and nothing else. The route decides, so a link into a section arrives with the right frame already up |
@@ -104,6 +104,9 @@ what more than one screen uses moves up into `lib/components/`.
 | 31 | **The root is shown, not edited** | `PATCH /projects/:id` can re-point a project, and *General* still prints the root as a read-only mount. A root is what makes a project *that* repository: moving it under the same entry would keep the name, the settings and the last run's summary while every one of them now describes something else. Removing and adding again says that plainly, costs a registry row, and touches nothing on disk. What the field is for is the opposite problem — an absolute server-side path is the one thing a reader of a web UI cannot see (decision 24), so it is worth printing where it can be read and copied |
 | 32 | **One config store behind every project section** | The revision *General* edits is the revision *Analyze / run* shows and the one *Scope & ignore* sits beside; `config.svelte` holds it once, keyed on the project it belongs to, so the sections are screens over one document rather than seven copies drifting apart. Keyed, because the workbench can be pointed at another project while a section is open — a revision read under one project must never be saved under another. It holds what the server answers rather than what was sent, since the server normalises on the way in |
 | 33 | **A section saves the two documents behind it as one screen** | *General* edits the display name, which is the registry entry, and the revision and history limit, which are the project's config — two endpoints, because the root has to stay unique across projects and the config is not the place that can promise that. `general.ts` turns the form into whichever halves changed, so an untouched half is not sent, and identity goes first: a config write that fails then leaves a screen whose own heading is still right |
+| 34 | **The run window is printed where a run is started, edited where it is owned** | *Analyze / run* shows the root, revision and history limit and offers no field for any of them: they are one setting each and *General* is where a setting is set. A second form over the same two values would be a second answer to "what does this project analyse", and the one in front of the button would win by being nearer. What the screen owes the reader is what is about to happen, so it prints the three and links to the screen that changes them |
+| 35 | **The chips say what the orchestrator does, not what the config allows** | `runPlugins` follows the pipeline's own rule — every language module and git metric runs, the first commit-convention plugin parses and the rest stand by, an AI provider takes no part — because a chip in front of *Run analysis* is a promise about the next run. The per-project plugin lists are stored and not yet honoured (`BACKLOG.md` → *Honour the rest of a project's config*), so filtering the chips by them would show a plugin as skipped that in fact runs. A plugin that stands by prints why: "why is my convention plugin doing nothing" is the question this screen exists to answer |
+| 36 | **The recents list is this browser's log, seeded from the registry** | The server records one run per project — the last one — so a list of several has nowhere else to live yet (`BACKLOG.md` → *Run history per project*). `recents-storage` keeps it per project in `localStorage`, and the registry's last run is folded in when the screen opens, so a run from another machine still shows up as the newest entry. `mergeRun` dedupes on the finish timestamp and hands back the **same list** when nothing is new, which is what keeps the effect that records a finished run from watching its own write. The screen also folds that run into the registry itself: the switcher normally does it and is not mounted inside settings |
 
 ## 7. Quality & Risks
 
@@ -115,10 +118,17 @@ what more than one screen uses moves up into `lib/components/`.
 - **Risk:** the palette here is derived from the mockup's description rather
   than exported from it; expect a tuning pass when the screens land. The light
   heat ramp already took one, so a single light ink clears 4.5:1 on every step.
-- **Debt:** *Add project* should land on *Project settings → Analyze / run* for
-  the first analysis; that screen is not built, so the switcher carries the run
-  itself (decision 24) and the entry moves the day the screen exists.
-- **Debt:** every settings section but *Project settings → General* is still
+- **Debt:** *Add project* lands on the new project but not on *Project settings
+  → Analyze / run*; the switcher links there instead (decision 25), so the
+  first analysis costs one click more than it could. Navigating from the
+  switcher would put routing inside a component the frame otherwise keeps clear
+  of it (decision 20), which is not worth that click yet.
+- **Debt:** the recents list is per browser (decision 36), so a workbench used
+  from two machines shows two different lists over the same project — each with
+  the server's last run at the top. A handful of runs kept in the registry is
+  the fix, and is on the backlog.
+- **Debt:** every settings section but *Project settings → General* and
+  *Analyze / run* is still
   listed and inert, so `/settings/app` is a landing screen only. Each section
   is its own issue, and the day one lands it becomes `ready` in `sections.ts`
   and the rail links to it — nothing else in the shell has to change.
@@ -178,7 +188,13 @@ what more than one screen uses moves up into `lib/components/`.
   until an edit, a rename through the registry, the window through the config,
   a bad limit answered without a round-trip, a refusal from the server, discard,
   no project, and a config that could not be read — and its
-  route, the plugin store's load-once, the overview's pure layer (the six
+  route, *Analyze / run*'s pure layer (the window a run reads, who takes part
+  and why the rest stand by, the log's ordering, its cap, its identity-on-
+  duplicate and the shape it is stored in) with its two views and the screen
+  end to end — the window it opens on, the chips, the run it posts and folds
+  into the registry, the log it opens on and remembers, a refused run, no
+  project, and a config that could not be read — and its route,
+  the plugin store's load-once, the overview's pure layer (the six
   cards' order, values, tones and links, a clean report reading as *none*, bar
   shares held against the whole ranking, change types grouped and tied by name,
   and dead code counted per finding *and* per file) with its views — the stat

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -50,7 +50,7 @@ src/
     projects/         the registered projects and the switcher over them
     plugins/          what the workbench loaded, fetched once for the app
     shell/            the workbench frame: rail, sticky header, scrolling pane
-    settings/         the settings frame: the two scopes, their sections, the rail in settings mode
+    settings/         the settings frame: the two scopes, their sections, the rail in settings mode, and the sections built so far
     format/           compact numbers, repo paths, durations and ages
     geometry/         squarify — the treemap layout
     overview/         the overview feature: stat cards, hotspot bars, cycles, plugins, commit types
@@ -120,13 +120,20 @@ analysis screens built so far and the settings shell:
   strip) for that scope's nav: *Back to workbench*, the scope's heading over
   what it applies to — the project and its root, or the workbench — and the
   section list. Each scope's landing screen prints the same sections with a
-  line on what each one holds. The sections themselves are still to build, so
-  they are listed disabled, as the analysis screens on the backlog are.
+  line on what each one holds; sections still to build are listed disabled, as
+  the analysis screens on the backlog are. Two are built:
+  - *General* — the display name (the registry entry) and the revision and
+    history limit every run over this project reads (its config). The root is
+    printed as a read-only mount: moving a project is remove-and-add-again.
+  - *Analyze / run* — what the next run reads, the plugins that will take part
+    (and a line for each loaded plugin that stands by, with why), *Run
+    analysis*, and the recent runs. Strata keeps one run summary per project,
+    so that list is this browser's log seeded with the registry's last run.
 
 A repository is named once, in *Add project*; the screens then read whatever
 run the selected project last had, the header's *Re-analyze* repeats it, and a
-project that has never been analysed is offered its first run in the switcher —
-until *Project settings → Analyze / run* takes that over.
+project that has never been analysed is pointed from the switcher at
+*Project settings → Analyze / run*, which owns the run.
 
 The remaining analysis and settings screens are next — see
 [`BACKLOG.md`](../../BACKLOG.md) and the *web-ui* issues.

--- a/apps/web/src/lib/projects/ProjectSwitcher.svelte
+++ b/apps/web/src/lib/projects/ProjectSwitcher.svelte
@@ -184,28 +184,22 @@
         {#if unanalysed}
           <!--
             A project that has never been analysed has nothing to show on any
-            screen, so the switcher offers the first run itself. *Project
-            settings → Analyze / run* is where this belongs once that screen
-            exists; until then this is the shortest way out of an empty
-            workbench.
+            screen, so the switcher says so and points at the way out. The run
+            itself belongs to *Project settings → Analyze / run*: what a run
+            reads and who takes part in it are settings, and a second door to
+            the same thing in a dropdown would eventually be a different one.
           -->
           <div class="border-line mt-1 border-t pt-2">
             <p class="text-subtle px-2 pb-1.5 text-[0.6875rem]">
               {current?.name} has not been analysed yet.
             </p>
-            <button
-              type="button"
-              class="bg-accent text-accent-ink hover:bg-accent-strong w-full rounded-md px-2 py-1.5 text-sm font-medium transition-colors disabled:opacity-60"
-              disabled={analysis.status === 'running'}
-              onclick={() => {
-                void analysis.run();
-                close();
-              }}
+            <a
+              href="/settings/project/analyze"
+              class="bg-accent text-accent-ink hover:bg-accent-strong block w-full rounded-md px-2 py-1.5 text-center text-sm font-medium transition-colors"
+              onclick={close}
             >
-              {analysis.status === 'running'
-                ? 'Analysing…'
-                : 'Run first analysis'}
-            </button>
+              Set up the first analysis
+            </a>
           </div>
         {/if}
       {/if}

--- a/apps/web/src/lib/projects/ProjectSwitcher.test.ts
+++ b/apps/web/src/lib/projects/ProjectSwitcher.test.ts
@@ -108,15 +108,19 @@ describe('ProjectSwitcher', () => {
     });
   });
 
-  it('offers the first analysis of a project that has never had one', async () => {
+  it('points a project that has never been analysed at its first run', async () => {
     ({ ui } = await open());
 
     button(ui.container, 'Kernel').click();
 
     await vi.waitFor(() => {
-      expect(button(ui.container, 'Run first analysis')).toBeTruthy();
+      expect(ui.container.textContent).toContain('has not been analysed yet');
     });
-    expect(ui.container.textContent).toContain('has not been analysed yet');
+    // The run belongs to *Analyze / run*; the switcher only says it is missing.
+    const link = [...ui.container.querySelectorAll('a')].find((element) =>
+      element.textContent?.includes('Set up the first analysis'),
+    );
+    expect(link?.getAttribute('href')).toBe('/settings/project/analyze');
   });
 
   it('registers a repository and lands on it', async () => {

--- a/apps/web/src/lib/settings/AnalyzeScreen.svelte
+++ b/apps/web/src/lib/settings/AnalyzeScreen.svelte
@@ -1,0 +1,229 @@
+<script lang="ts">
+  import { untrack } from 'svelte';
+  import { analysis } from '$lib/analysis';
+  import type { ProjectAnalysis } from '$lib/api';
+  import Card from '$lib/components/Card.svelte';
+  import { plugins as loaded, type PluginsStore } from '$lib/plugins';
+  import { projects as registry, type ProjectsStore } from '$lib/projects';
+  import RecentRuns from './RecentRuns.svelte';
+  import RunPlugins from './RunPlugins.svelte';
+  import {
+    projectConfig as store,
+    type ProjectConfigStore,
+  } from './config.svelte';
+  import { mergeRun, runEntry } from './recents';
+  import { readRecents, storeRecents } from './recents-storage';
+  import { runPlugins } from './run-plugins';
+  import { runWindow } from './run-window';
+
+  /**
+   * *Project settings → Analyze / run*: what a run over this project will
+   * read, who takes part in it, the button that starts it, and what the last
+   * few runs found.
+   *
+   * The window is printed rather than edited — the revision and the history
+   * limit are one setting each, and *General* is where they are set. This
+   * screen is where they are *used*, so it says what the button is about to do
+   * and links to the place that changes it.
+   */
+
+  interface Props {
+    /** The registry. Defaults to the app's, as the switcher's does. */
+    projects?: ProjectsStore;
+    /** The open project's config. Defaults to the app's. */
+    config?: ProjectConfigStore;
+    /** What the workbench loaded. Defaults to the app's. */
+    plugins?: PluginsStore;
+  }
+
+  let {
+    projects = registry,
+    config = store,
+    plugins = loaded,
+  }: Props = $props();
+
+  /** This browser's log for the open project; see `recents-storage.ts`. */
+  let runs = $state<readonly ProjectAnalysis[]>([]);
+  let opened = '';
+
+  // Mounted without the frame — in a test, or on a direct load — the screen
+  // still finds the project it is scoped to, its config and the plugins.
+  $effect(() => {
+    projects.load();
+    plugins.load();
+  });
+
+  let project = $derived(projects.current);
+
+  $effect(() => {
+    if (project) config.load(project.id);
+  });
+
+  // Only the config that belongs to the open project: the workbench can be
+  // pointed elsewhere while this screen is up, and a window read under one
+  // project must never be shown under another.
+  let stored = $derived(
+    project && config.config && config.projectId === project.id
+      ? config.config
+      : null,
+  );
+  let plan = $derived(project && stored ? runWindow(project, stored) : null);
+  let failed = $derived(
+    config.status === 'error' && config.projectId === project?.id,
+  );
+
+  let entries = $derived(runPlugins(plugins.response?.plugins ?? []));
+  let running = $derived(analysis.status === 'running');
+  // A failure belongs to the repository it was raised for: the header can be
+  // re-analysing something else by the time this screen is opened.
+  let failure = $derived(
+    analysis.status === 'error' && analysis.root === project?.root
+      ? analysis.error
+      : '',
+  );
+
+  // Open the log for whichever project this is, and fold in the run the
+  // registry knows about — a run started on another machine, or in an earlier
+  // session, is the server's to remember.
+  $effect(() => {
+    const current = project;
+    if (!current) return;
+    untrack(() => {
+      if (opened !== current.id) {
+        opened = current.id;
+        runs = readRecents(current.id);
+      }
+      if (current.lastAnalysis) record(current.id, current.lastAnalysis);
+    });
+  });
+
+  // The switcher is what usually folds a finished run into the registry, and
+  // inside settings it is not mounted — so while this screen is the one on
+  // screen, it does that itself. Only the report is tracked: recording writes
+  // the registry this reads, and an effect that watches its own write loops.
+  $effect(() => {
+    const report = analysis.report;
+    if (!report) return;
+    untrack(() => {
+      const current = projects.current;
+      if (!current || current.root !== analysis.root) return;
+      projects.record(report);
+      record(current.id, runEntry(report));
+    });
+  });
+
+  /** Fold a run into the log. A run already in it changes nothing. */
+  function record(id: string, run: ProjectAnalysis): void {
+    const next = mergeRun(runs, run);
+    if (next === runs) return;
+    runs = next;
+    storeRecents(id, next);
+  }
+</script>
+
+<svelte:head>
+  <title>Analyze / run · Project settings · Strata</title>
+</svelte:head>
+
+<div class="max-w-3xl">
+  <header class="mb-8">
+    <h1 class="text-2xl font-semibold">Analyze / run</h1>
+    <p class="text-muted mt-1 text-sm">
+      What a run over this project reads, who takes part in it, and what the
+      last few runs found.
+    </p>
+  </header>
+
+  {#if !project}
+    <p class="text-muted text-sm">
+      An analysis is always of one repository — pick a project in the switcher,
+      or add one, first.
+    </p>
+  {:else if failed}
+    {@const id = project.id}
+    <p class="text-danger text-sm">{config.error}</p>
+    <button
+      type="button"
+      class="border-line bg-surface hover:bg-elevated mt-3 rounded-md border px-3 py-1.5 text-xs font-medium transition-colors"
+      onclick={() => void config.reload(id)}
+    >
+      Try again
+    </button>
+  {:else if !plan}
+    <p class="text-muted text-sm">Reading this project's settings…</p>
+  {:else}
+    {@const root = project.root}
+    <div class="space-y-6">
+      <Card title="This run" hint="POST /analyze">
+        <dl class="space-y-3">
+          <div>
+            <dt class="text-subtle text-xs">Repository root</dt>
+            <dd class="mt-0.5 font-mono text-xs break-all">{plan.root}</dd>
+          </div>
+          <div>
+            <dt class="text-subtle text-xs">Revision</dt>
+            <dd class="mt-0.5 font-mono text-xs">{plan.rev}</dd>
+          </div>
+          <div>
+            <dt class="text-subtle text-xs">History limit</dt>
+            <dd class="mt-0.5 text-sm">{plan.historyLimit}</dd>
+          </div>
+        </dl>
+        <p class="text-subtle mt-4 text-[0.6875rem]">
+          The revision and the limit are the project's settings, so every run —
+          this button, <em>Re-analyze</em> in the header, a headless one — reads
+          the same window.
+          <a
+            class="text-accent hover:underline"
+            href="/settings/project/general"
+          >
+            Change them in General
+          </a>. The root is the mount, and it does not move.
+        </p>
+      </Card>
+
+      <Card title="Plugins" hint="loaded in this workbench">
+        <RunPlugins
+          {entries}
+          loading={plugins.status === 'loading'}
+          error={plugins.error}
+        />
+        <p class="text-subtle mt-4 text-[0.6875rem]">
+          Who takes part is a workbench-wide question today: what loaded here
+          runs over every project, and a language module whose file types this
+          repository does not hold is skipped when the run reaches it.
+          Narrowing it per project is what <em>Language plugins</em> and
+          <em>Metrics &amp; convention</em> will do.
+        </p>
+      </Card>
+
+      <div class="flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          class="bg-accent text-accent-ink hover:bg-accent-strong rounded-md px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-60"
+          disabled={running}
+          onclick={() => void analysis.run(root)}
+        >
+          {running ? 'Analysing…' : 'Run analysis'}
+        </button>
+        <p class="text-subtle text-xs">
+          Reads the repository at the revision above; the working tree is never
+          written to.
+        </p>
+      </div>
+
+      {#if failure}
+        <p class="text-danger text-sm" role="alert">{failure}</p>
+      {/if}
+
+      <Card title="Recent runs" hint="this browser">
+        <RecentRuns {runs} />
+        <p class="text-subtle mt-4 text-[0.6875rem]">
+          Strata keeps the last run of every project; the rest of this list is
+          what this browser has run, so a colleague's analysis of the same
+          repository shows up as its most recent entry.
+        </p>
+      </Card>
+    </div>
+  {/if}
+</div>

--- a/apps/web/src/lib/settings/AnalyzeScreen.test.ts
+++ b/apps/web/src/lib/settings/AnalyzeScreen.test.ts
@@ -1,0 +1,288 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { analysis } from '$lib/analysis';
+import type {
+  AnalysisReport,
+  LoadedPluginInfo,
+  Project,
+  ProjectConfig,
+} from '$lib/api';
+import { PluginsStore } from '$lib/plugins';
+import { ProjectsStore, SELECTION_STORAGE_KEY } from '$lib/projects';
+import { stubApi } from '$lib/test/api';
+import { render } from '$lib/test/render';
+import AnalyzeScreen from './AnalyzeScreen.svelte';
+import { ProjectConfigStore } from './config.svelte';
+import { readRecents } from './recents-storage';
+
+/**
+ * The *Analyze / run* section end to end, against a stubbed API. Each test
+ * gets its own registry, config and plugin stores; the analysis store the run
+ * goes through is the app's single instance, so that one is cleared first.
+ */
+
+const strata: Project = {
+  id: 'strata',
+  name: 'Strata',
+  root: '/home/dev/workspace/strata',
+  addedAt: '2026-08-01T09:00:00.000Z',
+  lastAnalysis: null,
+};
+
+const config: ProjectConfig = {
+  rev: 'main',
+  historyLimit: 500,
+  ignore: [],
+  paths: [],
+  languages: null,
+  metrics: null,
+  convention: null,
+  rules: [],
+};
+
+const loaded: LoadedPluginInfo[] = [
+  {
+    id: 'strata-language-typescript',
+    name: 'TypeScript',
+    kind: 'language',
+    version: '0.4.0',
+    sdk: '0',
+    main: 'dist/index.js',
+    source: 'builtin',
+  },
+  {
+    id: 'strata-ai-codex',
+    name: 'Codex',
+    kind: 'ai-provider',
+    version: '0.1.0',
+    sdk: '0',
+    main: 'dist/index.js',
+    source: 'user',
+  },
+];
+
+const report: AnalysisReport = {
+  rev: '7f80d51cafebabe',
+  run: {
+    branch: 'main',
+    files: 1240,
+    durationMs: 2440,
+    finishedAt: '2026-08-16T09:00:00.000Z',
+  },
+  languages: {},
+  metrics: [],
+  commits: [],
+  cache: {
+    enabled: true,
+    hits: 0,
+    misses: 0,
+    runHits: 0,
+    runMisses: 0,
+    writes: 0,
+  },
+};
+
+/** The rendered text on one line — the markup wraps where a sentence does not. */
+const flat = (node: Element | null) =>
+  node?.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+
+/** The recents card — the plugin chips are a list of `li` too. */
+const recents = (container: HTMLElement) =>
+  [...container.querySelectorAll('section')].find((card) =>
+    card.textContent?.includes('Recent runs'),
+  )!;
+
+const button = (container: HTMLElement, text: string) =>
+  [...container.querySelectorAll('button')].find((element) =>
+    element.textContent?.includes(text),
+  )!;
+
+/** Mount the screen over a registry, a config and the plugins, and let them arrive. */
+async function open(
+  routes: Record<string, unknown> = {},
+  registered: Project[] = [strata],
+) {
+  const first = registered[0];
+  if (first) localStorage.setItem(SELECTION_STORAGE_KEY, first.id);
+  const fetchMock = stubApi({
+    '/projects': { projects: registered },
+    '/projects/strata/config': config,
+    '/plugins': { directory: '/plugins', plugins: loaded, failures: [] },
+    ...routes,
+  });
+  const projects = new ProjectsStore();
+  const configStore = new ProjectConfigStore();
+  const plugins = new PluginsStore();
+  const ui = render(AnalyzeScreen, {
+    projects,
+    config: configStore,
+    plugins,
+  });
+
+  await vi.waitFor(() => {
+    expect(projects.status).toBe('ready');
+  });
+  return { ui, projects, config: configStore, plugins, fetchMock };
+}
+
+let ui: ReturnType<typeof render>;
+
+beforeEach(() => {
+  analysis.select('');
+  localStorage.clear();
+});
+
+afterEach(() => {
+  ui?.destroy();
+  vi.unstubAllGlobals();
+  localStorage.clear();
+});
+
+describe('AnalyzeScreen', () => {
+  it('says what the next run will read', async () => {
+    const opened = await open();
+    ui = opened.ui;
+
+    await vi.waitFor(() => {
+      expect(ui.container.textContent).toContain('/home/dev/workspace/strata');
+    });
+    const text = flat(ui.container);
+    expect(text).toContain('main');
+    expect(text).toContain('Last 500 commits');
+  });
+
+  it('chips the plugins that take part, and says why the others do not', async () => {
+    const opened = await open();
+    ui = opened.ui;
+
+    await vi.waitFor(() => {
+      expect(ui.container.textContent).toContain('TypeScript');
+    });
+    expect(flat(ui.container)).toContain('Codex stands by');
+  });
+
+  it('runs the analysis over the project the workbench is on', async () => {
+    const opened = await open({ 'POST /analyze': report });
+    ui = opened.ui;
+
+    await vi.waitFor(() => {
+      expect(button(ui.container, 'Run analysis')).toBeTruthy();
+    });
+    button(ui.container, 'Run analysis').click();
+
+    await vi.waitFor(() => {
+      expect(analysis.status).toBe('ready');
+    });
+    const call = opened.fetchMock.mock.calls.find(
+      ([, init]) => (init as RequestInit | undefined)?.method === 'POST',
+    );
+    expect(JSON.parse((call?.[1] as RequestInit).body as string)).toEqual({
+      root: '/home/dev/workspace/strata',
+    });
+  });
+
+  it('lists the run it just made, and remembers it', async () => {
+    const opened = await open({ 'POST /analyze': report });
+    ui = opened.ui;
+
+    await vi.waitFor(() => {
+      expect(button(ui.container, 'Run analysis')).toBeTruthy();
+    });
+    button(ui.container, 'Run analysis').click();
+
+    await vi.waitFor(() => {
+      expect(flat(ui.container)).toContain('7f80d51c');
+    });
+    expect(readRecents('strata')).toHaveLength(1);
+    // The switcher is not mounted in settings, so the screen folds the run into
+    // the registry itself — the dropdown must not say "never analysed" after it.
+    expect(opened.projects.current?.lastAnalysis).toMatchObject({
+      rev: '7f80d51cafebabe',
+    });
+  });
+
+  it('opens on the run the registry knows about, and on this browser’s log', async () => {
+    const analysed: Project = {
+      ...strata,
+      lastAnalysis: {
+        rev: 'aaaa1111bbbb',
+        branch: 'main',
+        files: 900,
+        durationMs: 1200,
+        finishedAt: '2026-08-14T09:00:00.000Z',
+      },
+    };
+    localStorage.setItem(
+      'strata:recents',
+      JSON.stringify({
+        strata: [
+          {
+            rev: 'cccc2222dddd',
+            branch: 'main',
+            files: 880,
+            durationMs: 1100,
+            finishedAt: '2026-08-13T09:00:00.000Z',
+          },
+        ],
+      }),
+    );
+
+    const opened = await open({}, [analysed]);
+    ui = opened.ui;
+
+    await vi.waitFor(() => {
+      expect(flat(ui.container)).toContain('aaaa1111');
+    });
+    // Newest first: the registry's run is more recent than the stored one.
+    const rows = [...recents(ui.container).querySelectorAll('li')].map((row) =>
+      flat(row),
+    );
+    expect(rows[0]).toContain('aaaa1111');
+    expect(rows.some((row) => row.includes('cccc2222'))).toBe(true);
+  });
+
+  it('surfaces a run the server refused', async () => {
+    const opened = await open({
+      'POST /analyze': Response.json(
+        { message: 'not a git repository' },
+        { status: 400 },
+      ),
+    });
+    ui = opened.ui;
+
+    await vi.waitFor(() => {
+      expect(button(ui.container, 'Run analysis')).toBeTruthy();
+    });
+    button(ui.container, 'Run analysis').click();
+
+    await vi.waitFor(() => {
+      const alert = ui.container.querySelector('[role="alert"]');
+      expect(alert?.textContent).toContain('not a git repository');
+    });
+  });
+
+  it('asks for a project rather than a run when none is selected', async () => {
+    const opened = await open({}, []);
+    ui = opened.ui;
+
+    await vi.waitFor(() => {
+      expect(opened.projects.status).toBe('ready');
+    });
+    expect(ui.container.textContent).toContain('An analysis is always of one');
+    expect(button(ui.container, 'Run analysis')).toBeUndefined();
+  });
+
+  it('offers a way back when the config could not be read', async () => {
+    const opened = await open({
+      '/projects/strata/config': Response.json(
+        { message: 'registry unreadable' },
+        { status: 500 },
+      ),
+    });
+    ui = opened.ui;
+
+    await vi.waitFor(() => {
+      expect(ui.container.textContent).toContain('registry unreadable');
+    });
+    expect(button(ui.container, 'Try again')).toBeTruthy();
+  });
+});

--- a/apps/web/src/lib/settings/RecentRuns.svelte
+++ b/apps/web/src/lib/settings/RecentRuns.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+  import type { ProjectAnalysis } from '$lib/api';
+  import { recentRows } from './recent-rows';
+
+  /**
+   * What the last few runs over this project found. The ages keep counting
+   * while the screen sits open, as the header's summary does — a list that
+   * still says "just now" an hour later is worse than no age at all.
+   */
+
+  interface Props {
+    runs: readonly ProjectAnalysis[];
+  }
+
+  let { runs }: Props = $props();
+
+  let now = $state(Date.now());
+  $effect(() => {
+    const timer = setInterval(() => {
+      now = Date.now();
+    }, 30_000);
+    return () => clearInterval(timer);
+  });
+
+  let rows = $derived(recentRows(runs, now));
+</script>
+
+{#if rows.length === 0}
+  <p class="text-muted text-sm">
+    No run recorded yet. The first analysis of this project shows up here.
+  </p>
+{:else}
+  <ul class="divide-line flex flex-col divide-y">
+    {#each rows as row (row.id)}
+      <li
+        class="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 py-2 first:pt-0 last:pb-0"
+      >
+        <span class="flex min-w-0 items-baseline gap-2">
+          <span class="font-mono text-sm">{row.rev}</span>
+          <span class="text-subtle truncate text-xs">{row.branch}</span>
+        </span>
+        <span class="text-muted text-xs whitespace-nowrap">
+          {row.files} files · {row.duration} · {row.age}
+        </span>
+      </li>
+    {/each}
+  </ul>
+{/if}

--- a/apps/web/src/lib/settings/RecentRuns.test.ts
+++ b/apps/web/src/lib/settings/RecentRuns.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import type { ProjectAnalysis } from '$lib/api';
+import { render } from '$lib/test/render';
+import RecentRuns from './RecentRuns.svelte';
+
+function run(overrides: Partial<ProjectAnalysis> = {}): ProjectAnalysis {
+  return {
+    rev: '7f80d51cafebabe',
+    branch: 'main',
+    files: 1240,
+    durationMs: 2440,
+    finishedAt: '2026-08-16T09:00:00.000Z',
+    ...overrides,
+  };
+}
+
+/** The rendered text on one line — the markup wraps where a sentence does not. */
+const flat = (node: Element | null) =>
+  node?.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+
+let ui: ReturnType<typeof render>;
+
+afterEach(() => ui?.destroy());
+
+describe('RecentRuns', () => {
+  it('lists a run as its revision, branch and what it cost', () => {
+    ui = render(RecentRuns, { runs: [run()] });
+
+    const row = flat(ui.container.querySelector('li'));
+    expect(row).toContain('7f80d51c');
+    expect(row).toContain('main');
+    expect(row).toContain('1.2k files');
+    expect(row).toContain('2.4 s');
+  });
+
+  it('lists them in the order it is given, one row each', () => {
+    ui = render(RecentRuns, {
+      runs: [run(), run({ finishedAt: '2026-08-15T09:00:00.000Z' })],
+    });
+
+    expect(ui.container.querySelectorAll('li')).toHaveLength(2);
+  });
+
+  it('says a project with no run behind it has none', () => {
+    ui = render(RecentRuns, { runs: [] });
+
+    expect(ui.container.textContent).toContain('No run recorded yet');
+  });
+});

--- a/apps/web/src/lib/settings/RunPlugins.svelte
+++ b/apps/web/src/lib/settings/RunPlugins.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+  import type { RunPlugin } from './run-plugins';
+
+  /**
+   * Who takes part in the next run: a chip each, and a line for every plugin
+   * that is loaded but stands by. Dimming a chip would leave the reason to be
+   * guessed, and "why is my convention plugin doing nothing" is exactly the
+   * question this screen exists to answer.
+   */
+
+  interface Props {
+    entries: readonly RunPlugin[];
+    /** True while the first `/plugins` response is still on the way. */
+    loading?: boolean;
+    /** Why the list is empty, when the server said so. */
+    error?: string;
+  }
+
+  let { entries, loading = false, error = '' }: Props = $props();
+
+  let running = $derived(entries.filter((entry) => entry.runs));
+  let standby = $derived(entries.filter((entry) => !entry.runs));
+</script>
+
+{#if error}
+  <p class="text-warn text-sm">{error}</p>
+{:else if loading && entries.length === 0}
+  <p class="text-muted text-sm">Loading plugins…</p>
+{:else if entries.length === 0}
+  <p class="text-muted text-sm">
+    No plugins loaded — a run over this project would find nothing.
+  </p>
+{:else}
+  {#if running.length === 0}
+    <p class="text-warn text-sm">
+      Nothing loaded takes part in a run: what is installed cannot analyse a
+      repository.
+    </p>
+  {:else}
+    <ul class="flex flex-wrap gap-2">
+      {#each running as entry (entry.id)}
+        <li
+          class="border-line bg-elevated flex items-baseline gap-2 rounded-md border px-2 py-1"
+          title={entry.id}
+        >
+          <span class="text-sm">{entry.name}</span>
+          <span class="text-subtle font-mono text-[0.6875rem]">
+            {entry.kind}
+          </span>
+          {#if entry.source === 'user'}
+            <span class="text-accent text-[0.6875rem]">user</span>
+          {/if}
+        </li>
+      {/each}
+    </ul>
+  {/if}
+
+  {#if standby.length > 0}
+    <ul class="mt-3 space-y-1">
+      {#each standby as entry (entry.id)}
+        <li class="text-subtle text-xs">
+          <span class="text-muted">{entry.name}</span>
+          stands by — {entry.note}
+        </li>
+      {/each}
+    </ul>
+  {/if}
+{/if}

--- a/apps/web/src/lib/settings/RunPlugins.test.ts
+++ b/apps/web/src/lib/settings/RunPlugins.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { render } from '$lib/test/render';
+import RunPlugins from './RunPlugins.svelte';
+import type { RunPlugin } from './run-plugins';
+
+function entry(overrides: Partial<RunPlugin> = {}): RunPlugin {
+  return {
+    id: 'strata-language-typescript',
+    name: 'TypeScript',
+    kind: 'language',
+    source: 'builtin',
+    runs: true,
+    note: '',
+    ...overrides,
+  };
+}
+
+/** The rendered text on one line — the markup wraps where a sentence does not. */
+const flat = (node: Element | null) =>
+  node?.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+
+let ui: ReturnType<typeof render>;
+
+afterEach(() => ui?.destroy());
+
+describe('RunPlugins', () => {
+  it('chips the plugins that take part', () => {
+    const hotspots = entry({
+      id: 'hotspots',
+      name: 'Hotspots',
+      kind: 'git-metric',
+    });
+    ui = render(RunPlugins, { entries: [entry(), hotspots] });
+
+    const chips = ui.container.querySelectorAll('ul:first-of-type > li');
+    expect(chips).toHaveLength(2);
+    expect(flat(chips[0] ?? null)).toContain('TypeScript');
+    expect(flat(chips[0] ?? null)).toContain('language');
+  });
+
+  it('marks a plugin that came from outside the image', () => {
+    ui = render(RunPlugins, { entries: [entry({ source: 'user' })] });
+
+    expect(ui.container.textContent).toContain('user');
+  });
+
+  it('says why a loaded plugin stands by', () => {
+    ui = render(RunPlugins, {
+      entries: [
+        entry(),
+        entry({
+          id: 'gitmoji',
+          name: 'Gitmoji',
+          kind: 'commit-convention',
+          runs: false,
+          note: 'another convention already parses this history',
+        }),
+      ],
+    });
+
+    expect(flat(ui.container)).toContain(
+      'Gitmoji stands by — another convention already parses this history',
+    );
+  });
+
+  it('says so when nothing loaded would take part', () => {
+    const codex = entry({
+      kind: 'ai-provider',
+      runs: false,
+      note: 'no part of a run',
+    });
+    ui = render(RunPlugins, { entries: [codex] });
+
+    expect(ui.container.textContent).toContain('Nothing loaded takes part');
+  });
+
+  it('waits rather than claiming an empty workbench', () => {
+    ui = render(RunPlugins, { entries: [], loading: true });
+
+    expect(ui.container.textContent).toContain('Loading plugins…');
+  });
+
+  it('says an empty workbench is empty once the answer is in', () => {
+    ui = render(RunPlugins, { entries: [] });
+
+    expect(ui.container.textContent).toContain('No plugins loaded');
+  });
+
+  it('surfaces a server that would not answer', () => {
+    ui = render(RunPlugins, { entries: [], error: 'Server unreachable' });
+
+    expect(ui.container.textContent).toContain('Server unreachable');
+  });
+});

--- a/apps/web/src/lib/settings/index.ts
+++ b/apps/web/src/lib/settings/index.ts
@@ -1,4 +1,7 @@
+export { default as AnalyzeScreen } from './AnalyzeScreen.svelte';
 export { default as GeneralScreen } from './GeneralScreen.svelte';
+export { default as RecentRuns } from './RecentRuns.svelte';
+export { default as RunPlugins } from './RunPlugins.svelte';
 export { default as SettingsNav } from './SettingsNav.svelte';
 export { default as SettingsScreen } from './SettingsScreen.svelte';
 export {
@@ -15,6 +18,15 @@ export {
   type GeneralForm,
   type GeneralPatch,
 } from './general';
+export { recentRows, type RecentRow } from './recent-rows';
+export { mergeRun, RECENT_LIMIT, runEntry } from './recents';
+export {
+  readRecents,
+  RECENTS_STORAGE_KEY,
+  storeRecents,
+} from './recents-storage';
+export { runPlugins, type RunPlugin } from './run-plugins';
+export { runWindow, type RunWindow } from './run-window';
 export { scopeHeading, type ScopeHeading } from './heading';
 export {
   APP_SECTIONS,

--- a/apps/web/src/lib/settings/recent-rows.test.ts
+++ b/apps/web/src/lib/settings/recent-rows.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import type { ProjectAnalysis } from '$lib/api';
+import { recentRows } from './recent-rows';
+
+const NOW = Date.parse('2026-08-16T12:00:00.000Z');
+
+function run(overrides: Partial<ProjectAnalysis> = {}): ProjectAnalysis {
+  return {
+    rev: '7f80d51cafebabe',
+    branch: 'main',
+    files: 1240,
+    durationMs: 2440,
+    finishedAt: '2026-08-16T09:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('recentRows', () => {
+  it('reads a run the way the header reads it', () => {
+    expect(recentRows([run()], NOW)).toEqual([
+      {
+        id: '2026-08-16T09:00:00.000Z',
+        rev: '7f80d51c',
+        branch: 'main',
+        files: '1.2k',
+        duration: '2.4 s',
+        age: '3 h ago',
+      },
+    ]);
+  });
+
+  it('names a revision that sits on no branch', () => {
+    expect(recentRows([run({ branch: null })], NOW)[0]?.branch).toBe('detached');
+  });
+
+  it('keeps the order it is given', () => {
+    const rows = recentRows(
+      [run(), run({ finishedAt: '2026-08-15T09:00:00.000Z' })],
+      NOW,
+    );
+
+    expect(rows.map((row) => row.age)).toEqual(['3 h ago', '1 d ago']);
+  });
+});

--- a/apps/web/src/lib/settings/recent-rows.ts
+++ b/apps/web/src/lib/settings/recent-rows.ts
@@ -1,0 +1,36 @@
+import type { ProjectAnalysis } from '$lib/api';
+import { compactNumber, formatDuration, relativeAge } from '$lib/format';
+
+/** One row of the recents list — strings, ready to paint. */
+export interface RecentRow {
+  /** The finish timestamp; also the row's identity in the list. */
+  id: string;
+  /** Short revision, as everything else in the UI abbreviates it. */
+  rev: string;
+  /** Branch of the analysed revision; `detached` when the rev names none. */
+  branch: string;
+  files: string;
+  duration: string;
+  age: string;
+}
+
+const SHORT_REV = 8;
+
+/**
+ * The log as it reads: same abbreviations the header's run summary uses, so
+ * the last row and the chips above the screen say the same thing about the
+ * same run.
+ */
+export function recentRows(
+  runs: readonly ProjectAnalysis[],
+  now: number = Date.now(),
+): RecentRow[] {
+  return runs.map((run) => ({
+    id: run.finishedAt,
+    rev: run.rev.slice(0, SHORT_REV),
+    branch: run.branch ?? 'detached',
+    files: compactNumber(run.files),
+    duration: formatDuration(run.durationMs),
+    age: relativeAge(run.finishedAt, now),
+  }));
+}

--- a/apps/web/src/lib/settings/recents-storage.test.ts
+++ b/apps/web/src/lib/settings/recents-storage.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import type { ProjectAnalysis } from '$lib/api';
+import {
+  readRecents,
+  RECENTS_STORAGE_KEY,
+  storeRecents,
+} from './recents-storage';
+
+const run: ProjectAnalysis = {
+  rev: '7f80d51cafe',
+  branch: 'main',
+  files: 1240,
+  durationMs: 2440,
+  finishedAt: '2026-08-16T09:00:00.000Z',
+};
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe('recents storage', () => {
+  it('keeps a log per project', () => {
+    storeRecents('strata', [run]);
+    storeRecents('other', []);
+
+    expect(readRecents('strata')).toEqual([run]);
+    expect(readRecents('other')).toEqual([]);
+  });
+
+  it('leaves the other projects alone', () => {
+    storeRecents('strata', [run]);
+    storeRecents('other', [{ ...run, rev: 'deadbeef' }]);
+
+    expect(readRecents('strata')).toEqual([run]);
+  });
+
+  it('drops the entry when a log empties', () => {
+    storeRecents('strata', [run]);
+    storeRecents('strata', []);
+
+    expect(localStorage.getItem(RECENTS_STORAGE_KEY)).toBe('{}');
+  });
+
+  it('reads nothing for a project that has none', () => {
+    expect(readRecents('strata')).toEqual([]);
+  });
+
+  it('ignores anything that is not a stored log', () => {
+    localStorage.setItem(RECENTS_STORAGE_KEY, 'not json');
+    expect(readRecents('strata')).toEqual([]);
+
+    localStorage.setItem(RECENTS_STORAGE_KEY, '["strata"]');
+    expect(readRecents('strata')).toEqual([]);
+  });
+
+  it('drops entries that are not runs', () => {
+    localStorage.setItem(
+      RECENTS_STORAGE_KEY,
+      JSON.stringify({ strata: [run, { rev: 'half a run' }, 7] }),
+    );
+
+    expect(readRecents('strata')).toEqual([run]);
+  });
+});

--- a/apps/web/src/lib/settings/recents-storage.ts
+++ b/apps/web/src/lib/settings/recents-storage.ts
@@ -1,0 +1,64 @@
+import type { ProjectAnalysis } from '$lib/api';
+
+/**
+ * Where the recent runs are kept: one entry per project, in this browser.
+ *
+ * The server records only the *last* run against a registered project, so a
+ * list of several has nowhere else to live yet. Keeping it here means the log
+ * survives a reload and is honest about being local — it is what this browser
+ * ran, and a run started from another machine shows up as the registry's last
+ * one when the screen opens.
+ */
+export const RECENTS_STORAGE_KEY = 'strata:recents';
+
+/** Empty when nothing is stored, unreadable, or storage is unavailable. */
+export function readRecents(projectId: string): readonly ProjectAnalysis[] {
+  const stored = readAll()[projectId];
+  return Array.isArray(stored) ? stored.filter(isRun) : [];
+}
+
+/** Replace one project's log. An empty list drops the entry entirely. */
+export function storeRecents(
+  projectId: string,
+  runs: readonly ProjectAnalysis[],
+): void {
+  const all = readAll();
+  if (runs.length > 0) all[projectId] = [...runs];
+  else delete all[projectId];
+
+  try {
+    localStorage.setItem(RECENTS_STORAGE_KEY, JSON.stringify(all));
+  } catch {
+    // Private mode, storage disabled or full: the log stays in memory for as
+    // long as the screen is open, which is more than nothing and costs the
+    // reader no error.
+  }
+}
+
+function readAll(): Record<string, unknown> {
+  try {
+    const raw = localStorage.getItem(RECENTS_STORAGE_KEY);
+    const parsed: unknown = raw ? JSON.parse(raw) : null;
+    // Anything but an object — an older format, or something else writing this
+    // key — is treated as nothing stored rather than crashing the screen.
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Only entries in the registry's own shape are shown; the rest are dropped. */
+function isRun(value: unknown): value is ProjectAnalysis {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.rev === 'string' &&
+    (typeof value.branch === 'string' || value.branch === null) &&
+    typeof value.files === 'number' &&
+    typeof value.durationMs === 'number' &&
+    typeof value.finishedAt === 'string'
+  );
+}

--- a/apps/web/src/lib/settings/recents.test.ts
+++ b/apps/web/src/lib/settings/recents.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import type { AnalysisReport, ProjectAnalysis } from '$lib/api';
+import { mergeRun, RECENT_LIMIT, runEntry } from './recents';
+
+function run(overrides: Partial<ProjectAnalysis> = {}): ProjectAnalysis {
+  return {
+    rev: '7f80d51cafe',
+    branch: 'main',
+    files: 1240,
+    durationMs: 2440,
+    finishedAt: '2026-08-16T09:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('runEntry', () => {
+  it('is the summary the registry keeps, taken from a report', () => {
+    const report = {
+      rev: '7f80d51cafe',
+      run: {
+        branch: 'main',
+        files: 1240,
+        durationMs: 2440,
+        finishedAt: '2026-08-16T09:00:00.000Z',
+      },
+      languages: {},
+      metrics: [],
+      commits: [],
+      cache: {
+        enabled: true,
+        hits: 0,
+        misses: 0,
+        runHits: 0,
+        runMisses: 0,
+        writes: 0,
+      },
+    } satisfies AnalysisReport;
+
+    expect(runEntry(report)).toEqual(run());
+  });
+});
+
+describe('mergeRun', () => {
+  it('puts the newest run first, whichever order they arrive in', () => {
+    const older = run({ finishedAt: '2026-08-16T08:00:00.000Z' });
+    const newer = run({ finishedAt: '2026-08-16T10:00:00.000Z' });
+
+    const runs = mergeRun(mergeRun([], newer), older);
+
+    expect(runs.map((entry) => entry.finishedAt)).toEqual([
+      '2026-08-16T10:00:00.000Z',
+      '2026-08-16T08:00:00.000Z',
+    ]);
+  });
+
+  it('hands the same list back for a run it already holds', () => {
+    const runs = mergeRun([], run());
+
+    // Identity, not equality: it is what lets a caller skip the write.
+    expect(mergeRun(runs, run({ files: 9 }))).toBe(runs);
+  });
+
+  it('keeps only the last few runs', () => {
+    let runs: readonly ProjectAnalysis[] = [];
+    for (let i = 0; i < RECENT_LIMIT + 3; i++) {
+      const hour = String(i).padStart(2, '0');
+      const finishedAt = `2026-08-16T${hour}:00:00.000Z`;
+      runs = mergeRun(runs, run({ finishedAt }));
+    }
+
+    expect(runs).toHaveLength(RECENT_LIMIT);
+    expect(runs[0]?.finishedAt).toBe('2026-08-16T10:00:00.000Z');
+  });
+
+  it('sorts a timestamp it cannot read to the end', () => {
+    const runs = mergeRun(mergeRun([], run({ finishedAt: 'whenever' })), run());
+
+    expect(runs.map((entry) => entry.finishedAt)).toEqual([
+      '2026-08-16T09:00:00.000Z',
+      'whenever',
+    ]);
+  });
+
+  it('never rewrites the list it was given', () => {
+    const runs = [run()];
+
+    mergeRun(runs, run({ finishedAt: '2026-08-16T10:00:00.000Z' }));
+
+    expect(runs).toHaveLength(1);
+  });
+});

--- a/apps/web/src/lib/settings/recents.ts
+++ b/apps/web/src/lib/settings/recents.ts
@@ -1,0 +1,42 @@
+import type { AnalysisReport, ProjectAnalysis } from '$lib/api';
+
+/**
+ * The runs a project has behind it. The registry keeps one summary per project
+ * — the last one — so a list of several is this browser's own log, seeded with
+ * the run the server knows about; see `recents-storage.ts` for where it is
+ * kept.
+ *
+ * A run is identified by when it finished: the same analysis folded in twice
+ * (the screen records the run it started, and re-opens on the registry's copy
+ * of it) is one entry, not two.
+ */
+export const RECENT_LIMIT = 8;
+
+/** What one finished report leaves behind — the registry's own shape. */
+export function runEntry(report: AnalysisReport): ProjectAnalysis {
+  return { rev: report.rev, ...report.run };
+}
+
+/**
+ * Fold a run into the log: newest first, capped, and a run already in it
+ * changes nothing — the **same list** comes back, so a caller can tell "this
+ * is new" from identity alone rather than by comparing entries.
+ */
+export function mergeRun(
+  runs: readonly ProjectAnalysis[],
+  entry: ProjectAnalysis,
+  limit: number = RECENT_LIMIT,
+): readonly ProjectAnalysis[] {
+  if (runs.some((run) => run.finishedAt === entry.finishedAt)) return runs;
+  return [...runs, entry].sort(byNewest).slice(0, limit);
+}
+
+/** A timestamp that cannot be read sorts last rather than shuffling the list. */
+function byNewest(a: ProjectAnalysis, b: ProjectAnalysis): number {
+  return at(b.finishedAt) - at(a.finishedAt);
+}
+
+function at(iso: string): number {
+  const parsed = Date.parse(iso);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}

--- a/apps/web/src/lib/settings/run-plugins.test.ts
+++ b/apps/web/src/lib/settings/run-plugins.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import type { LoadedPluginInfo } from '$lib/api';
+import { runPlugins } from './run-plugins';
+
+function plugin(overrides: Partial<LoadedPluginInfo> = {}): LoadedPluginInfo {
+  return {
+    id: 'strata-language-typescript',
+    name: 'TypeScript',
+    kind: 'language',
+    version: '0.1.0',
+    sdk: '0',
+    main: 'dist/index.js',
+    source: 'builtin',
+    ...overrides,
+  };
+}
+
+describe('runPlugins', () => {
+  it('runs every language module and every git metric', () => {
+    const entries = runPlugins([
+      plugin(),
+      plugin({ id: 'strata-git-hotspots', kind: 'git-metric' }),
+    ]);
+
+    expect(entries.map((entry) => entry.runs)).toEqual([true, true]);
+    expect(entries.every((entry) => entry.note === '')).toBe(true);
+  });
+
+  it('keeps the order the workbench loaded them in', () => {
+    const entries = runPlugins([
+      plugin({ id: 'strata-git-coupling', kind: 'git-metric' }),
+      plugin(),
+    ]);
+
+    expect(entries.map((entry) => entry.id)).toEqual([
+      'strata-git-coupling',
+      'strata-language-typescript',
+    ]);
+  });
+
+  it('lets the first convention parse and stands the rest by', () => {
+    const entries = runPlugins([
+      plugin({ id: 'conventional', kind: 'commit-convention' }),
+      plugin({ id: 'gitmoji', kind: 'commit-convention' }),
+    ]);
+
+    expect(entries[0]).toMatchObject({ id: 'conventional', runs: true });
+    expect(entries[1]?.runs).toBe(false);
+    expect(entries[1]?.note).toContain('another convention');
+  });
+
+  it('leaves an AI provider out of a run', () => {
+    const [entry] = runPlugins([plugin({ id: 'codex', kind: 'ai-provider' })]);
+
+    expect(entry?.runs).toBe(false);
+    expect(entry?.note).toContain('no part of a run');
+  });
+
+  it('carries what a chip prints, source included', () => {
+    const [entry] = runPlugins([plugin({ source: 'user' })]);
+
+    expect(entry).toMatchObject({
+      id: 'strata-language-typescript',
+      name: 'TypeScript',
+      kind: 'language',
+      source: 'user',
+    });
+  });
+});

--- a/apps/web/src/lib/settings/run-plugins.ts
+++ b/apps/web/src/lib/settings/run-plugins.ts
@@ -1,0 +1,76 @@
+import type { LoadedPluginInfo } from '$lib/api';
+
+/**
+ * One plugin, as *Analyze / run* shows it: whether the next run calls it at
+ * all, and — when it does not — why it stands by. A chip that only listed what
+ * is installed would answer a question nobody asked in front of a *Run
+ * analysis* button; what the reader wants there is who takes part.
+ */
+export interface RunPlugin {
+  id: string;
+  name: string;
+  kind: LoadedPluginInfo['kind'];
+  source: LoadedPluginInfo['source'];
+  /** Whether the pipeline calls this plugin. */
+  runs: boolean;
+  /** Why it stands by; empty for the ones that run. */
+  note: string;
+}
+
+/**
+ * Who takes part in a run, in the order the workbench loaded them.
+ *
+ * The rule is the orchestrator's own, not a wish: every language module and
+ * every git-metric plugin is called, the **first** commit-convention plugin
+ * parses the history and the rest stand by, and an AI provider is never part
+ * of an analysis at all. A language module whose extensions match no file in
+ * the repository is skipped when the run gets there — that depends on the
+ * repository rather than on the registry, so it is not something this list can
+ * promise.
+ */
+export function runPlugins(
+  plugins: readonly LoadedPluginInfo[],
+): RunPlugin[] {
+  let parsing = false;
+  return plugins.map((plugin) => {
+    const entry = {
+      id: plugin.id,
+      name: plugin.name,
+      kind: plugin.kind,
+      source: plugin.source,
+    };
+
+    switch (plugin.kind) {
+      case 'language':
+      case 'git-metric':
+        return { ...entry, runs: true, note: '' };
+      case 'commit-convention': {
+        // First one loaded wins; a second convention would parse the same
+        // commits into a second answer.
+        const first = !parsing;
+        parsing = true;
+        return first
+          ? { ...entry, runs: true, note: '' }
+          : {
+              ...entry,
+              runs: false,
+              note: 'another convention already parses this history',
+            };
+      }
+      case 'ai-provider':
+        return {
+          ...entry,
+          runs: false,
+          note: 'answers questions about a report; no part of a run',
+        };
+      default:
+        // A kind this build does not know about: the server loaded it, the
+        // pipeline has no step for it.
+        return {
+          ...entry,
+          runs: false,
+          note: 'this workbench has no step for it',
+        };
+    }
+  });
+}

--- a/apps/web/src/lib/settings/run-window.test.ts
+++ b/apps/web/src/lib/settings/run-window.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import type { ProjectConfig } from '$lib/api';
+import { runWindow } from './run-window';
+
+const project = { root: '/home/dev/workspace/strata' };
+
+function config(overrides: Partial<ProjectConfig> = {}): ProjectConfig {
+  return {
+    rev: 'HEAD',
+    historyLimit: null,
+    ignore: [],
+    paths: [],
+    languages: null,
+    metrics: null,
+    convention: null,
+    rules: [],
+    ...overrides,
+  };
+}
+
+describe('runWindow', () => {
+  it('says what the next run reads', () => {
+    const window = runWindow(project, config({ rev: 'main', historyLimit: 500 }));
+
+    expect(window).toEqual({
+      root: '/home/dev/workspace/strata',
+      rev: 'main',
+      historyLimit: 'Last 500 commits',
+    });
+  });
+
+  it('calls an absent limit the whole history', () => {
+    expect(runWindow(project, config()).historyLimit).toBe('Whole history');
+  });
+
+  it('abbreviates a long window, and counts one commit as one', () => {
+    const limit = (commits: number) =>
+      runWindow(project, config({ historyLimit: commits })).historyLimit;
+
+    expect(limit(12_000)).toBe('Last 12k commits');
+    expect(limit(1)).toBe('Last 1 commit');
+  });
+});

--- a/apps/web/src/lib/settings/run-window.ts
+++ b/apps/web/src/lib/settings/run-window.ts
@@ -1,0 +1,33 @@
+import type { Project, ProjectConfig } from '$lib/api';
+import { compactNumber } from '$lib/format';
+
+/**
+ * What the next run over this project will read: the repository it is mounted
+ * at, the revision it resolves, and how far back it reads the history. All
+ * three are settings *General* owns — this is the same three said as a
+ * sentence, in the place where a run is started, so nobody has to open another
+ * screen to see what the button is about to do.
+ */
+export interface RunWindow {
+  /** Absolute working-tree root on the server's machine. */
+  root: string;
+  rev: string;
+  /** The history window, in words — the whole history is not a number. */
+  historyLimit: string;
+}
+
+export function runWindow(
+  project: Pick<Project, 'root'>,
+  config: Pick<ProjectConfig, 'rev' | 'historyLimit'>,
+): RunWindow {
+  return {
+    root: project.root,
+    rev: config.rev,
+    historyLimit: historyText(config.historyLimit),
+  };
+}
+
+function historyText(limit: number | null): string {
+  if (limit === null) return 'Whole history';
+  return limit === 1 ? 'Last 1 commit' : `Last ${compactNumber(limit)} commits`;
+}

--- a/apps/web/src/lib/settings/sections.test.ts
+++ b/apps/web/src/lib/settings/sections.test.ts
@@ -52,6 +52,7 @@ describe('settings sections', () => {
 
     expect(ready.map((section) => section.href)).toEqual([
       '/settings/project/general',
+      '/settings/project/analyze',
     ]);
   });
 });

--- a/apps/web/src/lib/settings/sections.ts
+++ b/apps/web/src/lib/settings/sections.ts
@@ -30,7 +30,7 @@ export const PROJECT_SECTIONS: readonly SettingsSection[] = [
     label: 'Analyze / run',
     description:
       'Start a run over this project, see which plugins will take part, and what the recent runs found.',
-    status: 'planned',
+    status: 'ready',
   },
   {
     href: '/settings/project/scope',

--- a/apps/web/src/routes/settings/project/analyze/+page.svelte
+++ b/apps/web/src/routes/settings/project/analyze/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import { AnalyzeScreen } from '$lib/settings';
+</script>
+
+<!-- What a run over the open project reads, who takes part in it, the button
+     that starts it, and what the last few runs found. -->
+<AnalyzeScreen />

--- a/apps/web/src/routes/settings/project/analyze/page.test.ts
+++ b/apps/web/src/routes/settings/project/analyze/page.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { analysis } from '$lib/analysis';
+import { projects, SELECTION_STORAGE_KEY } from '$lib/projects';
+import { stubApi } from '$lib/test/api';
+import { render } from '$lib/test/render';
+import Page from './+page.svelte';
+
+/**
+ * The route as the app mounts it: over the app-wide registry, config and
+ * plugin stores, with nothing handed in.
+ */
+
+const strata = {
+  id: 'strata',
+  name: 'Strata',
+  root: '/home/dev/workspace/strata',
+  addedAt: '2026-08-01T09:00:00.000Z',
+  lastAnalysis: null,
+};
+
+const config = {
+  rev: 'main',
+  historyLimit: 500,
+  ignore: [],
+  paths: [],
+  languages: null,
+  metrics: null,
+  convention: null,
+  rules: [],
+};
+
+let ui: ReturnType<typeof render>;
+
+beforeEach(async () => {
+  analysis.select('');
+  localStorage.setItem(SELECTION_STORAGE_KEY, 'strata');
+  stubApi({
+    '/projects': { projects: [strata] },
+    '/projects/strata/config': config,
+    '/plugins': { directory: '/plugins', plugins: [], failures: [] },
+  });
+  await projects.reload();
+});
+
+afterEach(() => {
+  ui?.destroy();
+  vi.unstubAllGlobals();
+  localStorage.clear();
+});
+
+describe('project analyze settings page', () => {
+  it('opens on the project the workbench is pointed at', async () => {
+    ui = render(Page);
+
+    await vi.waitFor(() => {
+      expect(ui.container.textContent).toContain('/home/dev/workspace/strata');
+    });
+    const text = ui.container.textContent?.replace(/\s+/g, ' ') ?? '';
+    expect(text).toContain('Last 500 commits');
+    expect(
+      [...ui.container.querySelectorAll('button')].some((element) =>
+        element.textContent?.includes('Run analysis'),
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #77.

*Project settings → Analyze / run* — `/settings/project/analyze` — the second
settings section with something in it, and the place a run belongs.

### What the screen holds

- **This run** — the root, revision and history limit the next analysis will
  read, printed rather than edited. Each is one setting and *General* owns it;
  a second form over the same values would be a second answer to "what does
  this project analyse", and the one in front of the button would win by being
  nearer. The screen prints the three and links to the one that changes them.
- **Plugins** — chips for who takes part, and a line for every loaded plugin
  that stands by, with why. The rule is the orchestrator's own: every language
  module and git metric runs, the *first* commit-convention plugin parses the
  history, an AI provider takes no part. Deliberately **not** filtered by the
  config's `languages` / `metrics` / `convention` lists — those are stored and
  not yet honoured by the pipeline, so filtering by them would mark a plugin as
  skipped that in fact runs.
- **Run analysis** — `POST /analyze` through the app-wide analysis store, so
  the run this screen starts is the run every other screen reads. It also folds
  the finished run into the registry: the switcher normally does that and is
  not mounted inside settings, so without it the dropdown would still say
  "never analysed" after an analysis.
- **Recent runs** — the registry keeps one summary per project, so the list is
  this browser's log, kept per project in `localStorage` and seeded with the
  registry's last run when the screen opens. Newest first, capped at 8, deduped
  on the finish timestamp. `mergeRun` returns the *same* list when nothing is
  new, which is what keeps the effect that records a finished run from watching
  its own write. Server-side run history is on the backlog.

### Also

- The switcher stops carrying the first analysis and links here instead — what
  a run reads and who takes part are settings, and a dropdown could show
  neither. (`ARCHITECTURE.md` decision 25 always said the entry moves the day
  this screen exists.)
- The section flips to `ready` in `sections.ts`, so the rail links to it and
  nothing else in the shell changes.
- Docs: `BACKLOG.md` (item done; new P2 for server-side run history),
  `apps/web/ARCHITECTURE.md` (decisions 34–36, revised 25, the new debt, the
  test list) and `apps/web/README.md`.

### Checks

`vitest` 655 tests pass repo-wide (35 new: the five pure modules, both views,
the screen end to end and its route), `svelte-check` 0 errors / 0 warnings,
`eslint .` clean, the web build succeeds. Not driven in a real browser — the
run flow is covered against a stubbed API rather than a live server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
