### PR TITLE
feat(core): honour the rest of a project's config in the pipeline

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -68,13 +68,19 @@ New area — the mockup's settings screens need somewhere to write to.
       renames a project or re-points its root. Settings are stored sparsely and
       defaulted on read, and a plugin id nobody loaded is refused. `/analyze`
       over a registered root takes `rev` and `historyLimit` from here (an
-      explicit request field still wins) — the remaining fields are stored and
-      served but not yet honoured by the pipeline, which is the item below.
-- [ ] **P0** Honour the rest of a project's config in the pipeline — ignore
-      globs and analyze paths in the file routing, the enabled-plugin lists in
-      `Strata.analyze`, and the chosen commit convention instead of
-      first-registered-wins. (Architecture rules need the rule engine under
-      *Architecture fitness*.)
+      explicit request field still wins) and the rest of the config outright,
+      which is the item below.
+- [x] Honour the rest of a project's config in the pipeline — the analyse paths
+      and ignore globs narrow the tracked files once, before any plugin sees
+      them, so the plugins, the file count the report prints and every cache key
+      describe the same set; the enabled-plugin lists are allow-lists in
+      `Strata.analyze` (nothing named is every plugin, an empty list is none);
+      and the chosen commit convention parses instead of first-registered-wins,
+      parsing nothing rather than falling back when a project names one nobody
+      loaded. These describe the project rather than one run, so `/analyze` has
+      no request field to override them. *Analyze / run* reads the same rule, so
+      its plugin chips answer per project. (Architecture rules need the rule
+      engine under *Architecture fitness*.)
 - [x] App-scoped config store + endpoints — `GET`/`PATCH` `/settings` holds
       appearance (theme, density), the plugins directory, third-party plugin
       loading, the incremental cache toggle, the CI gate thresholds and the AI
@@ -275,16 +281,21 @@ Sans/Mono.
       history limit a run reads, printed rather than edited (*General* owns
       them, and this is where they are used); the plugins that will take part
       as chips, with a line for every loaded plugin that stands by and why —
-      the orchestrator's own rule, so the first commit-convention plugin parses
-      and an AI provider never runs; *Run analysis* (`POST /analyze`); and the
+      the orchestrator's own rule, read against this project's config, so a
+      plugin it leaves out stands by, the convention it chose parses and an AI
+      provider never runs; *Run analysis* (`POST /analyze`); and the
       recent runs. Strata keeps one run summary per project, so the list is
       this browser's own log seeded with the registry's last one. The switcher
       no longer carries the first run; it links here.
-- [ ] **P1** Scope & ignore — ignore globs and analyze paths as editable chip lists
+- [ ] **P1** Scope & ignore — ignore globs and analyze paths as editable chip
+      lists. The pipeline honours both already, so this is the editor for a
+      field that works.
 - [ ] **P1** Language plugins — per-project toggles with the extensions each one
-      claims; *planned* modules (Angular, PHP) shown disabled
+      claims; *planned* modules (Angular, PHP) shown disabled. The allow-list is
+      honoured; this writes it.
 - [ ] **P1** Metrics & convention — metric toggles plus a
