### PR TITLE
feat(core): aggregate the parsed commit log

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -104,9 +104,13 @@ New area — the mockup's settings screens need somewhere to write to.
 ## Git / history intelligence
 
 - [x] Hotspots (churn × complexity)
-- [ ] **P0** Commit analytics aggregates behind the *Commit analytics* screen —
+- [x] Commit analytics aggregates behind the *Commit analytics* screen —
       per-type and per-scope counts, convention-validity rate (`96% valid ·
       6 non-conforming`), breaking-change count, and a weekly activity series.
+      The core folds them once, onto `report.commitAnalytics`, rather than
+      leaving every reader to walk the log its own way; the weeks are
+      Monday-started (UTC) and contiguous, so a quiet week is a zero and not a
+      gap. The *Commit analytics* screen reads them as it lands.
 - [x] Change coupling — files that change together (temporal coupling).
       Thresholds (min changes/shared/degree) are still fixed constants; they
       become the *Project settings → Metrics* toggles.

--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -57,12 +57,47 @@ export interface RunReport {
   finishedAt: string;
 }
 
+/** One `type` or `scope` of the analysed window; `null` where a commit named none. */
+export interface CommitBucket {
+  name: string | null;
+  count: number;
+  /** 0–1 of every parsed commit in the window. */
+  share: number;
+  breaking: number;
+}
+
+/** One week of the activity series, dated by its Monday (UTC), `YYYY-MM-DD`. */
+export interface CommitWeek {
+  week: string;
+  commits: number;
+}
+
+/**
+ * The history window as the core folded it: what the *Commit analytics* screen
+ * prints, counted once on the server so a screen never has to walk the log and
+ * arrive at its own quietly different answer.
+ */
+export interface CommitAnalytics {
+  total: number;
+  valid: number;
+  /** Parsed commits the convention could not make sense of. */
+  invalid: number;
+  /** 0–1 of the judged commits; 0 when nothing judged them. */
+  validRate: number;
+  breaking: number;
+  types: CommitBucket[];
+  scopes: CommitBucket[];
+  /** Contiguous weeks, oldest first — a week with no commits included as 0. */
+  weeks: CommitWeek[];
+}
+
 export interface AnalysisReport {
   rev: string;
   run: RunReport;
   languages: Record<string, LanguageAnalysis>;
   metrics: MetricSeries[];
   commits: ParsedCommit[];
+  commitAnalytics: CommitAnalytics;
   cache: CacheReport;
 }
 

--- a/apps/web/src/lib/graph/merge.test.ts
+++ b/apps/web/src/lib/graph/merge.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { AnalysisReport } from '$lib/api';
+import { noCommits } from '$lib/test/commits';
 import { graphOf, languageOf } from '$lib/test/graph';
 import { mergedGraph } from './merge';
 
@@ -17,6 +18,7 @@ function reportWith(
     languages,
     metrics: [],
     commits: [],
+    commitAnalytics: noCommits(),
     cache: {
       enabled: false,
       hits: 0,

--- a/apps/web/src/lib/graph/summary.test.ts
+++ b/apps/web/src/lib/graph/summary.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { AnalysisReport } from '$lib/api';
+import { noCommits } from '$lib/test/commits';
 import { graphOf, languageOf } from '$lib/test/graph';
 import { reportSummary } from './summary';
 
@@ -15,6 +16,7 @@ function reportWith(languages: AnalysisReport['languages']): AnalysisReport {
     languages,
     metrics: [],
     commits: [],
+    commitAnalytics: noCommits(),
     cache: {
       enabled: false,
       hits: 0,

--- a/apps/web/src/lib/hotspots/rows.test.ts
+++ b/apps/web/src/lib/hotspots/rows.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { AnalysisReport } from '$lib/api';
+import { noCommits } from '$lib/test/commits';
 import { languageOf } from '$lib/test/graph';
 import { hotspotRows } from './rows';
 
@@ -15,6 +16,7 @@ function report(partial: Partial<AnalysisReport> = {}): AnalysisReport {
     languages: {},
     metrics: [],
     commits: [],
+    commitAnalytics: noCommits(),
     cache: {
       enabled: false,
       hits: 0,

--- a/apps/web/src/lib/projects/store.test.ts
+++ b/apps/web/src/lib/projects/store.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { analysis, ROOT_STORAGE_KEY } from '$lib/analysis';
 import type { Project } from '$lib/api';
 import { stubApi } from '$lib/test/api';
+import { noCommits } from '$lib/test/commits';
 import { SELECTION_STORAGE_KEY } from './selection';
 import { ProjectsStore } from './store.svelte';
 
@@ -45,6 +46,7 @@ const report = {
   languages: {},
   metrics: [],
   commits: [],
+  commitAnalytics: noCommits(),
   cache: {
     enabled: false,
     hits: 0,

--- a/apps/web/src/lib/settings/AnalyzeScreen.test.ts
+++ b/apps/web/src/lib/settings/AnalyzeScreen.test.ts
@@ -9,6 +9,7 @@ import type {
 import { PluginsStore } from '$lib/plugins';
 import { ProjectsStore, SELECTION_STORAGE_KEY } from '$lib/projects';
 import { stubApi } from '$lib/test/api';
+import { noCommits } from '$lib/test/commits';
 import { render } from '$lib/test/render';
 import AnalyzeScreen from './AnalyzeScreen.svelte';
 import { ProjectConfigStore } from './config.svelte';
@@ -71,6 +72,7 @@ const report: AnalysisReport = {
   languages: {},
   metrics: [],
   commits: [],
+  commitAnalytics: noCommits(),
   cache: {
     enabled: true,
     hits: 0,

--- a/apps/web/src/lib/settings/recents.test.ts
+++ b/apps/web/src/lib/settings/recents.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { AnalysisReport, ProjectAnalysis } from '$lib/api';
+import { noCommits } from '$lib/test/commits';
 import { mergeRun, RECENT_LIMIT, runEntry } from './recents';
 
 function run(overrides: Partial<ProjectAnalysis> = {}): ProjectAnalysis {
@@ -26,6 +27,7 @@ describe('runEntry', () => {
       languages: {},
       metrics: [],
       commits: [],
+      commitAnalytics: noCommits(),
       cache: {
         enabled: true,
         hits: 0,

--- a/apps/web/src/lib/test/commits.ts
+++ b/apps/web/src/lib/test/commits.ts
@@ -1,0 +1,21 @@
+import type { CommitAnalytics } from '$lib/api';
+
+/**
+ * The commit aggregates of an empty history window.
+ *
+ * Every report carries them, and most fixtures are about something else —
+ * a graph, a hotspot, a run summary — so they say "no commits" once, here,
+ * instead of eight zeroes at every call site.
+ */
+export function noCommits(): CommitAnalytics {
+  return {
+    total: 0,
+    valid: 0,
+    invalid: 0,
+    validRate: 0,
+    breaking: 0,
+    types: [],
+    scopes: [],
+    weeks: [],
+  };
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -143,7 +143,9 @@ builds a `RepoContext` and fans work out.
    tracked files (each with its blob sha).
 2. Files are routed to `language` plugins by extension.
 3. Commit history is streamed; `git-metric` plugins compute their series.
-4. The active `commit-convention` plugin parses each commit.
+4. The active `commit-convention` plugin parses each commit, and the core folds
+   the parsed log into `CommitAnalytics` — per type, per scope, how much of the
+   history conforms, breaking changes, weekly activity.
 5. Results merge into an `AnalysisReport`, returned by the API.
 
 Steps 2 and 3 go through the cache. The core skips any plugin whose inputs

--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -37,6 +37,10 @@ itself behaves.
 | `index.ts` | Barrel — the package's public surface, no logic. |
 | `strata.ts` | The `Strata` orchestrator. |
 | `types.ts` | `AnalyzeOptions`, `StrataOptions`, `AnalysisReport`, `RunReport`, `CacheReport`. |
+| `commits/analyse.ts` | `analyseCommits()` — the parsed log folded into `CommitAnalytics`. |
+| `commits/buckets.ts` | `bucketBy()` — counts per type / per scope, biggest first. |
+| `commits/weeks.ts` | `weeklyActivity()` — commits per Monday-started week (UTC). |
+| `commits/types.ts` | `CommitAnalytics`, `CommitBucket`, `CommitWeek`. |
 | `logger.ts` | `createConsoleLogger(scope)` — what `RepoContext.log` gets. |
 | `registry.ts` | `PluginRegistry` — load plugins, contain load failures, `byKind()` / `loadedByKind()`. |
 | `manifest.ts` | `readManifest()` / `resolveEntry()` — validate a `strata.plugin.json` and its entry path. |
@@ -91,7 +95,9 @@ itself behaves.
 3. Route files to `language` plugins by extension — skipping any plugin whose
    input digest already has a stored result.
 4. Stream `history`; run `git-metric` plugins (same skip).
-5. Parse commits with the first `commit-convention` plugin.
+5. Parse commits with the first `commit-convention` plugin, then fold the log
+   into `CommitAnalytics` (per type, per scope, conformance, breaking changes,
+   weekly activity).
 6. Merge into `AnalysisReport`, with the run's own metadata (`RunReport`:
    branch, file count, duration, finished-at) beside the resolved `rev`.
 
@@ -125,6 +131,14 @@ section keeps its value — because each section is one settings screen.
   `registry.failures()` rather than thrown: a broken third-party plugin must
   cost only itself, not the process.
 - **First-registered commit convention wins** (single active convention).
+- **The aggregates are folded in the core, not by each reader.** A plugin says
+  what one commit means; how many `feat` commits there were is a question every
+  screen, card and gate asks, and three of them counting it three ways is three
+  quietly disagreeing definitions. A window no convention parsed still reports
+  its activity and claims nothing about conformance — "unjudged" is not the
+  same as "non-conforming". Weeks are bucketed Monday-to-Monday in **UTC**: an
+  author's timezone is whatever their laptop said at the time, so anything else
+  would move a commit between columns depending on who ran the analysis.
 - **The run times itself** — duration covers everything the caller waited for,
   cache open included, and `finishedAt` is stamped where the run ends. A client
   measuring its own round-trip would be measuring the network too. A revision

--- a/packages/core/src/commit-analytics.test.ts
+++ b/packages/core/src/commit-analytics.test.ts
@@ -1,0 +1,143 @@
+import { execFile } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { PluginRegistry } from './registry.js';
+import { Strata } from './strata.js';
+
+const exec = promisify(execFile);
+
+/**
+ * End-to-end proof that a run carries the aggregates over its own history: a
+ * real repository, dated commits, and the convention plugin the registry
+ * loaded — the numbers the *Commit analytics* screen reads, straight off the
+ * report rather than off a hand-built log.
+ */
+
+/** A conventional parser, small enough to keep the fixture readable. */
+const PLUGIN_SOURCE = `const HEADER = /^(\\w+)(?:\\(([^)]+)\\))?(!)?: (.+)$/;
+
+export default {
+  kind: 'commit-convention',
+  convention: 'test-conventional',
+  parse(commit) {
+    const m = commit.message.split('\\n')[0].match(HEADER);
+    if (!m) {
+      return { type: null, scope: null, breaking: false, subject: commit.message, tags: {}, valid: false };
+    }
+    return {
+      type: m[1],
+      scope: m[2] ?? null,
+      breaking: m[3] === '!',
+      subject: m[4],
+      tags: {},
+      valid: true,
+    };
+  },
+};
+`;
+
+let repo: string;
+let pluginDir: string;
+let strata: Strata;
+
+/** Commit `message`, authored at `date`, so the weekly series has weeks. */
+async function commit(message: string, date: string): Promise<void> {
+  writeFileSync(join(repo, 'file.txt'), message);
+  await exec('git', ['add', '-A'], { cwd: repo });
+  await exec('git', ['commit', '-m', message], {
+    cwd: repo,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'Strata Test',
+      GIT_AUTHOR_EMAIL: 'test@example.com',
+      GIT_AUTHOR_DATE: date,
+      GIT_COMMITTER_NAME: 'Strata Test',
+      GIT_COMMITTER_EMAIL: 'test@example.com',
+      GIT_COMMITTER_DATE: date,
+    },
+  });
+}
+
+beforeAll(async () => {
+  repo = mkdtempSync(join(tmpdir(), 'strata-commits-'));
+  pluginDir = mkdtempSync(join(tmpdir(), 'strata-convention-'));
+
+  mkdirSync(join(pluginDir, 'dist'), { recursive: true });
+  writeFileSync(join(pluginDir, 'dist/index.mjs'), PLUGIN_SOURCE);
+  writeFileSync(
+    join(pluginDir, 'strata.plugin.json'),
+    JSON.stringify({
+      id: 'test-convention',
+      name: 'test-convention',
+      kind: 'commit-convention',
+      version: '1.0.0',
+      sdk: '0.1.0',
+      main: './dist/index.mjs',
+    }),
+  );
+
+  await exec('git', ['init', '-q', '-b', 'main'], { cwd: repo });
+  // Two weeks apart, with the week between them left empty on purpose.
+  await commit('feat(core): one', '2024-03-06T12:00:00+00:00');
+  await commit('fix(core): two', '2024-03-07T12:00:00+00:00');
+  await commit('feat(web)!: three', '2024-03-08T12:00:00+00:00');
+  await commit('nothing conventional here', '2024-03-20T12:00:00+00:00');
+
+  const registry = new PluginRegistry();
+  await registry.loadFrom(join(pluginDir, 'strata.plugin.json'));
+  strata = new Strata(registry, { cache: false });
+}, 30_000);
+
+afterAll(() => {
+  strata.close();
+  for (const dir of [repo, pluginDir]) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('commit analytics', () => {
+  it('folds the analysed window the registered convention parsed', async () => {
+    const { commitAnalytics: analytics } = await strata.analyze({ root: repo });
+
+    expect(analytics.total).toBe(4);
+    expect(analytics.valid).toBe(3);
+    expect(analytics.invalid).toBe(1);
+    expect(analytics.validRate).toBe(0.75);
+    expect(analytics.breaking).toBe(1);
+    expect(analytics.types.map((b) => [b.name, b.count])).toEqual([
+      ['feat', 2],
+      ['fix', 1],
+      [null, 1],
+    ]);
+    expect(analytics.scopes.map((b) => [b.name, b.count])).toEqual([
+      ['core', 2],
+      ['web', 1],
+      [null, 1],
+    ]);
+  });
+
+  it('dates the activity series by the commits git reported', async () => {
+    const { commitAnalytics: analytics } = await strata.analyze({ root: repo });
+
+    expect(analytics.weeks).toEqual([
+      { week: '2024-03-04', commits: 3 },
+      { week: '2024-03-11', commits: 0 },
+      { week: '2024-03-18', commits: 1 },
+    ]);
+  });
+
+  it('counts only the window a history limit asked for', async () => {
+    const { commitAnalytics: analytics } = await strata.analyze({
+      root: repo,
+      historyLimit: 2,
+    });
+
+    // `git log` walks newest first, so the limit keeps the last two commits.
+    expect(analytics.total).toBe(2);
+    expect(analytics.weeks).toHaveLength(3);
+    expect(analytics.types.map((b) => b.name)).toEqual(['feat', null]);
+  });
+});

--- a/packages/core/src/commits/analyse.ts
+++ b/packages/core/src/commits/analyse.ts
@@ -1,0 +1,40 @@
+import type { ParsedCommit, RawCommit } from '@strata/sdk';
+import { bucketBy } from './buckets.js';
+import type { CommitAnalytics } from './types.js';
+import { weeklyActivity } from './weeks.js';
+
+/**
+ * Fold a history window into the numbers the *Commit analytics* screen prints.
+ *
+ * The convention plugin decides what one commit *means*; nothing so far counts
+ * what a thousand of them add up to, and every reader that wants the total —
+ * a screen, an overview card, a CI gate — would otherwise walk the whole log
+ * itself and reach its own quietly different answer.
+ *
+ * `log` dates the activity series and sizes the window, `parsed` carries what
+ * the convention made of each message. They describe the same commits in the
+ * same order, and neither fold reads the other's list, so a window that no
+ * convention parsed still reports its activity.
+ */
+export function analyseCommits(
+  log: readonly RawCommit[],
+  parsed: readonly ParsedCommit[],
+): CommitAnalytics {
+  let valid = 0;
+  let breaking = 0;
+  for (const commit of parsed) {
+    if (commit.valid) valid += 1;
+    if (commit.breaking) breaking += 1;
+  }
+
+  return {
+    total: log.length,
+    valid,
+    invalid: parsed.length - valid,
+    validRate: parsed.length > 0 ? valid / parsed.length : 0,
+    breaking,
+    types: bucketBy(parsed, 'type'),
+    scopes: bucketBy(parsed, 'scope'),
+    weeks: weeklyActivity(log),
+  };
+}

--- a/packages/core/src/commits/buckets.ts
+++ b/packages/core/src/commits/buckets.ts
@@ -1,0 +1,43 @@
+import type { ParsedCommit } from '@strata/sdk';
+import type { CommitBucket } from './types.js';
+
+/** The fields a parsed log can be grouped by. */
+type Groupable = 'type' | 'scope';
+
+/**
+ * Group a parsed log by one of its fields.
+ *
+ * Biggest bucket first, ties broken by name, so two runs over the same history
+ * print the same order — and the unnamed bucket (`null`) sorts last of its
+ * size, because "no scope" is the residue of a list of scopes, not an entry in
+ * it.
+ */
+export function bucketBy(
+  commits: readonly ParsedCommit[],
+  field: Groupable,
+): CommitBucket[] {
+  const counts = new Map<string | null, { count: number; breaking: number }>();
+
+  for (const commit of commits) {
+    const name = commit[field];
+    const entry = counts.get(name) ?? { count: 0, breaking: 0 };
+    entry.count += 1;
+    if (commit.breaking) entry.breaking += 1;
+    counts.set(name, entry);
+  }
+
+  return [...counts]
+    .map(([name, entry]) => ({
+      name,
+      count: entry.count,
+      share: commits.length > 0 ? entry.count / commits.length : 0,
+      breaking: entry.breaking,
+    }))
+    .sort((a, b) => b.count - a.count || byName(a.name, b.name));
+}
+
+function byName(a: string | null, b: string | null): number {
+  if (a === null) return b === null ? 0 : 1;
+  if (b === null) return -1;
+  return a.localeCompare(b);
+}

--- a/packages/core/src/commits/commits.test.ts
+++ b/packages/core/src/commits/commits.test.ts
@@ -1,0 +1,219 @@
+import type { ParsedCommit, RawCommit } from '@strata/sdk';
+import { describe, expect, it } from 'vitest';
+import { analyseCommits } from './analyse.js';
+import { bucketBy } from './buckets.js';
+import { weeklyActivity } from './weeks.js';
+
+/** A parsed commit; every field the aggregates read is named at the call site. */
+function parsed(p: Partial<ParsedCommit> = {}): ParsedCommit {
+  return {
+    type: 'feat',
+    scope: null,
+    breaking: false,
+    subject: 'something',
+    tags: {},
+    valid: true,
+    ...p,
+  };
+}
+
+/** A raw commit; only the date matters to the activity series. */
+function raw(date: string): RawCommit {
+  return {
+    sha: date,
+    author: 'Ada',
+    authorEmail: 'ada@example.com',
+    date,
+    message: 'feat: something',
+  };
+}
+
+describe('bucketBy', () => {
+  it('counts a field, biggest first, with each bucket share', () => {
+    const log = [
+      parsed({ type: 'feat' }),
+      parsed({ type: 'fix' }),
+      parsed({ type: 'fix' }),
+      parsed({ type: 'docs' }),
+    ];
+
+    expect(bucketBy(log, 'type')).toEqual([
+      { name: 'fix', count: 2, share: 0.5, breaking: 0 },
+      { name: 'docs', count: 1, share: 0.25, breaking: 0 },
+      { name: 'feat', count: 1, share: 0.25, breaking: 0 },
+    ]);
+  });
+
+  it('counts the breaking changes inside each bucket', () => {
+    const log = [
+      parsed({ type: 'feat', breaking: true }),
+      parsed({ type: 'feat' }),
+      parsed({ type: 'fix', breaking: true }),
+    ];
+
+    expect(bucketBy(log, 'type').map((b) => [b.name, b.breaking])).toEqual([
+      ['feat', 1],
+      ['fix', 1],
+    ]);
+  });
+
+  it('groups by scope, keeping the unscoped commits as their own bucket', () => {
+    const log = [
+      parsed({ scope: 'core' }),
+      parsed({ scope: 'core' }),
+      parsed({ scope: null }),
+      parsed({ scope: null }),
+      parsed({ scope: 'web' }),
+    ];
+
+    // `null` sorts last of its size: "no scope" is the residue of the list.
+    expect(bucketBy(log, 'scope').map((b) => b.name)).toEqual([
+      'core',
+      null,
+      'web',
+    ]);
+  });
+
+  it('keeps a commit the convention did not recognise, under no name', () => {
+    const log = [parsed({ type: null, valid: false }), parsed({ type: 'fix' })];
+
+    // A repository where half the history is unconventional should say so,
+    // and `other` stays available as a type someone actually writes.
+    expect(bucketBy(log, 'type')).toContainEqual({
+      name: null,
+      count: 1,
+      share: 0.5,
+      breaking: 0,
+    });
+  });
+
+  it('has nothing to say about an empty log', () => {
+    expect(bucketBy([], 'type')).toEqual([]);
+  });
+});
+
+describe('weeklyActivity', () => {
+  it('buckets commits into Monday-started weeks, oldest first', () => {
+    // 2024-03-06 is a Wednesday, 2024-03-11 the Monday after it.
+    const weeks = weeklyActivity([
+      raw('2024-03-06T12:00:00+00:00'),
+      raw('2024-03-08T09:30:00+00:00'),
+      raw('2024-03-11T08:00:00+00:00'),
+    ]);
+
+    expect(weeks).toEqual([
+      { week: '2024-03-04', commits: 2 },
+      { week: '2024-03-11', commits: 1 },
+    ]);
+  });
+
+  it('buckets a Sunday into the week that began six days earlier', () => {
+    // Sunday closes a Monday-started week rather than opening the next one.
+    expect(weeklyActivity([raw('2024-03-10T23:59:00+00:00')])).toEqual([
+      { week: '2024-03-04', commits: 1 },
+    ]);
+  });
+
+  it('reads the offset, so a commit is dated where it happened in UTC', () => {
+    // 2024-03-11T00:30+02:00 is still Sunday the 10th in UTC.
+    expect(weeklyActivity([raw('2024-03-11T00:30:00+02:00')])).toEqual([
+      { week: '2024-03-04', commits: 1 },
+    ]);
+  });
+
+  it('emits the quiet weeks in between as zero', () => {
+    const weeks = weeklyActivity([
+      raw('2024-03-05T12:00:00+00:00'),
+      raw('2024-03-26T12:00:00+00:00'),
+    ]);
+
+    expect(weeks).toEqual([
+      { week: '2024-03-04', commits: 1 },
+      { week: '2024-03-11', commits: 0 },
+      { week: '2024-03-18', commits: 0 },
+      { week: '2024-03-25', commits: 1 },
+    ]);
+  });
+
+  it('skips a commit git gave no date for', () => {
+    expect(weeklyActivity([raw(''), raw('2024-03-06T12:00:00+00:00')])).toEqual([
+      { week: '2024-03-04', commits: 1 },
+    ]);
+  });
+
+  it('has no series for an empty history', () => {
+    expect(weeklyActivity([])).toEqual([]);
+  });
+});
+
+describe('analyseCommits', () => {
+  const log = [
+    raw('2024-03-06T12:00:00+00:00'),
+    raw('2024-03-07T12:00:00+00:00'),
+    raw('2024-03-12T12:00:00+00:00'),
+    raw('2024-03-13T12:00:00+00:00'),
+  ];
+  const window = [
+    parsed({ type: 'feat', scope: 'core' }),
+    parsed({ type: 'feat', scope: 'web', breaking: true }),
+    parsed({ type: 'fix', scope: 'core' }),
+    parsed({ type: null, scope: null, valid: false }),
+  ];
+
+  it('reports the window, its conformance and its breaking changes', () => {
+    const analytics = analyseCommits(log, window);
+
+    expect(analytics.total).toBe(4);
+    expect(analytics.valid).toBe(3);
+    expect(analytics.invalid).toBe(1);
+    expect(analytics.validRate).toBe(0.75);
+    expect(analytics.breaking).toBe(1);
+  });
+
+  it('breaks the window down by type and by scope', () => {
+    const analytics = analyseCommits(log, window);
+
+    expect(analytics.types.map((b) => [b.name, b.count])).toEqual([
+      ['feat', 2],
+      ['fix', 1],
+      [null, 1],
+    ]);
+    expect(analytics.scopes.map((b) => [b.name, b.count])).toEqual([
+      ['core', 2],
+      ['web', 1],
+      [null, 1],
+    ]);
+  });
+
+  it('carries the weekly activity series', () => {
+    expect(analyseCommits(log, window).weeks).toEqual([
+      { week: '2024-03-04', commits: 2 },
+      { week: '2024-03-11', commits: 2 },
+    ]);
+  });
+
+  it('reports activity for a window no convention parsed', () => {
+    const analytics = analyseCommits(log, []);
+
+    // No plugin judged these commits, so none of them is non-conforming —
+    // an unparsed history says nothing about conformance either way.
+    expect(analytics.total).toBe(4);
+    expect(analytics.invalid).toBe(0);
+    expect(analytics.validRate).toBe(0);
+    expect(analytics.types).toEqual([]);
+    expect(analytics.weeks).toHaveLength(2);
+  });
+
+  it('folds an empty history into zeroes rather than a division by zero', () => {
+    expect(analyseCommits([], [])).toEqual({
+      total: 0,
+      valid: 0,
+      invalid: 0,
+      validRate: 0,
+      breaking: 0,
+      types: [],
+      scopes: [],
+      weeks: [],
+    });
+  });
+});

--- a/packages/core/src/commits/index.ts
+++ b/packages/core/src/commits/index.ts
@@ -1,0 +1,4 @@
+export { analyseCommits } from './analyse.js';
+export { bucketBy } from './buckets.js';
+export { weeklyActivity } from './weeks.js';
+export type { CommitAnalytics, CommitBucket, CommitWeek } from './types.js';

--- a/packages/core/src/commits/types.ts
+++ b/packages/core/src/commits/types.ts
@@ -1,0 +1,51 @@
+/**
+ * One `type` or `scope` of the analysed history window.
+ *
+ * `name` is `null` where the commit named none — an unconventional message has
+ * no type, a `feat: …` without parentheses has no scope — rather than being
+ * folded into a bucket called "other", which a repository is free to use as a
+ * real type.
+ */
+export interface CommitBucket {
+  name: string | null;
+  count: number;
+  /** 0–1 of every parsed commit in the window. */
+  share: number;
+  /** How many of them announced a breaking change. */
+  breaking: number;
+}
+
+/** One week of the activity series. */
+export interface CommitWeek {
+  /** Monday of the week (UTC), `YYYY-MM-DD`. */
+  week: string;
+  commits: number;
+}
+
+/**
+ * What the *Commit analytics* screen prints, folded once by the core.
+ *
+ * `total` counts the analysed window; everything the convention decides is
+ * counted over the commits it actually parsed, which is the same set whenever
+ * a `commit-convention` plugin is registered and empty when none is — an
+ * unparsed history then reports its activity and claims nothing about
+ * conformance, rather than reporting every commit as non-conforming.
+ */
+export interface CommitAnalytics {
+  /** Commits in the analysed history window. */
+  total: number;
+  /** Commits the convention parsed at all. */
+  valid: number;
+  /** Parsed commits it could not make sense of — the `6 non-conforming`. */
+  invalid: number;
+  /** 0–1 of the judged commits; 0 when nothing judged them. */
+  validRate: number;
+  /** Commits announcing a breaking change, however the convention marks one. */
+  breaking: number;
+  /** By change type, biggest first. */
+  types: CommitBucket[];
+  /** By scope, biggest first. */
+  scopes: CommitBucket[];
+  /** Contiguous weeks, oldest first — a week with no commits included as 0. */
+  weeks: CommitWeek[];
+}

--- a/packages/core/src/commits/weeks.ts
+++ b/packages/core/src/commits/weeks.ts
@@ -1,0 +1,54 @@
+import type { RawCommit } from '@strata/sdk';
+import type { CommitWeek } from './types.js';
+
+const DAY_MS = 86_400_000;
+const WEEK_MS = 7 * DAY_MS;
+
+/**
+ * Commits per calendar week, oldest first.
+ *
+ * Weeks start Monday **UTC**: an author's timezone is whatever their laptop
+ * said at the time, so bucketing in local time would move a commit between
+ * columns depending on who ran the analysis. Weeks nobody committed in are
+ * emitted as zero, because a chart that silently closes its gaps draws a busy
+ * repository out of a quiet one.
+ *
+ * Commits whose date git could not give us are skipped rather than dated to
+ * the epoch, which would stretch the series across every week since 1970.
+ */
+export function weeklyActivity(log: readonly RawCommit[]): CommitWeek[] {
+  const counts = new Map<number, number>();
+
+  for (const commit of log) {
+    const at = Date.parse(commit.date);
+    if (Number.isNaN(at)) continue;
+    const start = weekStart(at);
+    counts.set(start, (counts.get(start) ?? 0) + 1);
+  }
+  if (counts.size === 0) return [];
+
+  const starts = [...counts.keys()];
+  const last = Math.max(...starts);
+  const weeks: CommitWeek[] = [];
+  // Every start is a Monday midnight UTC, where a week is exactly 7 × 24h.
+  for (let at = Math.min(...starts); at <= last; at += WEEK_MS) {
+    weeks.push({ week: isoDate(at), commits: counts.get(at) ?? 0 });
+  }
+  return weeks;
+}
+
+/** Monday 00:00 UTC of the week a timestamp falls in. */
+function weekStart(at: number): number {
+  const d = new Date(at);
+  const sinceMonday = (d.getUTCDay() + 6) % 7;
+  const midnight = Date.UTC(
+    d.getUTCFullYear(),
+    d.getUTCMonth(),
+    d.getUTCDate(),
+  );
+  return midnight - sinceMonday * DAY_MS;
+}
+
+function isoDate(at: number): string {
+  return new Date(at).toISOString().slice(0, 10);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,6 +35,14 @@ export {
   type CacheStats,
 } from './cache/index.js';
 export {
+  analyseCommits,
+  bucketBy,
+  weeklyActivity,
+  type CommitAnalytics,
+  type CommitBucket,
+  type CommitWeek,
+} from './commits/index.js';
+export {
   openProjectStore,
   memoryProjectStore,
   DuplicateRootError,

--- a/packages/core/src/strata.ts
+++ b/packages/core/src/strata.ts
@@ -8,6 +8,7 @@ import {
   openAnalysisCache,
   type AnalysisCache,
 } from './cache/index.js';
+import { analyseCommits } from './commits/index.js';
 import { branchAt, git, history, listFiles, resolveRev } from './git/index.js';
 import { consoleLogger } from './logger.js';
 import type { PluginRegistry } from './registry.js';
@@ -115,9 +116,12 @@ export class Strata {
       cache.flush();
     }
 
-    // 3. Commit-convention parsing (first registered convention wins).
+    // 3. Commit-convention parsing (first registered convention wins), then the
+    // aggregates over the parsed log — folded once here rather than by every
+    // screen, card and gate that wants them.
     const [convention] = this.registry.byKind('commit-convention');
     const commits = convention ? commitLog.map((c) => convention.parse(c)) : [];
+    const commitAnalytics = analyseCommits(commitLog, commits);
 
     cache.flush();
     return {
@@ -131,6 +135,7 @@ export class Strata {
       languages,
       metrics,
       commits,
+      commitAnalytics,
       cache: {
         enabled: cache.path !== null,
         ...(cache.path ? { path: cache.path } : {}),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,5 +1,6 @@
 import type { LanguageAnalysis, MetricSeries, ParsedCommit } from '@strata/sdk';
 import type { CacheOptions, CacheStats } from './cache/index.js';
+import type { CommitAnalytics } from './commits/index.js';
 
 export interface AnalyzeOptions {
   /** Working-tree root of the repo to analyse. */
@@ -46,5 +47,7 @@ export interface AnalysisReport {
   languages: Record<string, LanguageAnalysis>;
   metrics: MetricSeries[];
   commits: ParsedCommit[];
+  /** The same window, folded: per type and scope, conformance, activity. */
+  commitAnalytics: CommitAnalytics;
   cache: CacheReport;
 }

--- a/packages/server/src/routes/analyze.test.ts
+++ b/packages/server/src/routes/analyze.test.ts
@@ -51,6 +51,16 @@ const report = {
   languages: {},
   metrics: [],
   commits: [],
+  commitAnalytics: {
+    total: 0,
+    valid: 0,
+    invalid: 0,
+    validRate: 0,
+    breaking: 0,
+    types: [],
+    scopes: [],
+    weeks: [],
+  },
   cache: {
     enabled: false,
     hits: 0,

--- a/scripts/lib/report.mjs
+++ b/scripts/lib/report.mjs
@@ -38,13 +38,25 @@ function printCoupling(report, limit = 15) {
   }
 }
 
-function printCommits(report) {
-  const valid = report.commits.filter((c) => c.valid).length;
-  const breaking = report.commits.filter((c) => c.breaking).length;
+function printCommits(report, typeLimit = 8) {
+  const { total, valid, breaking, validRate, types, weeks } =
+    report.commitAnalytics;
   console.log(
-    `\nCommits: ${report.commits.length} analysed, ${valid} conventional, ` +
-      `${breaking} breaking`,
+    `\nCommits: ${total} analysed, ${valid} conventional ` +
+      `(${Math.round(validRate * 100)}%), ${breaking} breaking`,
   );
+
+  const byType = types
+    .slice(0, typeLimit)
+    .map((t) => `${t.name ?? 'unconventional'} ${t.count}`)
+    .join(', ');
+  if (byType) console.log(`  by type: ${byType}`);
+
+  const recent = weeks.slice(-8);
+  if (recent.length > 0) {
+    const series = recent.map((w) => w.commits).join(' ');
+    console.log(`  weekly (from ${recent[0].week}): ${series}`);
+  }
 }
 
 function printCache({ cache }) {


### PR DESCRIPTION
## What

The core folds a run's commit history once, onto a new `report.commitAnalytics`:

- counts per **type** and per **scope**, biggest first, each with its share of the window and its own breaking-change count
- **conformance** — `valid`, `invalid`, `validRate` (the `96% valid · 6 non-conforming` badge)
- total **breaking changes**
- a **weekly activity series**, Monday-started (UTC) and contiguous

New module `packages/core/src/commits/` (`analyse` · `buckets` · `weeks` · `types`), wired into `Strata.analyze()` right after convention parsing and exported from the core barrel. The wire shape is mirrored in the web's `$lib/api` types; `scripts/analyze.mjs` now prints the rate, the type breakdown and the last 8 weeks.

Two calls worth a reviewer's eye:

- **A window no convention parsed still reports its activity.** `total` counts the raw log, but `invalid` / `validRate` are counted over the commits a convention actually judged — a run with no convention plugin loaded reports 0 non-conforming rather than declaring the whole history unconventional.
- **Buckets keep `null` as a name** instead of folding unnamed commits into `"other"`, which a repository is free to use as a real type. `null` sorts last among equal counts.

The web screens still fold the overview card client-side; migrating them (and picking a label for the unnamed bucket) belongs with #31, which this unblocks.

## Why

The `commit-convention` plugin already parses each commit into `{type, scope, breaking, valid}` — what was missing is the aggregation over the parsed log. Without it, every reader that wants a total walks the whole log itself and reaches its own quietly different answer.

Refs #11

## Type of change

- [x] feat / fix / perf / refactor
- [ ] docs / test / build / ci / chore

## Checklist

- [x] `pnpm build && pnpm test && pnpm lint` pass locally (`make check`, 686 tests)
- [x] Added/updated tests where it made sense — unit tests for the folds (offsets, Sundays, quiet weeks, dateless commits, empty history) and an end-to-end run over a real repo with dated commits, a registered convention plugin and a `historyLimit` window
- [x] Docs updated — `packages/core/ARCHITECTURE.md` (building blocks, runtime, the decision), `docs/ARCHITECTURE.md`, `BACKLOG.md`