-      `conventional` / `gitmoji` / `custom` convention selector
+      `conventional` / `gitmoji` / `custom` convention selector. Both are
+      honoured; this writes them.
 - [ ] **P1** Architecture rules — list and edit `X may not import Y` rules with an
       *enforced* marker
 - [ ] **P1** Danger zone — remove the project from Strata (repo on disk

--- a/README.md
+++ b/README.md
@@ -110,9 +110,10 @@ curl -X PATCH localhost:4000/projects/strata/config \
   -d '{"rev":"main","historyLimit":500,"ignore":["**/dist/**"]}'
 ```
 
-An analysis of a registered root uses those settings as its defaults, so
-`POST /analyze {"root":"…"}` runs what *Project settings* says; a request that
-names `rev` or `historyLimit` itself still wins.
+An analysis of a registered root runs what *Project settings* says: the scope,
+the enabled plugins and the commit convention come from the project, and
+`rev` / `historyLimit` are defaults a request naming them itself overrides.
+(Architecture rules are stored and served; enforcing them is on the backlog.)
 
 The registry lives in `$STRATA_DATA_DIR` (default `<cwd>/.strata/projects.db`),
 its own database beside the cache: `DELETE /cache` never touches it.

--- a/apps/web/src/lib/settings/AnalyzeScreen.svelte
+++ b/apps/web/src/lib/settings/AnalyzeScreen.svelte
@@ -72,7 +72,7 @@
     config.status === 'error' && config.projectId === project?.id,
   );
 
-  let entries = $derived(runPlugins(plugins.response?.plugins ?? []));
+  let entries = $derived(runPlugins(plugins.response?.plugins ?? [], stored));
   let running = $derived(analysis.status === 'running');
   // A failure belongs to the repository it was raised for: the header can be
   // re-analysing something else by the time this screen is opened.
@@ -189,11 +189,12 @@
           error={plugins.error}
         />
         <p class="text-subtle mt-4 text-[0.6875rem]">
-          Who takes part is a workbench-wide question today: what loaded here
-          runs over every project, and a language module whose file types this
-          repository does not hold is skipped when the run reaches it.
-          Narrowing it per project is what <em>Language plugins</em> and
-          <em>Metrics &amp; convention</em> will do.
+          What loaded here is workbench-wide; who takes part is this project's
+          own setting, and a run calls exactly the plugins listed above. A
+          language module whose file types this repository does not hold is
+          skipped when the run reaches it. Editing the lists is what
+          <em>Language plugins</em> and <em>Metrics &amp; convention</em> will
+          do.
         </p>
       </Card>
 

--- a/apps/web/src/lib/settings/run-plugins.test.ts
+++ b/apps/web/src/lib/settings/run-plugins.test.ts
@@ -49,6 +49,54 @@ describe('runPlugins', () => {
     expect(entries[1]?.note).toContain('another convention');
   });
 
+  it('calls only the plugins the project enables', () => {
+    const entries = runPlugins(
+      [
+        plugin(),
+        plugin({ id: 'strata-language-php' }),
+        plugin({ id: 'strata-git-hotspots', kind: 'git-metric' }),
+        plugin({ id: 'strata-git-coupling', kind: 'git-metric' }),
+      ],
+      {
+        languages: ['strata-language-typescript'],
+        metrics: [],
+        convention: null,
+      },
+    );
+
+    expect(entries.map((entry) => entry.runs)).toEqual([
+      true,
+      false,
+      false,
+      false,
+    ]);
+    expect(entries[1]?.note).toContain('leaves it out');
+  });
+
+  it('parses with the convention the project chose, not the first loaded', () => {
+    const entries = runPlugins(
+      [
+        plugin({ id: 'conventional', kind: 'commit-convention' }),
+        plugin({ id: 'gitmoji', kind: 'commit-convention' }),
+      ],
+      { languages: null, metrics: null, convention: 'gitmoji' },
+    );
+
+    expect(entries[0]).toMatchObject({ id: 'conventional', runs: false });
+    expect(entries[0]?.note).toContain('another convention');
+    expect(entries[1]).toMatchObject({ id: 'gitmoji', runs: true });
+  });
+
+  it('stands every convention by when the chosen one is not installed', () => {
+    const entries = runPlugins(
+      [plugin({ id: 'conventional', kind: 'commit-convention' })],
+      { languages: null, metrics: null, convention: 'jira' },
+    );
+
+    expect(entries[0]?.runs).toBe(false);
+    expect(entries[0]?.note).toContain('nobody loaded');
+  });
+
   it('leaves an AI provider out of a run', () => {
     const [entry] = runPlugins([plugin({ id: 'codex', kind: 'ai-provider' })]);
 

--- a/apps/web/src/lib/settings/run-plugins.ts
+++ b/apps/web/src/lib/settings/run-plugins.ts
@@ -1,4 +1,4 @@
-import type { LoadedPluginInfo } from '$lib/api';
+import type { LoadedPluginInfo, ProjectConfig } from '$lib/api';
 
 /**
  * One plugin, as *Analyze / run* shows it: whether the next run calls it at
@@ -17,21 +17,33 @@ export interface RunPlugin {
   note: string;
 }
 
+/** The half of a project's config that decides who takes part. */
+export type RunPluginConfig = Pick<
+  ProjectConfig,
+  'languages' | 'metrics' | 'convention'
+>;
+
 /**
- * Who takes part in a run, in the order the workbench loaded them.
+ * Who takes part in a run over this project, in the order the workbench loaded
+ * them.
  *
- * The rule is the orchestrator's own, not a wish: every language module and
- * every git-metric plugin is called, the **first** commit-convention plugin
- * parses the history and the rest stand by, and an AI provider is never part
- * of an analysis at all. A language module whose extensions match no file in
- * the repository is skipped when the run gets there — that depends on the
- * repository rather than on the registry, so it is not something this list can
- * promise.
+ * The rule is the orchestrator's own, not a wish. Every language module and
+ * every git-metric plugin the project enables is called — a list is an
+ * allow-list, and no list at all is all of them; one commit convention parses
+ * the history, the one the project chose or else the first registered; and an
+ * AI provider is never part of an analysis. A language module whose extensions
+ * match no file in the repository is skipped when the run gets there — that
+ * depends on the repository rather than on the settings, so it is not something
+ * this list can promise.
+ *
+ * Without a config — a project whose settings have not arrived yet — the answer
+ * is the unconfigured one, which is what such a run would do.
  */
 export function runPlugins(
   plugins: readonly LoadedPluginInfo[],
+  config?: RunPluginConfig | null,
 ): RunPlugin[] {
-  let parsing = false;
+  const parses = parsingConvention(plugins, config?.convention ?? null);
   return plugins.map((plugin) => {
     const entry = {
       id: plugin.id,
@@ -42,21 +54,18 @@ export function runPlugins(
 
     switch (plugin.kind) {
       case 'language':
+        return allowed(entry, config?.languages);
       case 'git-metric':
-        return { ...entry, runs: true, note: '' };
-      case 'commit-convention': {
-        // First one loaded wins; a second convention would parse the same
-        // commits into a second answer.
-        const first = !parsing;
-        parsing = true;
-        return first
-          ? { ...entry, runs: true, note: '' }
-          : {
-              ...entry,
-              runs: false,
-              note: 'another convention already parses this history',
-            };
-      }
+        return allowed(entry, config?.metrics);
+      case 'commit-convention':
+        if (plugin.id === parses) return { ...entry, runs: true, note: '' };
+        return {
+          ...entry,
+          runs: false,
+          note: parses
+            ? 'another convention already parses this history'
+            : 'this project chose a convention nobody loaded',
+        };
       case 'ai-provider':
         return {
           ...entry,
@@ -73,4 +82,26 @@ export function runPlugins(
         };
     }
   });
+}
+
+/**
+ * Which convention will actually parse, or `null` when none will — a project
+ * naming one that is no longer installed parses nothing rather than falling
+ * back to another, so every loaded convention stands by and says why.
+ */
+function parsingConvention(
+  plugins: readonly LoadedPluginInfo[],
+  chosen: string | null,
+): string | null {
+  const conventions = plugins.filter((p) => p.kind === 'commit-convention');
+  if (!chosen) return conventions[0]?.id ?? null;
+  return conventions.some((p) => p.id === chosen) ? chosen : null;
+}
+
+function allowed(
+  entry: Omit<RunPlugin, 'runs' | 'note'>,
+  ids: readonly string[] | null | undefined,
+): RunPlugin {
+  if (!ids || ids.includes(entry.id)) return { ...entry, runs: true, note: '' };
+  return { ...entry, runs: false, note: 'this project leaves it out' };
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -140,13 +140,21 @@ builds a `RepoContext` and fans work out.
 ### Analyse a repository
 
 1. `Strata.analyze({root, rev})` resolves `rev` → sha and branch, and lists
-   tracked files (each with its blob sha).
-2. Files are routed to `language` plugins by extension.
-3. Commit history is streamed; `git-metric` plugins compute their series.
+   tracked files (each with its blob sha), narrowed once to the project's
+   scope — its analyse paths, minus its ignore globs.
+2. Files are routed to the enabled `language` plugins by extension.
+3. Commit history is streamed; the enabled `git-metric` plugins compute their
+   series.
 4. The active `commit-convention` plugin parses each commit, and the core folds
    the parsed log into `CommitAnalytics` — per type, per scope, how much of the
    history conforms, breaking changes, weekly activity.
 5. Results merge into an `AnalysisReport`, returned by the API.
+
+Which plugins are "enabled" and which convention is "active" are the project's
+configuration; a project that has configured neither runs every plugin and
+parses with the first convention registered. The scope and those lists are
+applied at the top of the pipeline rather than inside any plugin, so one answer
+serves the plugins, the file count the report prints and the cache keys alike.
 
 Steps 2 and 3 go through the cache. The core skips any plugin whose inputs
 digest to a stored result — that part needs no cooperation. Per-file reuse
@@ -227,9 +235,13 @@ publish. The Linux desktop job is still a stub — it produces no bundle until
   run, the commit convention, architecture rules), behind
   `/projects/:id/config`. Stored sparsely beside the registry entry and merged
   with the defaults on read, so an unset field follows the default rather than a
-  copy of it. `/analyze` takes these as its defaults and lets an explicit
-  request field win. Identity — display name and root — stays on the registry
-  entry, which is the only place that can keep a root unique.
+  copy of it. Every run over a registered root reads them: the revision and the
+  history window as defaults an explicit request field may override, the scope,
+  the plugin lists and the convention as the project's own — a caller wanting a
+  different scope is describing a different project, not a different run.
+  Identity — display name and root — stays on the registry entry, which is the
+  only place that can keep a root unique. (Architecture rules are stored and
+  served; enforcing them needs the rule engine.)
 - **App settings** — how the workbench itself behaves (appearance, the plugins
   directory and third-party loading, the incremental cache, the CI gate
   thresholds, the AI provider instances), behind `/settings`. A third SQLite

--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -46,6 +46,10 @@ itself behaves.
 | `manifest.ts` | `readManifest()` / `resolveEntry()` — validate a `strata.plugin.json` and its entry path. |
 | `plugin-shape.ts` | `pluginShapeError()` — does the module implement the kind it claims? |
 | `summarise.ts` | `summarised()` — fill in a language result's graph summary when the plugin (or its cached run) predates the field. |
+| `scope/glob.ts` | `globMatcher()` — the ignore/analyse globs compiled to one predicate over repo-relative paths. |
+| `scope/files.ts` | `scopedFiles()` — the tracked files narrowed to a project's `paths` minus its `ignore`. |
+| `scope/plugins.ts` | `enabledPlugins()` — the plugins of one kind a run may call. |
+| `scope/convention.ts` | `chosenConvention()` — which `commit-convention` plugin parses this history. |
 | `discover.ts` | `discoverPlugins(dir)` — the manifests installed in a plugins directory. |
 | `plugins-dir.ts` | `userPluginsDir()` — where drop-in plugins live (`STRATA_PLUGINS_DIR`). |
 | `git/exec.ts` | Run a read-only git command. |
@@ -90,14 +94,15 @@ itself behaves.
 
 `analyze()`:
 1. `resolveRev` → sha; `branchAt` → branch (or none); `listFiles` → `RepoFile[]`
-   (blob-keyed).
+   (blob-keyed), narrowed once by `scopedFiles()` to the project's analyse
+   paths minus its ignore globs.
 2. Build `RepoContext`, one `cache` scope per plugin.
-3. Route files to `language` plugins by extension — skipping any plugin whose
-   input digest already has a stored result.
-4. Stream `history`; run `git-metric` plugins (same skip).
-5. Parse commits with the first `commit-convention` plugin, then fold the log
-   into `CommitAnalytics` (per type, per scope, conformance, breaking changes,
-   weekly activity).
+3. Route files to the enabled `language` plugins by extension — skipping any
+   plugin whose input digest already has a stored result.
+4. Stream `history`; run the enabled `git-metric` plugins (same skip).
+5. Parse commits with the project's `commit-convention` plugin — the first
+   registered when it names none — then fold the log into `CommitAnalytics`
+   (per type, per scope, conformance, breaking changes, weekly activity).
 6. Merge into `AnalysisReport`, with the run's own metadata (`RunReport`:
    branch, file count, duration, finished-at) beside the resolved `rev`.
 
@@ -130,7 +135,25 @@ section keeps its value — because each section is one settings screen.
   is recorded in
   `registry.failures()` rather than thrown: a broken third-party plugin must
   cost only itself, not the process.
-- **First-registered commit convention wins** (single active convention).
+- **One active commit convention**, the project's choice, and the
+  first-registered one when it has made none — two conventions would parse the
+  same commits into two answers. A project naming a convention that is no longer
+  installed parses **nothing**, with a warning, rather than falling back to
+  whichever plugin happens to be first: a report claiming a history conforms to
+  a convention nobody asked for is worse than one that claims nothing.
+- **A project's config is turned into behaviour in one place** (`scope/`), at
+  the top of `analyze()`, and never inside a plugin. Scope narrows the file list
+  before any plugin sees it, so the plugins, the report's file count and every
+  cache key below describe the same set — and a plugin left to re-apply the
+  globs itself could disagree with all three, or forget. The enabled-plugin
+  lists are **allow-lists**: nothing named is every plugin (what an unconfigured
+  project asks for), a list is exactly those, and an empty list is none of them.
+- **Globs are matched, not shelled out.** `*` and `?` stay inside a path
+  segment, `**` crosses them and may stand for no directory at all, and a
+  pattern covers the tree under what it names — so `dist` is the build directory
+  without anyone having to know to write it as a wildcard. The lists are typed
+  by hand into a chip list, and the forgiving reading is the one that matches
+  what the writer meant.
 - **The aggregates are folded in the core, not by each reader.** A plugin says
   what one commit means; how many `feat` commits there were is a question every
   screen, card and gate asks, and three of them counting it three ways is three
@@ -226,7 +249,13 @@ section keeps its value — because each section is one settings screen.
   revision that no longer exists. **Mitigation:** the API checks plugin ids
   against the registry as they are written; a stale one survives only until the
   next edit of that field, and an unknown revision fails the run it is used in
-  rather than the settings screen.
+  rather than the settings screen. In a run, a stale id in an allow-list simply
+  selects nothing — the plugin it names is not there to run — and a stale
+  convention warns, because there the whole commit analysis goes quiet.
+- **Risk:** a scope narrow enough to hide the interesting code makes a report
+  look healthy. **Mitigation:** `run.files` is the count the run actually
+  analysed rather than what the checkout holds, and *Analyze / run* prints who
+  takes part, so a report is readable against the scope that produced it.
 - **Risk:** an AI provider's `env` values are stored and served in plain text,
   so a token put there is readable by anyone who can reach the API.
   **Mitigation:** none yet — secret storage (write-only, redacted on read) is

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -68,6 +68,14 @@ export {
   RootDeniedError,
 } from './roots/index.js';
 export {
+  globMatcher,
+  scopedFiles,
+  enabledPlugins,
+  chosenConvention,
+  type FileScope,
+  type LoadedConvention,
+} from './scope/index.js';
+export {
   DEFAULT_PROJECT_CONFIG,
   withDefaults,
   InvalidConfigError,

--- a/packages/core/src/scope/convention.ts
+++ b/packages/core/src/scope/convention.ts
@@ -1,0 +1,25 @@
+import type { CommitConventionPlugin } from '@strata/sdk';
+import type { LoadedPlugin } from '../registry.js';
+
+/** A loaded plugin already narrowed to the commit-convention kind. */
+export type LoadedConvention = LoadedPlugin & {
+  plugin: CommitConventionPlugin;
+};
+
+/**
+ * The convention that parses this run's history: the one the project names,
+ * or — with nothing named — the first registered, which is what the core did
+ * before a project could choose. Still one active convention either way: two
+ * would parse the same commits into two answers.
+ *
+ * A named convention that is not loaded parses nothing rather than falling back
+ * to whichever one happens to be first. A report claiming a history conforms to
+ * a convention nobody asked for is worse than one that claims nothing about it.
+ */
+export function chosenConvention(
+  loaded: readonly LoadedConvention[],
+  id?: string | null,
+): CommitConventionPlugin | undefined {
+  if (!id) return loaded[0]?.plugin;
+  return loaded.find((entry) => entry.manifest.id === id)?.plugin;
+}

--- a/packages/core/src/scope/files.ts
+++ b/packages/core/src/scope/files.ts
@@ -1,0 +1,36 @@
+import type { RepoFile } from '@strata/sdk';
+import { globMatcher } from './glob.js';
+
+/** The part of a repository a run looks at, as a project's config states it. */
+export interface FileScope {
+  /**
+   * Repo-relative paths (or globs) to analyse; empty means the whole
+   * repository.
+   */
+  paths?: readonly string[] | null;
+  /** Globs taken back out of it. */
+  ignore?: readonly string[] | null;
+}
+
+/**
+ * Narrow the tracked files to the ones a project's scope names: `paths` says
+ * what is looked at at all, `ignore` takes back out of it, in that order — a
+ * project that analyses `src` and ignores generated code gets neither `docs/`
+ * nor `src/schema.generated.ts`.
+ *
+ * Routing happens once, here, rather than inside each plugin. Scope is a
+ * property of the project rather than of any one analysis, and a plugin left to
+ * re-apply it could disagree with the file count the run reports — or forget.
+ */
+export function scopedFiles(
+  files: readonly RepoFile[],
+  scope: FileScope = {},
+): RepoFile[] {
+  const included = globMatcher(scope.paths);
+  const excluded = globMatcher(scope.ignore);
+  if (!included && !excluded) return [...files];
+  return files.filter(
+    (file) =>
+      (!included || included(file.path)) && !excluded?.(file.path),
+  );
+}

--- a/packages/core/src/scope/glob.ts
+++ b/packages/core/src/scope/glob.ts
@@ -1,0 +1,68 @@
+/**
+ * The globs a project's *Scope & ignore* lists are written in, compiled to one
+ * predicate over repo-relative paths.
+ *
+ * `*` and `?` stay inside a path segment and `**` crosses them. A `**` segment
+ * may also stand for no directory at all, so `**` + `/*.test.ts` covers
+ * `src/a.test.ts` and `a.test.ts` alike. A pattern matches everything *below*
+ * what it names as well, so `dist` is the build directory and not only a file
+ * that happens to be called `dist` — someone excluding a directory should not
+ * have to know to write it as a wildcard to mean it.
+ *
+ * `null` comes back when the list constrains nothing, because an empty list of
+ * globs means "no restriction" everywhere it is used, and a predicate that
+ * matched nothing would read as its opposite.
+ */
+export function globMatcher(
+  patterns: readonly string[] | null | undefined,
+): ((path: string) => boolean) | null {
+  const expressions = (patterns ?? [])
+    .map(normalise)
+    .filter(Boolean)
+    .map(toRegExp);
+  if (expressions.length === 0) return null;
+  return (path) => expressions.some((re) => re.test(normalise(path)));
+}
+
+/**
+ * A chip list is typed by hand, so `./src`, `/src` and `src/` all arrive
+ * meaning `src`. Paths are compared in the same shape.
+ */
+function normalise(pattern: string): string {
+  return pattern.trim().replace(/^\.?\/+/, '').replace(/\/+$/, '');
+}
+
+function toRegExp(glob: string): RegExp {
+  let source = '';
+  for (let i = 0; i < glob.length; i++) {
+    const char = glob[i]!;
+    if (char === '?') {
+      source += '[^/]';
+      continue;
+    }
+    if (char !== '*') {
+      source += escape(char);
+      continue;
+    }
+    if (glob[i + 1] !== '*') {
+      source += '[^/]*';
+      continue;
+    }
+    i++;
+    // A `**` segment is any run of whole directories, including none of them.
+    if (glob[i + 1] === '/') {
+      i++;
+      source += '(?:[^/]*/)*';
+    } else {
+      source += '.*';
+    }
+  }
+  // The trailing group is what makes a pattern cover the tree under it.
+  return new RegExp(`^(?:${source})(?:/.*)?$`);
+}
+
+const SPECIAL = /[.+^${}()|[\]\\]/;
+
+function escape(char: string): string {
+  return SPECIAL.test(char) ? `\\${char}` : char;
+}

--- a/packages/core/src/scope/index.ts
+++ b/packages/core/src/scope/index.ts
@@ -1,0 +1,9 @@
+/**
+ * What one run is allowed to look at and who is allowed to look — a project's
+ * config turned into the two decisions the pipeline makes before it starts:
+ * which files are in scope, and which plugins take part.
+ */
+export { globMatcher } from './glob.js';
+export { scopedFiles, type FileScope } from './files.js';
+export { enabledPlugins } from './plugins.js';
+export { chosenConvention, type LoadedConvention } from './convention.js';

--- a/packages/core/src/scope/plugins.ts
+++ b/packages/core/src/scope/plugins.ts
@@ -1,0 +1,23 @@
+import type { LoadedPlugin } from '../registry.js';
+
+/**
+ * The plugins of one kind a run may call.
+ *
+ * `null` (or nothing) is every registered one — what the pipeline did before a
+ * project could choose. A list is an **allow-list**: a plugin installed later
+ * stands by until someone adds it, which is the point of writing the list down,
+ * and an empty list runs none of them rather than all of them.
+ *
+ * Ids that name no loaded plugin select nothing. A stored config outliving the
+ * plugin it names is expected — the API checks ids as they are written, not
+ * forever — and the honest reading of "run exactly these" is that an absent one
+ * does not run.
+ */
+export function enabledPlugins<T extends LoadedPlugin>(
+  loaded: readonly T[],
+  allowed?: readonly string[] | null,
+): T[] {
+  if (!allowed) return [...loaded];
+  const wanted = new Set(allowed);
+  return loaded.filter((entry) => wanted.has(entry.manifest.id));
+}

--- a/packages/core/src/scope/scope.test.ts
+++ b/packages/core/src/scope/scope.test.ts
@@ -1,0 +1,224 @@
+import type {
+  CommitConventionPlugin,
+  LanguagePlugin,
+  RepoFile,
+  StrataPlugin,
+} from '@strata/sdk';
+import { describe, expect, it } from 'vitest';
+import type { LoadedPlugin } from '../registry.js';
+import {
+  chosenConvention,
+  enabledPlugins,
+  globMatcher,
+  scopedFiles,
+  type LoadedConvention,
+} from './index.js';
+
+/**
+ * A project's config decides what a run looks at and who takes part, so these
+ * are the two questions the pipeline asks before it starts. The rules that
+ * matter are the forgiving ones: an empty list restricts nothing, a bare
+ * directory name means the tree under it, and a plugin list is an allow-list
+ * rather than a wish.
+ */
+
+function file(path: string): RepoFile {
+  return { path, blob: path, read: async () => '' };
+}
+
+function paths(files: readonly RepoFile[]): string[] {
+  return files.map((f) => f.path);
+}
+
+const TREE = [
+  'src/a.ts',
+  'src/nested/b.ts',
+  'src/nested/b.test.ts',
+  'a.test.ts',
+  'docs/guide.md',
+  'dist/bundle.js',
+].map(file);
+
+describe('globMatcher', () => {
+  it('constrains nothing for a list with nothing in it', () => {
+    expect(globMatcher([])).toBeNull();
+    expect(globMatcher(null)).toBeNull();
+    expect(globMatcher(undefined)).toBeNull();
+    // A row someone left blank is not a pattern that matches everything.
+    expect(globMatcher(['', '  ', '/'])).toBeNull();
+  });
+
+  it('keeps a single star inside one path segment', () => {
+    const matches = globMatcher(['src/*.ts'])!;
+
+    expect(matches('src/a.ts')).toBe(true);
+    expect(matches('src/nested/b.ts')).toBe(false);
+  });
+
+  it('crosses segments with a double star, including none of them', () => {
+    const matches = globMatcher(['**/*.test.ts'])!;
+
+    expect(matches('src/nested/b.test.ts')).toBe(true);
+    expect(matches('a.test.ts')).toBe(true);
+    expect(matches('src/a.ts')).toBe(false);
+  });
+
+  it('matches one character per question mark, within a segment', () => {
+    const matches = globMatcher(['src/?.ts'])!;
+
+    expect(matches('src/a.ts')).toBe(true);
+    expect(matches('src/ab.ts')).toBe(false);
+  });
+
+  it('takes a bare directory name for the tree under it', () => {
+    const matches = globMatcher(['dist'])!;
+
+    expect(matches('dist/bundle.js')).toBe(true);
+    expect(matches('dist')).toBe(true);
+    // A sibling that only starts with the same letters is not inside it.
+    expect(matches('distribution/x.ts')).toBe(false);
+  });
+
+  it('reads a hand-typed pattern the way it was meant', () => {
+    const matches = globMatcher(['./src/', '/docs'])!;
+
+    expect(matches('src/a.ts')).toBe(true);
+    expect(matches('docs/guide.md')).toBe(true);
+  });
+
+  it('treats regex punctuation as itself', () => {
+    const matches = globMatcher(['a+b.ts'])!;
+
+    expect(matches('a+b.ts')).toBe(true);
+    expect(matches('aab.ts')).toBe(false);
+    expect(matches('a+bXts')).toBe(false);
+  });
+});
+
+describe('scopedFiles', () => {
+  it('analyses the whole repository when nothing narrows it', () => {
+    expect(paths(scopedFiles(TREE))).toEqual(paths(TREE));
+    expect(paths(scopedFiles(TREE, { paths: [], ignore: [] }))).toEqual(
+      paths(TREE),
+    );
+  });
+
+  it('keeps only what the analyse paths name', () => {
+    expect(paths(scopedFiles(TREE, { paths: ['src'] }))).toEqual([
+      'src/a.ts',
+      'src/nested/b.ts',
+      'src/nested/b.test.ts',
+    ]);
+  });
+
+  it('drops what the ignore globs name', () => {
+    expect(paths(scopedFiles(TREE, { ignore: ['dist', '**/*.test.ts'] }))).toEqual(
+      ['src/a.ts', 'src/nested/b.ts', 'docs/guide.md'],
+    );
+  });
+
+  it('ignores within the analysed paths, not the other way round', () => {
+    const scoped = scopedFiles(TREE, {
+      paths: ['src'],
+      ignore: ['**/*.test.ts'],
+    });
+
+    expect(paths(scoped)).toEqual(['src/a.ts', 'src/nested/b.ts']);
+  });
+
+  it('hands back a list of its own, so a caller cannot mutate the input', () => {
+    const scoped = scopedFiles(TREE);
+    scoped.pop();
+
+    expect(TREE).toHaveLength(6);
+  });
+});
+
+/**
+ * Selecting plugins reads nothing but the manifest, so the export behind it is
+ * a stand-in that would throw if anything here tried to run it.
+ */
+const STUB: LanguagePlugin = {
+  kind: 'language',
+  extensions: ['ts'],
+  analyze: () => {
+    throw new Error('choosing who runs never runs anyone');
+  },
+};
+
+function loaded(id: string, plugin: StrataPlugin = STUB): LoadedPlugin {
+  return {
+    manifest: {
+      id,
+      name: id,
+      kind: plugin.kind,
+      version: '1.0.0',
+      sdk: '0.1.0',
+      main: './dist/index.js',
+    },
+    plugin,
+    source: 'builtin',
+    manifestPath: `/plugins/${id}/strata.plugin.json`,
+  };
+}
+
+describe('enabledPlugins', () => {
+  const all = [loaded('ts'), loaded('php')];
+
+  it('runs every registered plugin when the project names none', () => {
+    expect(enabledPlugins(all)).toEqual(all);
+    expect(enabledPlugins(all, null)).toEqual(all);
+  });
+
+  it('runs exactly the ones a list names', () => {
+    expect(enabledPlugins(all, ['php'])).toEqual([all[1]]);
+  });
+
+  it('runs none for an empty list, rather than all of them', () => {
+    expect(enabledPlugins(all, [])).toEqual([]);
+  });
+
+  it('skips an id no plugin answers to', () => {
+    expect(enabledPlugins(all, ['ts', 'rust'])).toEqual([all[0]]);
+  });
+});
+
+function convention(id: string, name: string): LoadedConvention {
+  const plugin: CommitConventionPlugin = {
+    kind: 'commit-convention',
+    convention: name,
+    parse: () => ({
+      type: null,
+      scope: null,
+      breaking: false,
+      subject: '',
+      tags: {},
+      valid: false,
+    }),
+  };
+  return { ...loaded(id, plugin), plugin };
+}
+
+describe('chosenConvention', () => {
+  const all = [
+    convention('commit-conventional', 'conventional'),
+    convention('commit-gitmoji', 'gitmoji'),
+  ];
+
+  it('takes the first registered one when the project names none', () => {
+    expect(chosenConvention(all)?.convention).toBe('conventional');
+    expect(chosenConvention(all, null)?.convention).toBe('conventional');
+  });
+
+  it('takes the one the project names, wherever it loaded', () => {
+    expect(chosenConvention(all, 'commit-gitmoji')?.convention).toBe('gitmoji');
+  });
+
+  it('parses nothing rather than falling back to another convention', () => {
+    expect(chosenConvention(all, 'commit-jira')).toBeUndefined();
+  });
+
+  it('has nothing to choose when no convention is registered', () => {
+    expect(chosenConvention([])).toBeUndefined();
+  });
+});

--- a/packages/core/src/scoped-run.test.ts
+++ b/packages/core/src/scoped-run.test.ts
@@ -1,0 +1,252 @@
+import { execFile } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { PluginRegistry } from './registry.js';
+import { Strata } from './strata.js';
+
+const exec = promisify(execFile);
+
+/**
+ * A project's configuration is only worth storing if the pipeline obeys it, so
+ * this drives a real repository with real plugins loaded and asks what actually
+ * ran: which files reached a language module, which plugins were called at all,
+ * and which convention parsed the history.
+ *
+ * The repository:
+ *
+ *   src/a.ts            in scope
+ *   src/a.test.ts       in scope, but what an ignore glob is for
+ *   docs/note.md        outside `src`
+ *
+ * Two language plugins claim `ts`, one claims `md`, and two conventions parse
+ * the same history into recognisably different answers.
+ */
+
+const LANGUAGE = (id: string, ext: string) => `export default {
+  kind: 'language',
+  extensions: ['${ext}'],
+  async analyze(ctx) {
+    return {
+      graph: {
+        nodes: ctx.files.map((f) => ({ id: f.path, label: f.path, kind: 'file' })),
+        edges: [],
+        cycles: [],
+      },
+      deadCode: [],
+      metrics: [{ id: '${id}', label: '${id}', points: [] }],
+    };
+  },
+};
+`;
+
+const METRIC = (id: string) => `export default {
+  kind: 'git-metric',
+  id: '${id}',
+  async compute(ctx) {
+    return { id: '${id}', label: '${id}', points: [] };
+  },
+};
+`;
+
+/** Each convention stamps its own name as the type, so the report says who ran. */
+const CONVENTION = (name: string) => `export default {
+  kind: 'commit-convention',
+  convention: '${name}',
+  parse: (commit) => ({
+    type: '${name}',
+    scope: null,
+    breaking: false,
+    subject: commit.message.trim(),
+    tags: {},
+    valid: true,
+  }),
+};
+`;
+
+let repo: string;
+let plugins: string;
+let strata: Strata;
+
+async function git(args: string[]): Promise<void> {
+  await exec('git', args, {
+    cwd: repo,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'Strata Test',
+      GIT_AUTHOR_EMAIL: 'test@example.com',
+      GIT_COMMITTER_NAME: 'Strata Test',
+      GIT_COMMITTER_EMAIL: 'test@example.com',
+    },
+  });
+}
+
+/** Write a plugin out as a directory the registry can load. */
+async function install(
+  registry: PluginRegistry,
+  id: string,
+  kind: string,
+  source: string,
+): Promise<void> {
+  const dir = join(plugins, id);
+  mkdirSync(join(dir, 'dist'), { recursive: true });
+  writeFileSync(join(dir, 'dist/index.mjs'), source);
+  writeFileSync(
+    join(dir, 'strata.plugin.json'),
+    JSON.stringify({
+      id,
+      name: id,
+      kind,
+      version: '1.0.0',
+      sdk: '0.1.0',
+      main: './dist/index.mjs',
+    }),
+  );
+  await registry.loadFrom(join(dir, 'strata.plugin.json'));
+}
+
+/** Which files one language plugin was handed, from the graph it returned. */
+function analysed(
+  languages: Record<string, { graph: { nodes: { id: string }[] } }>,
+  ext: string,
+): string[] {
+  return (languages[ext]?.graph.nodes ?? []).map((n) => n.id).sort();
+}
+
+beforeAll(async () => {
+  repo = mkdtempSync(join(tmpdir(), 'strata-scoped-repo-'));
+  plugins = mkdtempSync(join(tmpdir(), 'strata-scoped-plugins-'));
+
+  await exec('git', ['init', '-q', '-b', 'main'], { cwd: repo });
+  mkdirSync(join(repo, 'src'));
+  mkdirSync(join(repo, 'docs'));
+  writeFileSync(join(repo, 'src/a.ts'), 'export const a = 1;\n');
+  writeFileSync(join(repo, 'src/a.test.ts'), 'export const t = 1;\n');
+  writeFileSync(join(repo, 'docs/note.md'), '# note\n');
+  await git(['add', '-A']);
+  await git(['commit', '-m', 'feat: initial']);
+
+  const registry = new PluginRegistry();
+  await install(registry, 'lang-ts', 'language', LANGUAGE('lang-ts', 'ts'));
+  await install(registry, 'lang-md', 'language', LANGUAGE('lang-md', 'md'));
+  await install(registry, 'metric-a', 'git-metric', METRIC('metric-a'));
+  await install(registry, 'metric-b', 'git-metric', METRIC('metric-b'));
+  await install(
+    registry,
+    'convention-first',
+    'commit-convention',
+    CONVENTION('first'),
+  );
+  await install(
+    registry,
+    'convention-second',
+    'commit-convention',
+    CONVENTION('second'),
+  );
+
+  // No cache: every run here is about what the pipeline chose to do, and a
+  // stored result would answer for a scope the next run no longer has.
+  strata = new Strata(registry, { cache: false });
+}, 30_000);
+
+afterAll(() => {
+  strata.close();
+  for (const dir of [repo, plugins]) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('a run without a configuration', () => {
+  it('analyses the whole repository with every plugin', async () => {
+    const report = await strata.analyze({ root: repo });
+
+    expect(report.run.files).toBe(3);
+    expect(analysed(report.languages, 'ts')).toEqual([
+      'src/a.test.ts',
+      'src/a.ts',
+    ]);
+    expect(analysed(report.languages, 'md')).toEqual(['docs/note.md']);
+    expect(report.metrics.map((m) => m.id)).toEqual(['metric-a', 'metric-b']);
+    expect(report.commits[0]?.type).toBe('first');
+  });
+});
+
+describe('scope', () => {
+  it('routes only the analysed paths to the plugins', async () => {
+    const report = await strata.analyze({ root: repo, paths: ['src'] });
+
+    expect(analysed(report.languages, 'ts')).toEqual([
+      'src/a.test.ts',
+      'src/a.ts',
+    ]);
+    // Nothing matched the markdown plugin's extension, so it never ran.
+    expect(report.languages.md).toBeUndefined();
+  });
+
+  it('takes the ignored globs back out', async () => {
+    const report = await strata.analyze({
+      root: repo,
+      paths: ['src'],
+      ignore: ['**/*.test.ts'],
+    });
+
+    expect(analysed(report.languages, 'ts')).toEqual(['src/a.ts']);
+  });
+
+  it('reports the file count the run actually analysed', async () => {
+    const report = await strata.analyze({ root: repo, ignore: ['docs'] });
+
+    expect(report.run.files).toBe(2);
+  });
+});
+
+describe('enabled plugins', () => {
+  it('calls only the language plugins the project allows', async () => {
+    const report = await strata.analyze({ root: repo, languages: ['lang-md'] });
+
+    expect(Object.keys(report.languages)).toEqual(['md']);
+  });
+
+  it('calls only the git metrics the project allows', async () => {
+    const report = await strata.analyze({ root: repo, metrics: ['metric-b'] });
+
+    expect(report.metrics.map((m) => m.id)).toEqual(['metric-b']);
+  });
+
+  it('runs none of a kind for an empty allow-list', async () => {
+    const report = await strata.analyze({
+      root: repo,
+      languages: [],
+      metrics: [],
+    });
+
+    expect(report.languages).toEqual({});
+    expect(report.metrics).toEqual([]);
+  });
+});
+
+describe('commit convention', () => {
+  it('parses with the convention the project chose, not the first loaded', async () => {
+    const report = await strata.analyze({
+      root: repo,
+      convention: 'convention-second',
+    });
+
+    expect(report.commits.map((c) => c.type)).toEqual(['second']);
+    expect(report.commitAnalytics.types).toEqual([
+      { name: 'second', count: 1, share: 1, breaking: 0 },
+    ]);
+  });
+
+  it('parses nothing when the chosen convention is not loaded', async () => {
+    const report = await strata.analyze({ root: repo, convention: 'gone' });
+
+    expect(report.commits).toEqual([]);
+    // An unparsed window still reports its activity and judges no conformance.
+    expect(report.commitAnalytics.total).toBe(1);
+    expect(report.commitAnalytics.valid).toBe(0);
+    expect(report.commitAnalytics.invalid).toBe(0);
+  });
+});

--- a/packages/core/src/strata.ts
+++ b/packages/core/src/strata.ts
@@ -12,6 +12,11 @@ import { analyseCommits } from './commits/index.js';
 import { branchAt, git, history, listFiles, resolveRev } from './git/index.js';
 import { consoleLogger } from './logger.js';
 import type { PluginRegistry } from './registry.js';
+import {
+  chosenConvention,
+  enabledPlugins,
+  scopedFiles,
+} from './scope/index.js';
 import { summarised } from './summarise.js';
 import type { AnalysisReport, AnalyzeOptions, StrataOptions } from './types.js';
 
@@ -20,6 +25,12 @@ import type { AnalysisReport, AnalyzeOptions, StrataOptions } from './types.js';
  * plugins are registered. Everything a plugin sees flows through here, which is
  * also where the incremental cache hooks in: each plugin gets a `cache` scoped
  * to its own id, and a plugin whose entire input is unchanged is skipped.
+ *
+ * It is also where a project's configuration turns into behaviour: the scope
+ * narrows the file list once, before any plugin sees it, and the enabled-plugin
+ * lists and the chosen commit convention decide who is called at all. A caller
+ * that passes none of them gets the whole repository and every plugin, which is
+ * what an unconfigured project asks for.
  */
 export class Strata {
   private cache?: AnalysisCache;
@@ -38,7 +49,9 @@ export class Strata {
     const before = cache.stats();
     const rev = await resolveRev(opts.root, opts.rev);
     const branch = await branchAt(opts.root, opts.rev);
-    const files = await listFiles(opts.root, rev);
+    // Scope is applied to the tracked files once, here: every plugin, the
+    // report's file count and every cache key below then describe the same set.
+    const files = scopedFiles(await listFiles(opts.root, rev), opts);
     const ctx: Omit<RepoContext, 'cache'> = {
       root: opts.root,
       rev,
@@ -47,9 +60,13 @@ export class Strata {
       log: consoleLogger,
     };
 
-    // 1. Per-language static analysis, routed by file extension.
+    // 1. Per-language static analysis, routed by file extension — across the
+    // language plugins this project enabled.
     const languages: Record<string, LanguageAnalysis> = {};
-    for (const { manifest, plugin } of this.registry.loadedByKind('language')) {
+    for (const { manifest, plugin } of enabledPlugins(
+      this.registry.loadedByKind('language'),
+      opts.languages,
+    )) {
       const exts = new Set(plugin.extensions.map((e) => `.${e}`));
       const matched = files.filter((f) => exts.has(extname(f.path)));
       if (matched.length === 0) continue;
@@ -84,8 +101,9 @@ export class Strata {
       maxCount: opts.historyLimit,
     });
     const metrics: MetricSeries[] = [];
-    for (const { manifest, plugin } of this.registry.loadedByKind(
-      'git-metric',
+    for (const { manifest, plugin } of enabledPlugins(
+      this.registry.loadedByKind('git-metric'),
+      opts.metrics,
     )) {
       // Metrics read history as well as files, and a shallow clone can hold a
       // different history for the same sha — so the repo goes into the key too.
@@ -116,10 +134,19 @@ export class Strata {
       cache.flush();
     }
 
-    // 3. Commit-convention parsing (first registered convention wins), then the
-    // aggregates over the parsed log — folded once here rather than by every
-    // screen, card and gate that wants them.
-    const [convention] = this.registry.byKind('commit-convention');
+    // 3. Commit-convention parsing (the project's convention, else the first
+    // registered), then the aggregates over the parsed log — folded once here
+    // rather than by every screen, card and gate that wants them.
+    const conventions = this.registry.loadedByKind('commit-convention');
+    const convention = chosenConvention(conventions, opts.convention);
+    if (opts.convention && !convention) {
+      // Nothing parses, so the report claims nothing about conformance. Worth a
+      // line: the config names a plugin this workbench no longer has.
+      consoleLogger.warn(
+        `commit convention "${opts.convention}" is not loaded; ` +
+          'this run parses no commits.',
+      );
+    }
     const commits = convention ? commitLog.map((c) => convention.parse(c)) : [];
     const commitAnalytics = analyseCommits(commitLog, commits);
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -9,6 +9,25 @@ export interface AnalyzeOptions {
   rev?: string;
   /** Cap the history window (number of commits). */
   historyLimit?: number;
+  /**
+   * Repo-relative paths (or globs) to analyse; omitted or empty is the whole
+   * repository.
+   */
+  paths?: readonly string[] | null;
+  /** Globs excluded from it. */
+  ignore?: readonly string[] | null;
+  /**
+   * Ids of the `language` plugins that may run; omitted or `null` is every
+   * registered one. A list is an allow-list, and an empty one runs none.
+   */
+  languages?: readonly string[] | null;
+  /** Ids of the `git-metric` plugins that may run; same rule. */
+  metrics?: readonly string[] | null;
+  /**
+   * Id of the `commit-convention` plugin that parses the history; omitted or
+   * `null` takes the first registered one.
+   */
+  convention?: string | null;
   /** Set false to recompute everything for this run (nothing is read or written). */
   cache?: boolean;
 }
@@ -33,7 +52,11 @@ export interface CacheReport extends CacheStats {
 export interface RunReport {
   /** Branch the analysed revision names; null for a detached HEAD, sha or tag. */
   branch: string | null;
-  /** Tracked files at that revision. */
+  /**
+   * Files the run analysed — tracked at that revision and inside the project's
+   * scope, so a repository narrowed to `src` reports what `src` holds rather
+   * than what the checkout does.
+   */
   files: number;
   /** Wall-clock time of the whole run, in milliseconds. */
   durationMs: number;

--- a/packages/server/ARCHITECTURE.md
+++ b/packages/server/ARCHITECTURE.md
@@ -36,7 +36,7 @@ UI and CI. Keeps transport concerns out of the core.
 | GET | `/browse` | `?path=&hidden=` → `{ path, parent, repo, entries, roots }` — the subdirectories of one directory on the server's machine, each marked whether it is a git working tree. The folder picker behind *Add project*. Directory names only, and only inside `$STRATA_ROOTS` (default: the server user's home): 403 outside them, 404 for a path that is not a directory. |
 | GET | `/settings` | The app-wide settings, filled out with the defaults: `{ appearance, engine, gates, ai }`. |
 | PATCH | `/settings` | Body: any of those four sections → all of them. Merges two levels deep (section, then field); an array replaces. 400 on a value that cannot be stored, or on a section named with no field in it. |
-| POST | `/analyze` | Body `{ root, rev?, historyLimit?, cache? }` → `AnalysisReport` (incl. run metadata and cache stats). The root is confined to `$STRATA_ROOTS` first: 403 outside them, 404 for a path inside them that is not a directory. Over a registered root, the project's config supplies the defaults and the run updates its last-analysis summary; the cache default comes from the app settings. |
+| POST | `/analyze` | Body `{ root, rev?, historyLimit?, cache? }` → `AnalysisReport` (incl. run metadata and cache stats). The root is confined to `$STRATA_ROOTS` first: 403 outside them, 404 for a path inside them that is not a directory. Over a registered root, the project's config supplies the defaults (`rev`, `historyLimit`) and its scope, plugin lists and convention outright, and the run updates its last-analysis summary; the cache default comes from the app settings. |
 | DELETE | `/cache` | Empty the incremental cache — the *Clear cache* button, which is an action rather than a setting. Registered projects and app settings are untouched: both live in their own databases. |
 
 ## 4. Building Blocks
@@ -96,6 +96,13 @@ restart of nothing.
   it: `/analyze` fills in `rev` and `historyLimit` from the settings and lets an
   explicit request field win, so *Re-analyze* follows *Project settings* while a
   CI job asking for a revision still gets that revision.
+- **…except for what describes the project rather than the run.** The scope
+  (analyse paths, ignore globs), the enabled-plugin lists and the commit
+  convention reach the core from the config with no request field to override
+  them. A revision is a question you ask of a repository; a scope is part of
+  what the repository *is* to this workbench, and a caller wanting a different
+  one is describing a different project. Keeping them off the request body also
+  keeps two reports of the same project comparable.
 - **Settings are two resources, split by who can promise what** — `/projects/:id`
   owns identity (the root has to stay unique across projects), `/projects/:id/config`
   owns what an analysis does. One PATCH each, merging by field.

--- a/packages/server/src/routes/analyze.test.ts
+++ b/packages/server/src/routes/analyze.test.ts
@@ -163,6 +163,27 @@ describe('POST /analyze', () => {
     expect(requested).toMatchObject({ rev: 'develop', historyLimit: 500 });
   });
 
+  it('hands the core the project scope, its plugins and its convention', async () => {
+    const { id } = projects.add({ name: 'Strata', root: repo });
+    projects.setConfig(id, {
+      paths: ['src'],
+      ignore: ['**/*.test.ts'],
+      languages: ['language-typescript'],
+      metrics: [],
+      convention: 'commit-gitmoji',
+    });
+
+    await analyze(repo);
+
+    expect(requested).toMatchObject({
+      paths: ['src'],
+      ignore: ['**/*.test.ts'],
+      languages: ['language-typescript'],
+      metrics: [],
+      convention: 'commit-gitmoji',
+    });
+  });
+
   it('lets the request override what the settings say', async () => {
     const { id } = projects.add({ name: 'Strata', root: repo });
     projects.setConfig(id, { rev: 'develop', historyLimit: 500 });
@@ -177,9 +198,31 @@ describe('POST /analyze', () => {
 
     await analyze(repo);
 
-    // `HEAD` and no cap are what the core does anyway; a null limit must not
-    // reach it as a number.
-    expect(requested).toMatchObject({ rev: 'HEAD', historyLimit: undefined });
+    // `HEAD`, no cap, the whole repository and every plugin are what the core
+    // does anyway; a null limit must not reach it as a number.
+    expect(requested).toMatchObject({
+      rev: 'HEAD',
+      historyLimit: undefined,
+      paths: [],
+      ignore: [],
+      languages: null,
+      metrics: null,
+      convention: null,
+    });
+  });
+
+  it('leaves the core its own defaults for a root nobody registered', async () => {
+    await analyze(unregistered);
+
+    // No project, so nothing narrows the run: the whole repository, every
+    // plugin, and the convention the registry loaded first.
+    expect(requested).toMatchObject({
+      paths: undefined,
+      ignore: undefined,
+      languages: undefined,
+      metrics: undefined,
+      convention: undefined,
+    });
   });
 
   it('runs with the cache the app settings leave switched on', async () => {

--- a/packages/server/src/routes/analyze.ts
+++ b/packages/server/src/routes/analyze.ts
@@ -44,11 +44,20 @@ export function analyzeRoute(app: FastifyInstance, ctx: RouteContext): void {
     // A registered project's settings are the defaults for a run over it, so
     // clicking *Re-analyze* honours what *Project settings* says. What the
     // request states wins: a CI job asking for a specific revision means it.
+    //
+    // Scope, the enabled-plugin lists and the convention have no request field
+    // to override them — they describe the project rather than one run, and a
+    // caller that wants a different scope is describing a different project.
     const { project, config } = registered(ctx, root, req.log);
     const report = await ctx.strata.analyze({
       root,
       rev: rev ?? config?.rev,
       historyLimit: historyLimit ?? config?.historyLimit ?? undefined,
+      paths: config?.paths,
+      ignore: config?.ignore,
+      languages: config?.languages,
+      metrics: config?.metrics,
+      convention: config?.convention,
       // The incremental cache is app-scoped, not per project: it is keyed on
       // blob shas and shared across every repository this workbench analyses.
       cache: cache ?? cacheEnabled(ctx, req.log),


### PR DESCRIPTION
Closes #100.

`/projects/:id/config` has stored a project's scope, its enabled-plugin lists and its commit convention since #58, but only `rev` and `historyLimit` ever reached a run — the orchestrator picked the convention with `byKind('commit-convention')[0]`, and the other fields appeared nowhere outside the store. This wires the rest through, which unblocks *Scope & ignore* (#78), *Language plugins* (#79) and *Metrics & convention* (#80) from writing values the pipeline would discard.

## What changed

**A new `scope/` module in the core** turns the config into the two decisions a run makes before it starts:

| File | Responsibility |
|------|----------------|
| `scope/glob.ts` | `globMatcher()` — the ignore/analyse globs compiled to one predicate |
| `scope/files.ts` | `scopedFiles()` — tracked files narrowed to `paths` minus `ignore` |
| `scope/plugins.ts` | `enabledPlugins()` — the plugins of one kind a run may call |
| `scope/convention.ts` | `chosenConvention()` — which convention parses this history |

**Scope is applied once**, at the top of `analyze()` and never inside a plugin, so the plugins, the file count the report prints and every cache key below describe the same set. A plugin left to re-apply the globs itself could disagree with all three, or forget.

**The plugin lists are allow-lists.** Nothing named is every plugin (what an unconfigured project asks for), a list is exactly those, an empty list is none of them.

**Globs are matched, not shelled out.** `*` and `?` stay inside a path segment, `**` crosses them and may stand for no directory at all, and a pattern covers the tree under what it names — so `dist` is the build directory without the writer having to know to spell it as a wildcard. These lists get typed by hand into a chip list, and the forgiving reading is the one that matches what was meant.

**A convention nobody loaded parses nothing**, with a warning, rather than falling back to whichever plugin happens to be first. A report claiming a history conforms to a convention nobody asked for is worse than one claiming nothing. A stale id in an allow-list needs no such care — the plugin it names is not there to run either way.

**`/analyze` passes all five from the config with no request field to override them.** A revision is a question you ask of a repository; a scope is part of what that repository *is* to this workbench, so a caller wanting a different one is describing a different project. Keeping them off the request body also keeps two reports of the same project comparable. `rev` and `historyLimit` stay overridable as before.

## Two consequences worth naming

- **`run.files` now counts what the run analysed**, not what the checkout holds. Documented on `RunReport`; a report is meant to be readable against the scope that produced it.
- **The shipped *Analyze / run* screen stated the orchestrator's rule**, which this made stale, so `run-plugins.ts` now reads the project config the screen already loads: a plugin the project leaves out stands by, and the chosen convention parses. No new editors — those are #78–#80.

The commit log itself is still unfiltered; ignore-globs for git metrics is its own P1 backlog item. Architecture rules still need the rule engine (#20).

## Verification

720 tests pass, plus lint, typecheck and build. New coverage: 20 unit tests over the scope helpers, 9 driving a real git repo with six stub plugins through the whole pipeline (`scoped-run.test.ts`), 2 on the route, 3 on the web list.

A smoke run against this repo, with `paths: ['packages/core/src']` and `ignore: ['**/*.test.ts']`:

```
whole repo : 452 files, 1 metrics, 50 commits parsed
scoped     :  64 files, 0 metrics, 50 commits parsed
```

No test files, nothing outside the path, `metrics: []` ran none, and the named convention parsed the window.