### PR TITLE
feat(server): authenticate the HTTP API with a bearer token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,12 +21,23 @@ STRATA_API_PROXY=http://localhost:4000
 # Default: <cwd>/.strata/plugins — in the container, /app/.strata/plugins.
 STRATA_PLUGINS_DIR=.strata/plugins
 
+# --- Who may call the API ----------------------------------------------------
+# One shared secret for this workbench. Set it and every endpoint except
+# /health requires `Authorization: Bearer <token>`; anything else is a 401.
+# Leave it unset and the API answers whoever can reach the port — reasonable on
+# the machine you are analysing, and warned about at every startup. Set it
+# before the port is reachable from anywhere else, and terminate TLS in front:
+# the token is sent in clear text otherwise. Rotating it is a restart.
+# Generate one with: openssl rand -hex 32
+# STRATA_TOKEN=
+
 # --- Roots the API may reach -------------------------------------------------
 # The allow-list every path a request names is confined to, PATH-separated:
 # what GET /browse lists (directory *names* only), what POST /projects may
-# register, and what POST /analyze may walk. Anything outside is a 403. The API
-# ships without authentication, so keep this to where your repositories
-# actually live. A root that does not exist is simply not offered.
+# register, and what POST /analyze may walk. Anything outside is a 403. It
+# applies to every caller, token or not — that says who may call, this says
+# what they may reach — so keep it to where your repositories actually live.
+# A root that does not exist is simply not offered.
 # Default: the server user's home directory; in the container, the /repos mount.
 # Set it to / to opt out of the confinement entirely.
 # STRATA_ROOTS=/repos:/srv/code

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -38,11 +38,17 @@ Anything marked *(mockup)* exists as a design and needs an implementation.
       inside. `$STRATA_BROWSE_ROOTS` is still read as the former name. The
       allow-list says *what* may be reached; *who* may reach it is the auth item
       below.
-- [ ] **P1** Authentication for the HTTP API — the allow-list confines what a
-      request may reach, not who may send one. Everything reachable on the port
-      is still unauthenticated (`DELETE /cache`, `DELETE /projects/:id`,
-      `PATCH /settings` and the plugins directory it names), so a deployment
-      outside a trusted network needs this.
+- [x] Authentication for the HTTP API — `$STRATA_TOKEN` is one shared secret
+      for the workbench, sent as `Authorization: Bearer <token>` and checked in
+      `onRequest`, before a body is parsed or a path resolved; everything but
+      `/health` answers 401 without it, unrouted paths included, so the API is
+      no way to ask which endpoints exist. Compared in constant time and read
+      from the header alone — a token in a query string lands in the request
+      log. Leaving it unset keeps the open API, which is what the machine being
+      analysed wants, and startup says so every time (and says so again for a
+      token short enough to guess). The allow-list still bounds every path a
+      caller names: holding the token makes them trusted, not unconfined. The
+      web UI asks for the token once and keeps it in the browser.
 - [ ] **P1** Worker queue for heavy analyses (BullMQ / worker_threads); progress
       events so *Re-analyze* can show a running state instead of blocking.
 - [ ] **P1** Analyse a bare/remote repo (clone-on-demand) and a specific `rev` range
@@ -330,7 +336,9 @@ Sans/Mono.
       nothing reads it yet
 - [ ] **P1** Commit the pnpm lockfile and switch CI to `--frozen-lockfile`
 - [ ] **P1** Serve the built web UI from `@strata/server` so the Docker image is a
-      single deployable workbench
+      single deployable workbench. The static files go outside `$STRATA_TOKEN`
+      (a browser has to load the app before it can be asked for the token);
+      every API path under them stays behind it.
 - [ ] **P2** Tauri desktop app under `apps/desktop` (enable the Linux release job)
 - [ ] **P2** Add macOS/Windows to the desktop release matrix (+ signing)
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ theme layer and API client wired; the analysis screens are next. See
 - Incremental cache — SQLite, keyed on the git blob sha, so a rerun only
   re-analyses what changed ✅
 - Drop-in third-party plugins from a user plugins directory ✅
+- Path allow-list + a bearer token on the API — what a request may reach, and
+  who may send one ✅
 
 **Architecture & AI**
 - Architecture fitness rules ("`ui` may not import `db`") ⏳
@@ -84,9 +86,29 @@ curl -s localhost:4000/plugins
 Every path a request names — the folder picker's, a project's root, `/analyze`'s
 `root` — is confined to `$STRATA_ROOTS` (`PATH`-separated, the server user's
 home by default, `/repos` in the image). Anything outside is a 403, symlinks
-included: the API is unauthenticated, so what it may walk is a deployment
-decision rather than whatever the process can read. Point it at the directory
-your repositories live in — or at `/` to opt out of the confinement.
+included: what the workbench may walk is a deployment decision rather than
+whatever the process can read. Point it at the directory your repositories live
+in — or at `/` to opt out of the confinement.
+
+### Who may call
+
+Set `$STRATA_TOKEN` and every endpoint but `/health` needs it:
+
+```bash
+STRATA_TOKEN=$(openssl rand -hex 32) make dev
+
+curl -s localhost:4000/plugins                      # 401
+curl -s -H "Authorization: Bearer $STRATA_TOKEN" localhost:4000/plugins
+```
+
+Leave it unset and the API answers anyone who can reach the port — fine on the
+machine you are analysing, which is why it stays the default, and said out loud
+at every startup. Set it before the port is reachable from anywhere else, and
+put TLS in front: the token travels in the clear otherwise. The web UI asks for
+it once and keeps it in the browser.
+
+The two limits are separate — the token says *who* may call, `$STRATA_ROOTS`
+says *what* any caller may reach — and holding the token widens nothing.
 
 Repositories can be registered, so the workbench remembers them (and what the
 last analysis of each one found) instead of being handed a path every time:
@@ -154,11 +176,16 @@ already do; `STRATA_CACHE=0` disables it globally.
 ```bash
 docker run --rm -p 4000:4000 \
   -v /path/to/repo:/repos/target:ro \
+  -e STRATA_TOKEN="$(openssl rand -hex 32)" \
   ghcr.io/sschorer/strata:latest
-# then POST /analyze with {"root":"/repos/target"}
+# then POST /analyze with {"root":"/repos/target"} and the token as
+# `Authorization: Bearer <token>`
 # the image confines requests to /repos ($STRATA_ROOTS); mount elsewhere and
 # set it to match
 ```
+
+Published ports are reachable from more than the host — set the token, or
+publish to `127.0.0.1:4000:4000` only.
 
 Or `docker compose up` (see `compose.yml`).
 

--- a/apps/web/ARCHITECTURE.md
+++ b/apps/web/ARCHITECTURE.md
@@ -26,7 +26,11 @@ app-scoped settings screens. The face of Strata for browser/self-host use.
 ## 3. Interfaces (Context)
 
 - **Depends on:** the `@strata/server` REST API (`/health`, `/plugins`,
-  `/analyze`, `/cache`, `/projects`, `/projects/:id/config`, `/browse`).
+  `/analyze`, `/cache`, `/projects`, `/projects/:id/config`, `/browse`,
+  `/settings`).
+- **Authentication:** none of its own. A deployment that set `$STRATA_TOKEN`
+  answers 401 until the reader supplies it once; it is then sent as
+  `Authorization: Bearer <token>` on every call.
 - **Consumed by:** end users (browser / desktop).
 
 ## 4. Building Blocks
@@ -37,7 +41,8 @@ app-scoped settings screens. The face of Strata for browser/self-host use.
 | `src/app.css` | Tailwind entry: fonts, `@theme inline` token mapping, base layer |
 | `src/lib/theme/tokens.css` | The palette, twice — dark and light, keyed on `data-theme` |
 | `src/lib/theme/*` | `mode` (types + resolution), `storage`, `apply`, `controller.svelte` (state) |
-| `src/lib/api/*` | `base` (origin), `request` (fetch + `ApiError`), one module per endpoint, `types` |
+| `src/lib/api/*` | `base` (origin), `request` (fetch + the bearer header + `ApiError`), one module per endpoint, `types` |
+| `src/lib/auth/*` | The workbench token: `storage` (where the browser keeps it), `session.svelte` (what is held, and whether the server has locked us out), `verify` (does the server answer to this one), and `Unlock` — the panel that takes it |
 | `src/lib/analysis/*` | The app-wide last report (`store.svelte`) and the remembered repo path |
 | `src/lib/projects/*` | The project registry end to end: `store.svelte` (the registered projects and which one the workbench is on), `entries` (project → a switcher row), `label` (root → name), `crumbs` (path → the picker's steps), `selection` (the remembered choice), and the views — `ProjectSwitcher`, `ProjectList`, `AddProject`, `FolderPicker` |
 | `src/lib/plugins/*` | What the workbench loaded (`store.svelte`), fetched once for the whole app |
@@ -63,7 +68,10 @@ what more than one screen uses moves up into `lib/components/`.
    and tracks `prefers-color-scheme` while the app is open.
 3. The switcher loads the registry and adopts the project the workbench was
    last on, which points `lib/analysis` at that repository.
-4. A view calls `lib/api`; failures arrive as one `ApiError` shape.
+4. A view calls `lib/api`; failures arrive as one `ApiError` shape. Every call
+   carries the workbench token when the browser holds one, and a 401 locks the
+   session, which puts the unlock panel in place of the whole frame until a
+   token is accepted.
 5. In dev, Vite proxies the API paths to `:4000`; in production the server
    serves this build, so the same relative URLs hold.
 
@@ -107,6 +115,8 @@ what more than one screen uses moves up into `lib/components/`.
 | 34 | **The run window is printed where a run is started, edited where it is owned** | *Analyze / run* shows the root, revision and history limit and offers no field for any of them: they are one setting each and *General* is where a setting is set. A second form over the same two values would be a second answer to "what does this project analyse", and the one in front of the button would win by being nearer. What the screen owes the reader is what is about to happen, so it prints the three and links to the screen that changes them |
 | 35 | **The chips say what the orchestrator does, not what the config allows** | `runPlugins` follows the pipeline's own rule — every language module and git metric runs, the first commit-convention plugin parses and the rest stand by, an AI provider takes no part — because a chip in front of *Run analysis* is a promise about the next run. The per-project plugin lists are stored and not yet honoured (`BACKLOG.md` → *Honour the rest of a project's config*), so filtering the chips by them would show a plugin as skipped that in fact runs. A plugin that stands by prints why: "why is my convention plugin doing nothing" is the question this screen exists to answer |
 | 36 | **The recents list is this browser's log, seeded from the registry** | The server records one run per project — the last one — so a list of several has nowhere else to live yet (`BACKLOG.md` → *Run history per project*). `recents-storage` keeps it per project in `localStorage`, and the registry's last run is folded in when the screen opens, so a run from another machine still shows up as the newest entry. `mergeRun` dedupes on the finish timestamp and hands back the **same list** when nothing is new, which is what keeps the effect that records a finished run from watching its own write. The screen also folds that run into the registry itself: the switcher normally does it and is not mounted inside settings |
+| 37 | **A 401 locks the whole app, not the call that got it** | A server started with `$STRATA_TOKEN` refuses *everything*, so a screen that renders "401" per panel would say it five times and explain it nowhere. `request.ts` hands the status to the session, the session locks, and the root layout puts `Unlock` where the frame goes — one prompt, one place, and no store left showing a stale count it can no longer refresh. Unlocking reloads rather than replaying: every store loads once and is holding a failed request by then, and a reload is the honest way to start them over |
+| 38 | **The token is checked before it is adopted, and dropped when it is refused** | `Unlock` calls `/plugins` with the candidate — `apiRequest`'s `token` option, which also promises not to re-raise the prompt — so a typo is answered where it was typed rather than by every screen behind it failing again. A token the server turns down is cleared from `localStorage` on the way into the lock, because keeping it only means the next reload fails the same way with nothing on screen to say why |
 
 ## 7. Quality & Risks
 
@@ -123,6 +133,11 @@ what more than one screen uses moves up into `lib/components/`.
   first analysis costs one click more than it could. Navigating from the
   switcher would put routing inside a component the frame otherwise keeps clear
   of it (decision 20), which is not worth that click yet.
+- **Risk:** the workbench token is kept in `localStorage`, so any script that
+  runs on this origin can read it. Nothing third-party is loaded — no CDN, no
+  analytics, fonts are self-hosted — which is what makes it acceptable; a
+  session cookie the browser cannot read is the upgrade if the UI ever grows
+  a surface that renders untrusted HTML.
 - **Debt:** the recents list is per browser (decision 36), so a workbench used
   from two machines shows two different lists over the same project — each with
   the server's last run at the top. A handful of runs kept in the registry is

--- a/apps/web/src/lib/api/request.test.ts
+++ b/apps/web/src/lib/api/request.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { session } from '$lib/auth/session.svelte';
 import { ApiError, apiRequest } from './request';
 
 function stubFetch(impl: typeof fetch): ReturnType<typeof vi.fn> {
@@ -9,7 +10,13 @@ function stubFetch(impl: typeof fetch): ReturnType<typeof vi.fn> {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  session.forget();
 });
+
+function headersOf(fetchMock: ReturnType<typeof vi.fn>): Record<string, string> {
+  const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+  return init.headers as Record<string, string>;
+}
 
 describe('apiRequest', () => {
   it('returns the parsed JSON body', async () => {
@@ -98,5 +105,61 @@ describe('apiRequest', () => {
     expect(error).toBeInstanceOf(ApiError);
     expect(error).toMatchObject({ status: 0, cause });
     expect((error as ApiError).message).toContain('Cannot reach');
+  });
+});
+
+describe('the token it carries', () => {
+  const unauthorized = async () =>
+    Response.json(
+      { statusCode: 401, error: 'Unauthorized', message: 'needs a token' },
+      { status: 401 },
+    );
+
+  it('sends nothing on a workbench that never asked for one', async () => {
+    const fetchMock = stubFetch(async () => Response.json({}));
+
+    await apiRequest('/plugins');
+
+    expect(headersOf(fetchMock).authorization).toBeUndefined();
+  });
+
+  it('sends the session token as a bearer credential', async () => {
+    session.unlock('the-real-token');
+    const fetchMock = stubFetch(async () => Response.json({}));
+
+    await apiRequest('/plugins');
+
+    expect(headersOf(fetchMock).authorization).toBe('Bearer the-real-token');
+  });
+
+  it('locks the workbench on a 401, so one prompt stands for every screen', async () => {
+    session.unlock('stale');
+    stubFetch(unauthorized);
+
+    const error = await apiRequest('/plugins').catch((err: unknown) => err);
+
+    expect(error).toMatchObject({ status: 401 });
+    expect(session.locked).toBe(true);
+    expect(session.refused).toBe(true);
+  });
+
+  it('leaves other failures to the caller', async () => {
+    session.unlock('the-real-token');
+    stubFetch(async () => Response.json({ message: 'nope' }, { status: 403 }));
+
+    await apiRequest('/browse').catch(() => undefined);
+
+    expect(session.locked).toBe(false);
+    expect(session.token).toBe('the-real-token');
+  });
+
+  it('tries a candidate token without touching the session', async () => {
+    const fetchMock = stubFetch(unauthorized);
+
+    await apiRequest('/plugins', { token: 'a-guess' }).catch(() => undefined);
+
+    expect(headersOf(fetchMock).authorization).toBe('Bearer a-guess');
+    // The unlock panel is already up; a wrong guess is its answer to give.
+    expect(session.locked).toBe(false);
   });
 });

--- a/apps/web/src/lib/api/request.ts
+++ b/apps/web/src/lib/api/request.ts
@@ -1,3 +1,7 @@
+// The session is imported by module rather than through `$lib/auth`, whose
+// barrel reaches back here for the token check — one import each way through
+// the barrels would be a cycle.
+import { session } from '$lib/auth/session.svelte';
 import { apiUrl } from './base';
 
 /** Every failed call surfaces as this, so views can render one error shape. */
@@ -19,16 +23,26 @@ interface RequestOptions {
   /** Serialised as JSON; sets the content-type. */
   body?: unknown;
   signal?: AbortSignal;
+  /**
+   * A credential to try instead of the session's — and, with it, a promise not
+   * to raise the unlock prompt if it is refused. The unlock panel checks a
+   * token before the session adopts it, and a wrong one there is an answer to
+   * the reader, not a fresh challenge.
+   */
+  token?: string;
 }
 
 /** One JSON round-trip against the server, with failures normalised. */
 export async function apiRequest<T>(
   path: string,
-  { method = 'GET', body, signal }: RequestOptions = {},
+  { method = 'GET', body, signal, token }: RequestOptions = {},
 ): Promise<T> {
   const url = apiUrl(path);
   const headers: Record<string, string> = { accept: 'application/json' };
   if (body !== undefined) headers['content-type'] = 'application/json';
+
+  const credential = token ?? session.token;
+  if (credential) headers.authorization = `Bearer ${credential}`;
 
   let response: Response;
   try {
@@ -47,6 +61,10 @@ export async function apiRequest<T>(
   }
 
   if (!response.ok) {
+    // A 401 is the whole app's business, not this call's: the workbench is
+    // locked until a token is supplied, so the session raises the prompt once
+    // and every screen behind it stops guessing why its data never came.
+    if (response.status === 401 && token === undefined) session.challenge();
     throw new ApiError(
       url,
       response.status,

--- a/apps/web/src/lib/auth/Unlock.svelte
+++ b/apps/web/src/lib/auth/Unlock.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+  import { ApiError } from '$lib/api';
+  import { session } from './session.svelte';
+  import { verifyToken } from './verify';
+
+  interface Props {
+    /**
+     * What to do once the token is accepted. The default reloads: every store
+     * in the app loads once and is holding a failed request by the time this
+     * panel is up, and a reload is the honest way to start them over.
+     */
+    onunlocked?: () => void;
+  }
+
+  let { onunlocked = () => location.reload() }: Props = $props();
+
+  let token = $state('');
+  let busy = $state(false);
+  let error = $state('');
+
+  async function submit(): Promise<void> {
+    const candidate = token.trim();
+    if (!candidate) {
+      error = 'Enter the token this workbench was started with.';
+      return;
+    }
+
+    busy = true;
+    error = '';
+    try {
+      await verifyToken(candidate);
+      session.unlock(candidate);
+      onunlocked();
+    } catch (err) {
+      // 401 is the one failure worth rewording: the server's message tells a
+      // caller how to send a token, and this reader just did.
+      error =
+        err instanceof ApiError
+          ? err.status === 401
+            ? 'That token was not accepted.'
+            : err.message
+          : 'Unexpected client error.';
+    } finally {
+      busy = false;
+    }
+  }
+</script>
+
+<div class="bg-bg text-ink grid min-h-screen place-items-center p-6">
+  <main
+    class="bg-surface border-line shadow-card w-full max-w-sm rounded-xl border p-6"
+  >
+    <h1 class="text-base font-semibold">This workbench is locked</h1>
+    <p class="text-muted mt-2 text-sm">
+      {#if session.refused}
+        The token this browser had was refused. It has been forgotten — enter
+        the current one.
+      {:else}
+        The server was started with a token
+        (<code class="font-mono text-xs">STRATA_TOKEN</code>). Enter it to
+        continue.
+      {/if}
+    </p>
+
+    <form
+      class="mt-5 space-y-3"
+      onsubmit={(event) => {
+        event.preventDefault();
+        void submit();
+      }}
+    >
+      <div>
+        <label class="text-subtle text-xs" for="unlock-token">Token</label>
+        <!-- svelte-ignore a11y_autofocus -->
+        <input
+          class="border-line bg-bg text-ink placeholder:text-subtle mt-1 w-full rounded-md border px-2 py-1.5 font-mono text-xs"
+          id="unlock-token"
+          type="password"
+          name="token"
+          autocomplete="current-password"
+          autofocus
+          spellcheck="false"
+          placeholder="••••••••••••••••"
+          bind:value={token}
+        />
+      </div>
+
+      {#if error}
+        <p class="text-danger text-xs" role="alert">{error}</p>
+      {/if}
+
+      <button
+        type="submit"
+        class="bg-accent text-accent-ink hover:bg-accent-strong w-full rounded-md px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-60"
+        disabled={busy}
+      >
+        {busy ? 'Checking…' : 'Unlock'}
+      </button>
+    </form>
+
+    <p class="text-subtle mt-4 text-xs">
+      Kept in this browser until the server turns it down.
+    </p>
+  </main>
+</div>

--- a/apps/web/src/lib/auth/Unlock.test.ts
+++ b/apps/web/src/lib/auth/Unlock.test.ts
@@ -1,0 +1,122 @@
+import { flushSync } from 'svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from '$lib/test/render';
+import { session } from './session.svelte';
+import Unlock from './Unlock.svelte';
+
+/**
+ * The way in when the server was started with a token. It checks the token
+ * before adopting it, so a typo is answered here rather than by every screen
+ * behind it failing again.
+ */
+
+let ui: ReturnType<typeof render>;
+let unlocked: number;
+
+function field(): HTMLInputElement {
+  const input = ui.container.querySelector('input');
+  if (!input) throw new Error('no token field');
+  return input;
+}
+
+function submit(token: string): void {
+  const input = field();
+  input.value = token;
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+  flushSync();
+  ui.container.querySelector('form')?.requestSubmit();
+}
+
+/** The submit handler awaits the server; let the round-trip finish. */
+async function settle(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  flushSync();
+}
+
+function text(): string {
+  return ui.container.textContent ?? '';
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  session.forget();
+  unlocked = 0;
+  ui = render(Unlock, { onunlocked: () => (unlocked += 1) });
+});
+
+afterEach(() => {
+  ui.destroy();
+  vi.unstubAllGlobals();
+  session.forget();
+});
+
+describe('Unlock', () => {
+  it('says what the workbench wants', () => {
+    expect(text()).toContain('STRATA_TOKEN');
+    expect(field().type).toBe('password');
+  });
+
+  it('adopts a token the server answers to', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => Response.json({ plugins: [] })),
+    );
+
+    submit('the-real-token');
+    await settle();
+
+    expect(session.token).toBe('the-real-token');
+    expect(session.locked).toBe(false);
+    expect(unlocked).toBe(1);
+  });
+
+  it('checks the token before storing it', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        Response.json({ message: 'needs a token' }, { status: 401 }),
+      ),
+    );
+
+    submit('a-guess');
+    await settle();
+
+    expect(text()).toContain('not accepted');
+    expect(session.token).toBeNull();
+    expect(unlocked).toBe(0);
+  });
+
+  it('reports a server that is down as itself, not as a bad token', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new TypeError('Failed to fetch');
+      }),
+    );
+
+    submit('the-real-token');
+    await settle();
+
+    expect(text()).toContain('Cannot reach');
+    expect(unlocked).toBe(0);
+  });
+
+  it('asks for a token rather than sending an empty one', async () => {
+    const fetchMock = vi.fn(async () => Response.json({}));
+    vi.stubGlobal('fetch', fetchMock);
+
+    submit('   ');
+    await settle();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(text()).toContain('Enter the token');
+  });
+
+  it('explains itself differently once a token has been turned down', () => {
+    session.unlock('stale');
+    session.challenge();
+    flushSync();
+
+    expect(text()).toContain('refused');
+  });
+});

--- a/apps/web/src/lib/auth/index.ts
+++ b/apps/web/src/lib/auth/index.ts
@@ -1,0 +1,9 @@
+export { default as Unlock } from './Unlock.svelte';
+export { Session, session } from './session.svelte';
+export {
+  clearStoredToken,
+  readStoredToken,
+  storeToken,
+  TOKEN_STORAGE_KEY,
+} from './storage';
+export { verifyToken } from './verify';

--- a/apps/web/src/lib/auth/session.svelte.ts
+++ b/apps/web/src/lib/auth/session.svelte.ts
@@ -1,0 +1,69 @@
+import { clearStoredToken, readStoredToken, storeToken } from './storage';
+
+/**
+ * The credential this browser talks to the workbench with.
+ *
+ * A server started without `$STRATA_TOKEN` never challenges, so this stays
+ * empty and nothing about it is ever shown — the unlock panel exists for the
+ * deployment that set one.
+ *
+ * Exported as a class as well as the singleton below: a test wants its own
+ * instance, the app wants one.
+ */
+export class Session {
+  #token = $state<string | null>(null);
+  #locked = $state(false);
+  #refused = $state(false);
+
+  constructor(token: string | null = readStoredToken()) {
+    this.#token = token;
+  }
+
+  /** What to send, or `null` to send nothing. */
+  get token(): string | null {
+    return this.#token;
+  }
+
+  /** The server has asked for a credential this browser cannot supply. */
+  get locked(): boolean {
+    return this.#locked;
+  }
+
+  /** The lock followed a token being turned down, rather than none being held. */
+  get refused(): boolean {
+    return this.#refused;
+  }
+
+  /**
+   * A request came back 401. The token that produced it is dropped, stored
+   * copy included: keeping a credential the server refuses only means the next
+   * reload fails the same way, silently.
+   */
+  challenge(): void {
+    this.#refused = this.#token !== null;
+    this.#token = null;
+    this.#locked = true;
+    clearStoredToken();
+  }
+
+  /**
+   * Accept a token the server has just answered to. Remembered, so a reload
+   * does not ask again.
+   */
+  unlock(token: string): void {
+    this.#token = token;
+    this.#locked = false;
+    this.#refused = false;
+    storeToken(token);
+  }
+
+  /** Forget the token without waiting to be challenged for it. */
+  forget(): void {
+    this.#token = null;
+    this.#locked = false;
+    this.#refused = false;
+    clearStoredToken();
+  }
+}
+
+export const session = new Session();

--- a/apps/web/src/lib/auth/session.test.ts
+++ b/apps/web/src/lib/auth/session.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Session } from './session.svelte';
+import { TOKEN_STORAGE_KEY } from './storage';
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe('Session', () => {
+  it('starts from what this browser stored', () => {
+    localStorage.setItem(TOKEN_STORAGE_KEY, 'from-storage');
+
+    const session = new Session();
+
+    expect(session.token).toBe('from-storage');
+    expect(session.locked).toBe(false);
+  });
+
+  it('holds nothing on a workbench that never asked', () => {
+    const session = new Session();
+
+    expect(session.token).toBeNull();
+    expect(session.locked).toBe(false);
+  });
+
+  it('locks when the server challenges, and says a token was never held', () => {
+    const session = new Session(null);
+
+    session.challenge();
+
+    expect(session.locked).toBe(true);
+    expect(session.refused).toBe(false);
+  });
+
+  it('drops a refused token rather than sending it again after a reload', () => {
+    localStorage.setItem(TOKEN_STORAGE_KEY, 'stale');
+    const session = new Session();
+
+    session.challenge();
+
+    expect(session.refused).toBe(true);
+    expect(session.token).toBeNull();
+    expect(localStorage.getItem(TOKEN_STORAGE_KEY)).toBeNull();
+  });
+
+  it('unlocks with a token and remembers it', () => {
+    const session = new Session(null);
+    session.challenge();
+
+    session.unlock('the-real-token');
+
+    expect(session.token).toBe('the-real-token');
+    expect(session.locked).toBe(false);
+    expect(session.refused).toBe(false);
+    expect(localStorage.getItem(TOKEN_STORAGE_KEY)).toBe('the-real-token');
+  });
+
+  it('forgets a token without a challenge', () => {
+    const session = new Session('held');
+
+    session.forget();
+
+    expect(session.token).toBeNull();
+    expect(localStorage.getItem(TOKEN_STORAGE_KEY)).toBeNull();
+  });
+
+  it('works where storage does not', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('storage disabled');
+    });
+    const session = new Session(null);
+
+    expect(() => session.unlock('the-real-token')).not.toThrow();
+    expect(session.token).toBe('the-real-token');
+  });
+});

--- a/apps/web/src/lib/auth/storage.ts
+++ b/apps/web/src/lib/auth/storage.ts
@@ -1,0 +1,33 @@
+/**
+ * Where this browser keeps the workbench token. Same storage as the theme, for
+ * the same reason: there is no server session to hang it on, and the SPA has
+ * to survive a reload without asking again.
+ */
+export const TOKEN_STORAGE_KEY = 'strata:token';
+
+/** `null` when nothing is stored, or storage is unavailable. */
+export function readStoredToken(): string | null {
+  try {
+    const stored = localStorage.getItem(TOKEN_STORAGE_KEY)?.trim();
+    return stored ? stored : null;
+  } catch {
+    // Private mode / storage disabled: the reader unlocks once per session.
+    return null;
+  }
+}
+
+export function storeToken(token: string): void {
+  try {
+    localStorage.setItem(TOKEN_STORAGE_KEY, token);
+  } catch {
+    // Not being able to remember it must not stop this session working.
+  }
+}
+
+export function clearStoredToken(): void {
+  try {
+    localStorage.removeItem(TOKEN_STORAGE_KEY);
+  } catch {
+    // Nothing to do — there is no storage to clear.
+  }
+}

--- a/apps/web/src/lib/auth/verify.ts
+++ b/apps/web/src/lib/auth/verify.ts
@@ -1,0 +1,15 @@
+// Imported by module rather than through `$lib/api`: see the note in
+// `api/request.ts` about the two barrels.
+import { apiRequest } from '$lib/api/request';
+
+/**
+ * Does the server answer to this token?
+ *
+ * `/plugins` is the cheapest guarded endpoint — no path to resolve, no
+ * repository to read, and it is behind the same hook as everything else. It
+ * resolves when the token works and rejects with the `ApiError` that says why
+ * not, which is a 401 for the wrong token and a 0 for a server that is down.
+ */
+export async function verifyToken(token: string): Promise<void> {
+  await apiRequest('/plugins', { token });
+}

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import '../app.css';
   import { page } from '$app/state';
+  import { session, Unlock } from '$lib/auth';
   import { Shell } from '$lib/shell';
   import { theme } from '$lib/theme';
 
@@ -10,6 +11,12 @@
   $effect(() => theme.start());
 </script>
 
-<Shell pathname={page.url.pathname}>
-  {@render children()}
-</Shell>
+<!-- A locked workbench has nothing to show: every screen behind the frame is a
+     failed request, and the rail would print counts it could not fetch. -->
+{#if session.locked}
+  <Unlock />
+{:else}
+  <Shell pathname={page.url.pathname}>
+    {@render children()}
+  </Shell>
+{/if}

--- a/compose.yml
+++ b/compose.yml
@@ -7,6 +7,11 @@ services:
       - "4000:4000"
     environment:
       PORT: "4000"
+      # Who may call: with this set, every endpoint but /health needs
+      # `Authorization: Bearer <token>`. The port below is published, so it is
+      # reachable from more than this host — set it in .env
+      # (openssl rand -hex 32) unless you narrow the mapping to 127.0.0.1.
+      STRATA_TOKEN: ${STRATA_TOKEN:-}
       # What this server may reach on disk: the mount below. It confines the
       # *Add project* folder picker, what may be registered, and what
       # /analyze will walk. Without it the default is the container user's

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -53,8 +53,9 @@ self-hosted over the browser.
 
 **In scope:** ingesting a local git repo, running analyses, serving and
 rendering results, plugin loading, optional AI calls.
-**Out of scope (today):** hosting git itself, auth/multi-tenant SaaS, writing to
-the analysed repo.
+**Out of scope (today):** hosting git itself, user accounts / multi-tenant SaaS
+(the API takes one shared token, not a directory of users), writing to the
+analysed repo.
 
 ### External interfaces
 
@@ -223,9 +224,18 @@ publish. The Linux desktop job is still a stub — it produces no bundle until
   whose repository begins above one is refused rather than registered. Outside
   is a 403; a path inside a root that is not a directory is a 404, and a
   missing path outside one gets the same 403 as anything else out there, so the
-  API is no way to ask what exists on the disk. On an unauthenticated API that
-  confinement is what stands between a caller and the filesystem: see
-  *Security* below.
+  API is no way to ask what exists on the disk. It confines every caller,
+  including one holding the token — the two limits answer different questions:
+  see *API token* below.
+- **API token** — who may call at all. `$STRATA_TOKEN` is one shared secret for
+  the workbench, presented as `Authorization: Bearer <token>` and checked
+  before a request is routed, parsed or resolved; anything but `/health` — the
+  liveness probe, which a container watcher calls without a credential —
+  answers 401 without it. Compared in constant time, over digests, and read
+  from the header alone: a token in a query string lands in the request log and
+  the browser's history, and one in a cookie would need a CSRF story. Leaving
+  it unset keeps the API open, which is the reasonable default on the machine
+  being analysed and a warning at every startup anywhere else.
 - **Folder browsing** — `/browse` lists the subdirectories of one directory on
   the server's machine and marks which are git working trees, so *Add project*
   can be a tree rather than a path the reader has to know by heart. Names of
@@ -259,14 +269,15 @@ publish. The Linux desktop job is still a stub — it produces no bundle until
   `@strata/sdk`) therefore stay stable as internals move. See CONTRIBUTING.
 - **Configuration** — `.env` (see `.env.example`); AI creds never committed.
 - **Logging** — structured logger injected via `RepoContext.log`.
-- **Security** — analysed repos mounted read-only; AI is opt-in. Every path a
-  request names is confined to `$STRATA_ROOTS` (see *Path allow-list* above),
-  so browsing, registering and analysing all stop at the same boundary. The
-  HTTP API is otherwise unauthenticated and assumes a trusted network:
-  `DELETE /cache` discards cached results (cost: a recomputation),
-  `DELETE /projects/:id` drops a registry entry, and `PATCH /settings` names
-  the directory the next start loads plugins from. An auth story is on the
-  backlog; until it lands, do not expose the port beyond a trusted network.
+- **Security** — analysed repos mounted read-only; AI is opt-in. Two limits sit
+  in front of the API and neither replaces the other: `$STRATA_TOKEN` says who
+  may call, `$STRATA_ROOTS` says what any caller may reach (see *API token* and
+  *Path allow-list* above). Without a token the port is open to whoever can
+  reach it — `DELETE /cache` discards cached results (cost: a recomputation),
+  `DELETE /projects/:id` drops a registry entry, `PATCH /settings` names the
+  directory the next start loads plugins from — which is why startup says so
+  until one is set. Set it, and terminate TLS in front, before the port is
+  reachable from anywhere but the machine it runs on.
 
 ## 9. Architecture Decisions
 
@@ -279,6 +290,7 @@ publish. The Linux desktop job is still a stub — it produces no bundle until
 | ADR-5 | Docker image is the primary deliverable | Matches "self-host over the browser". |
 | ADR-6 | Vouch file over GitHub team | Works on a personal repo; auditable in git history. |
 | ADR-7 | Web UI is a SvelteKit **static SPA** (Tailwind v4) | The build is plain files: the server can serve it from the same image, and the Tauri shell can load it from disk. Analysis is a local API call, so nothing needs server rendering. |
+| ADR-8 | One shared bearer token (`$STRATA_TOKEN`), opt-in | A self-hosted workbench has one owner: a secret in the environment is the whole credential, with no user store, no session state and nothing for CI to log into. Off by default keeps `docker run` and localhost working; startup warns while it is. Named, revocable keys are the upgrade path if it ever serves more than one person. |
 
 (Promote these into `docs/adr/NNNN-*.md` as they harden.)
 

--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -260,7 +260,9 @@ section keeps its value — because each section is one settings screen.
   so a token put there is readable by anyone who can reach the API.
   **Mitigation:** none yet — secret storage (write-only, redacted on read) is
   the next step in this area, and until it lands nothing sensitive belongs in
-  provider settings. The store is local and the API assumes a trusted network.
+  provider settings. The store is local, and `$STRATA_TOKEN` decides who may
+  read `/settings` at all — but a deployment that set no token serves them to
+  whoever reaches the port.
 - **Risk:** `listDirectory()` reads directories outside any repository, so a
   caller that exposes it exposes directory names. **Mitigation:** the roots
   above, no file names in the answer, and no content read at any point — plus

--- a/packages/server/ARCHITECTURE.md
+++ b/packages/server/ARCHITECTURE.md
@@ -20,11 +20,17 @@ UI and CI. Keeps transport concerns out of the core.
 
 - **Depends on:** `@strata/core`, `@strata/sdk`, Fastify.
 - **Consumed by:** `apps/web`, CI, `curl`.
+- **Authentication:** `$STRATA_TOKEN`, if the deployment sets one. Every
+  endpoint below except `/health` then needs
+  `Authorization: Bearer <token>`; without it, or with the wrong one, the
+  answer is `401` and a `WWW-Authenticate: Bearer realm="Strata"` header.
+  Unset means an open API — the default, and what a workstation wants — said
+  out loud in a warning at startup.
 - **Endpoints:**
 
 | Method | Path | Purpose |
 |--------|------|---------|
-| GET | `/health` | Liveness. |
+| GET | `/health` | Liveness. The one endpoint outside the token, so a probe can watch a container without holding a credential. |
 | GET | `/plugins` | What loaded, from where, and what was skipped: `{ directory, plugins, failures }` — each plugin its manifest plus a `source` (`builtin`/`user`). `directory` is the one actually scanned at startup. |
 | GET | `/projects` | `{ projects }` — the registry, in registration order; each entry carries its id, display name, root and last-analysis summary. |
 | POST | `/projects` | Body `{ name, root }` → the created `Project` (201). The root is confined to `$STRATA_ROOTS` (403 outside, 404 for a path inside them that is not a directory) and resolved to the repository that owns it — which has to be inside them too; 400 if it owns none, 409 if that repository is already registered. |
@@ -44,9 +50,14 @@ UI and CI. Keeps transport concerns out of the core.
 | File | Responsibility |
 |------|----------------|
 | `index.ts` | Barrel — the package's public surface. |
-| `app.ts` | `createServer()` — settings, plugin registry, one `Strata`, one project store, routes, shutdown hook. |
+| `app.ts` | `createServer()` — the token guard, settings, plugin registry, one `Strata`, one project store, routes, shutdown hook. |
 | `main.ts` | Process entry point (`node dist/main.js`). |
 | `registry.ts` | `buildRegistry(opts)` — load the built-ins, then the user plugins directory the settings name (unless third-party loading is off). |
+| `auth/token.ts` | `configuredToken()` — the deployment's secret from `$STRATA_TOKEN`, or `undefined` for an open API. |
+| `auth/hook.ts` | `requireToken()` — the `onRequest` hook that turns away anything but a liveness probe without the token. |
+| `auth/presented.ts` | `presentedToken()` — the bearer credential a request carries, read from `Authorization` and nowhere else. |
+| `auth/compare.ts` | `sameToken()` — constant-time comparison over two digests. |
+| `auth/warning.ts` | `authWarning()` — what to say at startup about an open API, or a token short enough to guess. |
 | `routes/health.ts` … `routes/settings.ts` | One module per endpoint. |
 | `routes/http-error.ts` | `httpError(status, message)` — a thrown error Fastify serialises in its own error shape. |
 | `routes/patch.ts` | `requirePatch()` — refuse a PATCH that changes nothing. |
@@ -57,11 +68,12 @@ UI and CI. Keeps transport concerns out of the core.
 
 ## 5. Runtime
 
-Request → validate body → confine the root to `$STRATA_ROOTS` →
-`Strata.analyze()` → JSON report, plus a write to the project registry when the
-analysed root is registered. Plugin discovery happens once at startup, as does
-opening the registry; the roots are read per request, so widening them is a
-restart of nothing.
+Request → check the bearer token → validate body → confine the root to
+`$STRATA_ROOTS` → `Strata.analyze()` → JSON report, plus a write to the project
+registry when the analysed root is registered. Plugin discovery happens once at
+startup, as does opening the registry and reading the token; the roots are read
+per request, so widening them is a restart of nothing while rotating the token
+is a restart.
 
 ## 6. Decisions
 
@@ -110,8 +122,27 @@ restart of nothing.
   the screens only offer loaded plugins, so an id that is not one is a typo or a
   stale client, and stored silently it would look like a plugin that is switched
   on but never runs.
-- **Every path from a request passes through the same allow-list** — the API is
-  unauthenticated, so `root` would otherwise be "any directory this process can
+- **One shared secret, opt-in, in front of everything but the probe** — this is
+  one workbench with one owner, so a token is the whole of the credential; it
+  lives in `$STRATA_TOKEN` beside `$STRATA_ROOTS`, because who may call and
+  what may be reached are both facts about the deployment rather than rows in a
+  database. It is checked in `onRequest`, the first hook of the lifecycle, so a
+  caller without it never reaches a body parser or a path check; unrouted paths
+  get the same 401, so the API is no way to ask which endpoints exist. Not
+  setting one keeps today's open API, because Strata is mostly run on the
+  machine it analyses — but startup says so, every time. `/health` stays open:
+  a probe cannot hold a secret and learns nothing but whether the process is
+  up.
+- **The credential is read from `Authorization` only** — never a query
+  parameter, which Fastify writes into its own request log and a browser writes
+  into history and `Referer`; never a cookie, which the browser would attach to
+  requests this app never made, turning an auth question into a CSRF one.
+- **Auth and the allow-list answer different questions** — a caller holding the
+  token is trusted, not unconfined, so `$STRATA_ROOTS` still bounds every path
+  they name. The token decides whether a request is answered; the allow-list
+  decides what it may reach.
+- **Every path from a request passes through the same allow-list** — `root`
+  would otherwise be "any directory this process can
   read": `GET /browse` a filesystem enumerator, `POST /analyze` a way to walk
   someone else's repository through it. `$STRATA_ROOTS` (the server user's home
   by default, `/repos` in the container) says what may be reached, one
@@ -130,13 +161,27 @@ restart of nothing.
 
 ## 7. Quality & Risks
 
-- **Risk:** the API is unauthenticated, so everything it can do is reachable by
-  anyone who can reach the port: `DELETE /cache` (cost: a recomputation),
+- **Risk:** a deployment that sets no `$STRATA_TOKEN` answers anyone who can
+  reach the port: `DELETE /cache` (cost: a recomputation),
   `DELETE /projects/:id` (cost: a registry entry, and nothing on disk), and
   `PATCH /settings`, which names a plugins directory the next start will load
-  code from. **Mitigation:** paths are allow-listed (below), but the rest is
-  not — the API assumes a trusted network and auth is on the backlog. Do not
-  expose the port publicly.
+  code from. **Mitigation:** set one — it is a single environment variable and
+  every endpoint but `/health` is behind it. Startup warns while it is unset,
+  and warns again if it is short enough to guess. An open API is still the
+  default, so a port that was only ever meant to be local must not be published
+  without one.
+- **Note for cross-origin work:** a bearer header makes every call
+  preflighted, and a browser sends `OPTIONS` without credentials. Nothing
+  serves CORS today (the UI is same-origin, or proxied in dev), so nothing is
+  broken — but whoever adds it has to let `OPTIONS` past the hook, or every
+  cross-origin call fails its preflight with a 401.
+- **Risk:** the token is a static shared secret with no expiry, and rotating it
+  is a restart. Anyone holding it holds all of the API — there is no second
+  credential to revoke on its own. **Mitigation:** enough for one self-hosted
+  workbench, which is what this is; named, revocable keys are the shape to
+  reach for if this ever serves more than one person. Transport is the
+  deployment's job: over plain HTTP the token travels in clear text, so
+  terminate TLS in front of it on anything but localhost.
 - **Risk:** `POST /analyze` and `POST /projects` take a path from the caller,
   and `GET /browse` discloses directory *names*. **Mitigation:**
   `$STRATA_ROOTS` — the server user's home by default, the read-only `/repos`

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -9,20 +9,22 @@ import {
   type EngineSettings,
   type SettingsStore,
 } from '@strata/core';
+import { authWarning, configuredToken, requireToken } from './auth/index.js';
 import { buildRegistry } from './registry.js';
 import { registerRoutes } from './routes/index.js';
 
 /**
  * Build the HTTP app: read the app settings, discover plugins the way they say
  * to, hold one `Strata` (so the incremental cache is opened once and closed
- * with the server), one project registry and one settings store, register
- * routes.
+ * with the server), one project registry and one settings store, put the
+ * deployment's token in front of the lot, register routes.
  *
  * The settings come first because *Plugins & engine* decides what gets loaded,
  * and loading happens exactly once, here.
  */
 export async function createServer(): Promise<FastifyInstance> {
   const app = Fastify({ logger: true });
+  guardWithToken(app);
   const settings = openSettingsStore();
   const engine = engineSettings(settings);
   const pluginsDir = engine.pluginsDir ?? userPluginsDir();
@@ -43,6 +45,24 @@ export async function createServer(): Promise<FastifyInstance> {
   });
 
   return app;
+}
+
+/**
+ * Put `$STRATA_TOKEN` in front of every route, and say at startup what that
+ * leaves reachable.
+ *
+ * Before the routes, because a Fastify hook only runs for the routes
+ * registered after it — and before the stores and the plugin scan, so the
+ * order in `createServer` reads the way a request travels.
+ */
+function guardWithToken(app: FastifyInstance): void {
+  const token = configuredToken();
+  if (token !== undefined) requireToken(app, token);
+
+  const warning = authWarning(token);
+  if (warning !== undefined) {
+    createConsoleLogger('strata:auth').warn(warning);
+  }
 }
 
 /**

--- a/packages/server/src/auth/compare.ts
+++ b/packages/server/src/auth/compare.ts
@@ -1,0 +1,21 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+
+/**
+ * Whether a presented credential is the configured one.
+ *
+ * Compared in constant time: `===` on a secret returns sooner the earlier the
+ * two differ, and over enough tries that timing is the secret itself, one
+ * character at a time.
+ *
+ * Both sides are hashed first, so the comparison is over two fixed-width
+ * digests. `timingSafeEqual` refuses buffers of different lengths, and handing
+ * it the raw strings would either throw on every wrong-length guess or leak
+ * how long the real token is.
+ */
+export function sameToken(presented: string, expected: string): boolean {
+  return timingSafeEqual(digest(presented), digest(expected));
+}
+
+function digest(value: string): Buffer {
+  return createHash('sha256').update(value, 'utf8').digest();
+}

--- a/packages/server/src/auth/hook.test.ts
+++ b/packages/server/src/auth/hook.test.ts
@@ -1,0 +1,148 @@
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { requireToken } from './hook.js';
+
+/**
+ * Who may talk to the API. The allow-list says what a request may reach;
+ * this says whether it is answered at all, so the test asserts the guard is in
+ * front of *everything* — routes it knows, routes it does not, and the methods
+ * that destroy something — with the liveness probe as the one way through.
+ */
+
+const TOKEN = 'a-long-enough-test-token';
+
+let app: FastifyInstance;
+/** Set by the `/analyze` stand-in, to show what the guard never reaches. */
+let handled: boolean;
+
+beforeEach(async () => {
+  handled = false;
+  app = Fastify();
+  requireToken(app, TOKEN);
+
+  // Stand-ins for the real routes: the guard is registered before them, the
+  // way `createServer` does it, and knows nothing about what they do.
+  app.get('/health', async () => ({ status: 'ok' }));
+  app.get('/health/secrets', async () => ({ secrets: 'many' }));
+  app.get('/plugins', async () => ({ plugins: [] }));
+  app.delete('/cache', async () => ({ cleared: true }));
+  app.post('/analyze', async () => {
+    handled = true;
+    return {};
+  });
+  // A handler that refuses on its own terms, the way the roots do.
+  app.get('/browse', async () => {
+    throw Object.assign(new Error('outside the roots'), { statusCode: 403 });
+  });
+  await app.ready();
+});
+
+afterEach(async () => {
+  await app.close();
+});
+
+function call(url: string, headers: Record<string, string> = {}) {
+  return app.inject({ url, headers });
+}
+
+const bearer = (token: string) => ({ authorization: `Bearer ${token}` });
+
+describe('a request with the token', () => {
+  it('is answered', async () => {
+    const res = await call('/plugins', bearer(TOKEN));
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ plugins: [] });
+  });
+
+  it('may use any capitalisation of the scheme, and extra spacing', async () => {
+    const res = await call('/plugins', { authorization: `bearer  ${TOKEN} ` });
+
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('may still be refused by the roots — the two limits are separate', async () => {
+    const res = await call('/browse', bearer(TOKEN));
+
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+describe('a request without it', () => {
+  it('is refused, whatever it was going to do', async () => {
+    for (const url of ['/plugins', '/cache']) {
+      expect((await call(url)).statusCode).toBe(401);
+    }
+
+    const deleted = await app.inject({ method: 'DELETE', url: '/cache' });
+    expect(deleted.statusCode).toBe(401);
+  });
+
+  it('names the scheme it should have used', async () => {
+    const res = await call('/plugins');
+
+    expect(res.headers['www-authenticate']).toBe('Bearer realm="Strata"');
+    expect(res.json().message).toContain('Authorization: Bearer');
+  });
+
+  it('is refused before the handler runs', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/analyze',
+      payload: { root: '/repos/strata' },
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(handled).toBe(false);
+  });
+
+  it('cannot tell a wrong token from no token, or a real path from an unrouted one', async () => {
+    const missing = await call('/plugins');
+    const wrong = await call('/plugins', bearer('not-the-token'));
+    const unrouted = await call('/nope', bearer('not-the-token'));
+
+    expect(wrong.statusCode).toBe(401);
+    expect(wrong.json()).toEqual(missing.json());
+    expect(unrouted.statusCode).toBe(401);
+    expect(unrouted.json()).toEqual(missing.json());
+  });
+
+  it('is refused for a token that only starts right', async () => {
+    expect((await call('/plugins', bearer(TOKEN.slice(0, -1)))).statusCode).toBe(
+      401,
+    );
+    expect((await call('/plugins', bearer(`${TOKEN}x`))).statusCode).toBe(401);
+  });
+
+  it('is refused for a credential that is not a bearer one', async () => {
+    const basic = await call('/plugins', {
+      authorization: `Basic ${Buffer.from(`:${TOKEN}`).toString('base64')}`,
+    });
+    const bare = await call('/plugins', { authorization: TOKEN });
+    const empty = await call('/plugins', { authorization: 'Bearer ' });
+
+    for (const res of [basic, bare, empty]) expect(res.statusCode).toBe(401);
+  });
+
+  it('cannot smuggle the token past the header', async () => {
+    const query = await call(`/plugins?token=${TOKEN}`);
+    const cookie = await call('/plugins', { cookie: `token=${TOKEN}` });
+
+    expect(query.statusCode).toBe(401);
+    expect(cookie.statusCode).toBe(401);
+  });
+});
+
+describe('the liveness probe', () => {
+  it('answers without a token, so a container can be watched', async () => {
+    const res = await call('/health');
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ status: 'ok' });
+  });
+
+  it('is exempt by path, not by prefix', async () => {
+    expect((await call('/health/secrets')).statusCode).toBe(401);
+    expect((await call('/health?verbose=1')).statusCode).toBe(200);
+  });
+});

--- a/packages/server/src/auth/hook.ts
+++ b/packages/server/src/auth/hook.ts
@@ -1,0 +1,57 @@
+import type { FastifyInstance } from 'fastify';
+import { httpError } from '../routes/http-error.js';
+import { sameToken } from './compare.js';
+import { presentedToken } from './presented.js';
+
+/**
+ * The paths that answer without a credential.
+ *
+ * `/health` alone: it is a liveness probe, called by Docker, compose and every
+ * orchestrator without one, and it discloses nothing but whether the process
+ * is up. Everything else is behind the token — including the reads, because
+ * `GET /plugins` describes what this deployment runs, `GET /projects` and
+ * `GET /browse` describe what is on its disk, and `GET /settings` serves
+ * provider `env` values as written until secret storage lands.
+ *
+ * The web UI's own files will belong here too once the server serves them: a
+ * browser has to load the app before it can be asked for a token, so the
+ * static build is public and every API call under it is not.
+ */
+const OPEN_PATHS = new Set(['/health']);
+
+/**
+ * Require this deployment's bearer token on everything but a liveness probe.
+ *
+ * Registered as `onRequest`, the first hook in Fastify's lifecycle, so a
+ * caller without the token is turned away before a body is parsed, a path is
+ * resolved against the roots or a store is opened. It runs for unrouted paths
+ * too, so the 401 is also the answer to "which endpoints does this server
+ * have?".
+ *
+ * The allow-list confines what a request may reach; this decides whether the
+ * request is answered at all. Both still apply: a caller holding the token is
+ * a trusted one, not an unconfined one, so `$STRATA_ROOTS` continues to bound
+ * every path they name.
+ */
+export function requireToken(app: FastifyInstance, token: string): void {
+  app.addHook('onRequest', async (req, reply) => {
+    if (OPEN_PATHS.has(requestPath(req.url))) return;
+
+    const presented = presentedToken(req);
+    if (presented !== undefined && sameToken(presented, token)) return;
+
+    // One answer for a request with no credential and one with the wrong
+    // credential: which of the two it was is not the server's to confirm.
+    reply.header('WWW-Authenticate', 'Bearer realm="Strata"');
+    throw httpError(
+      401,
+      'This workbench requires a token. Send it as `Authorization: Bearer <token>`.',
+    );
+  });
+}
+
+/** The path a request names, without the query string. */
+function requestPath(url: string): string {
+  const query = url.indexOf('?');
+  return query === -1 ? url : url.slice(0, query);
+}

--- a/packages/server/src/auth/index.ts
+++ b/packages/server/src/auth/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Who may talk to the API. One shared secret (`$STRATA_TOKEN`), presented as a
+ * bearer token, checked before anything else in the request lifecycle.
+ *
+ * This file is a barrel: one concern per module.
+ */
+export { configuredToken } from './token.js';
+export { requireToken } from './hook.js';
+export { authWarning } from './warning.js';
+export { presentedToken } from './presented.js';
+export { sameToken } from './compare.js';

--- a/packages/server/src/auth/presented.ts
+++ b/packages/server/src/auth/presented.ts
@@ -1,0 +1,20 @@
+import type { FastifyRequest } from 'fastify';
+
+/** `Bearer <token>`, case-insensitive in the scheme, as RFC 6750 writes it. */
+const BEARER = /^Bearer[ \t]+(\S.*)$/i;
+
+/**
+ * The bearer token a request carries, if it carries one.
+ *
+ * `Authorization` is the only place it is read from. A token in a query string
+ * ends up in access logs, browser history and the `Referer` of every link that
+ * leaves the page; one in a cookie would be sent by the browser on requests
+ * this app never made, which is a CSRF story rather than an auth one.
+ */
+export function presentedToken(req: FastifyRequest): string | undefined {
+  const header = req.headers.authorization;
+  if (typeof header !== 'string') return undefined;
+
+  const token = BEARER.exec(header.trim())?.[1]?.trim();
+  return token === undefined || token === '' ? undefined : token;
+}

--- a/packages/server/src/auth/token.test.ts
+++ b/packages/server/src/auth/token.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { sameToken } from './compare.js';
+import { configuredToken } from './token.js';
+import { authWarning } from './warning.js';
+
+/**
+ * Reading the deployment's credential, and what is said about it at startup.
+ * The awkward cases are the ones where a deployment *looks* configured: an
+ * empty variable, or a token left at a placeholder.
+ */
+
+describe('configuredToken', () => {
+  it('is the variable, without the whitespace an .env file brings', () => {
+    expect(configuredToken('  s3cret  ')).toBe('s3cret');
+  });
+
+  it('is undefined when the variable is unset, empty or blank', () => {
+    expect(configuredToken(undefined)).toBeUndefined();
+    expect(configuredToken('')).toBeUndefined();
+    expect(configuredToken('   ')).toBeUndefined();
+  });
+
+  it('reads the environment when nothing is passed', () => {
+    const previous = process.env.STRATA_TOKEN;
+    process.env.STRATA_TOKEN = 'from-the-environment';
+    try {
+      expect(configuredToken()).toBe('from-the-environment');
+    } finally {
+      if (previous === undefined) delete process.env.STRATA_TOKEN;
+      else process.env.STRATA_TOKEN = previous;
+    }
+  });
+});
+
+describe('sameToken', () => {
+  it('holds for the same secret and nothing else', () => {
+    expect(sameToken('s3cret', 's3cret')).toBe(true);
+    expect(sameToken('s3cret', 's3crey')).toBe(false);
+    // Length is not a shortcut out: a prefix and a superset both compare.
+    expect(sameToken('s3cre', 's3cret')).toBe(false);
+    expect(sameToken('s3crets', 's3cret')).toBe(false);
+    expect(sameToken('', 's3cret')).toBe(false);
+  });
+
+  it('compares bytes, not normalised text', () => {
+    expect(sameToken('S3CRET', 's3cret')).toBe(false);
+    expect(sameToken('s3cret ', 's3cret')).toBe(false);
+  });
+});
+
+describe('authWarning', () => {
+  it('says an unauthenticated API out loud', () => {
+    expect(authWarning(undefined)).toContain('unauthenticated');
+  });
+
+  it('says a token short enough to guess', () => {
+    expect(authWarning('hunter2')).toContain('guess');
+  });
+
+  it('has nothing to say about a real one', () => {
+    expect(authWarning('0123456789abcdef')).toBeUndefined();
+  });
+});

--- a/packages/server/src/auth/token.ts
+++ b/packages/server/src/auth/token.ts
@@ -1,0 +1,20 @@
+/**
+ * The shared secret this deployment requires, or `undefined` for an API that
+ * answers anyone who can reach the port.
+ *
+ * `$STRATA_TOKEN` is the whole of the credential, the way `$STRATA_ROOTS` is
+ * the whole of the path allow-list: one secret for one workbench, set where
+ * the rest of the deployment is described. Surrounding whitespace is stripped,
+ * because a token pasted into an `.env` file or a compose environment usually
+ * arrives with some.
+ *
+ * A variable set to nothing reads as unset. The alternative — an empty string
+ * as a valid token — would leave the API open while looking configured, which
+ * is the one failure this feature exists to prevent.
+ */
+export function configuredToken(
+  configured: string | undefined = process.env.STRATA_TOKEN,
+): string | undefined {
+  const token = (configured ?? '').trim();
+  return token === '' ? undefined : token;
+}

--- a/packages/server/src/auth/warning.ts
+++ b/packages/server/src/auth/warning.ts
@@ -1,0 +1,33 @@
+/**
+ * Short enough to be guessed at HTTP speed. Not a policy — nothing is refused
+ * for being under it — but a deployment that set a four-character token has
+ * almost certainly mistaken it for a placeholder.
+ */
+const MIN_TOKEN_LENGTH = 16;
+
+/**
+ * What to say at startup about the credential this deployment is running with,
+ * or `undefined` when there is nothing to say.
+ *
+ * An open API is a legitimate choice on a workstation and stays the default,
+ * so it is a warning rather than a refusal — but it is said out loud on every
+ * start, because the failure mode is a port that was only ever meant to be
+ * local quietly becoming reachable.
+ */
+export function authWarning(token: string | undefined): string | undefined {
+  if (token === undefined) {
+    return (
+      'no STRATA_TOKEN set — the API is unauthenticated, so anyone who can ' +
+      'reach this port can analyse, register and remove projects, clear the ' +
+      'cache and change the settings. Fine on a workstation; set a token ' +
+      'before the port is reachable from anywhere else.'
+    );
+  }
+  if (token.length < MIN_TOKEN_LENGTH) {
+    return (
+      `STRATA_TOKEN is ${token.length} characters — short enough to guess. ` +
+      `Use at least ${MIN_TOKEN_LENGTH}, e.g. \`openssl rand -hex 32\`.`
+    );
+  }
+  return undefined;
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -6,3 +6,4 @@
 export { createServer } from './app.js';
 export { buildRegistry } from './registry.js';
 export { registerRoutes, type RouteContext } from './routes/index.js';
+export { authWarning, configuredToken, requireToken } from './auth/index.js';

--- a/packages/server/src/routes/allowed-root.ts
+++ b/packages/server/src/routes/allowed-root.ts
@@ -9,11 +9,12 @@ import { httpError } from './http-error.js';
  * The directory a request named, resolved and confined to the roots this
  * deployment allows (`$STRATA_ROOTS`) — or a 403.
  *
- * Every endpoint that takes a path from a caller goes through here, because
- * the API is unauthenticated: without it, `root` is "any directory this process
- * can read" and the workbench walks whatever it is pointed at. The resolved
- * path is what the caller should use from then on, so what runs is what was
- * checked.
+ * Every endpoint that takes a path from a caller goes through here. Without it,
+ * `root` is "any directory this process can read" and the workbench walks
+ * whatever it is pointed at — and it applies whether or not this deployment set
+ * a token, because holding the credential makes a caller trusted, not
+ * unconfined. The resolved path is what the caller should use from then on, so
+ * what runs is what was checked.
  */
 export async function requireAllowedRoot(path: string): Promise<string> {
   try {

--- a/packages/server/src/routes/analyze.ts
+++ b/packages/server/src/routes/analyze.ts
@@ -31,10 +31,10 @@ const schema = {
  * Run an analysis and return the full report.
  *
  * The `root` is confined to `$STRATA_ROOTS` first — 403 outside them — because
- * everything below this line reads a repository, and the API is
- * unauthenticated. The resolved path is what gets analysed and what the
- * registry is looked up by, so a symlink cannot point the run somewhere else
- * after the check.
+ * everything below this line reads a repository, and a caller who got this far
+ * is a trusted one rather than an unconfined one. The resolved path is what
+ * gets analysed and what the registry is looked up by, so a symlink cannot
+ * point the run somewhere else after the check.
  */
 export function analyzeRoute(app: FastifyInstance, ctx: RouteContext): void {
   app.post<{ Body: AnalyzeBody }>('/analyze', { schema }, async (req) => {

--- a/packages/server/src/routes/browse.ts
+++ b/packages/server/src/routes/browse.ts
@@ -26,8 +26,9 @@ const schema = {
  *
  * Names of directories, nothing else — no files, no contents — and only inside
  * `$STRATA_ROOTS` (the server user's home by default). That confinement is the
- * point: this endpoint is otherwise a directory enumerator for anyone who can
- * reach the API, and Strata ships without authentication.
+ * point: this endpoint is otherwise a directory enumerator for whoever can
+ * reach the API, and on a deployment that set no `$STRATA_TOKEN` that is
+ * anyone who can reach the port.
  */
 export function browseRoute(app: FastifyInstance): void {
   app.get<{ Querystring: BrowseQuery }>(


### PR DESCRIPTION
Closes #106.

`$STRATA_ROOTS` says what a request may reach; nothing said who may send one. This adds the second limit.

## The API

`$STRATA_TOKEN` is one shared secret for the workbench, presented as `Authorization: Bearer <token>`:

```bash
STRATA_TOKEN=$(openssl rand -hex 32) make dev

curl -s localhost:4000/plugins                                   # 401
curl -s -H "Authorization: Bearer $STRATA_TOKEN" localhost:4000/plugins
```

- Checked in `onRequest`, the first hook of the lifecycle, so a caller without it never reaches a body parser or a path check.
- Everything but `/health` is behind it — the reads included, since `/plugins` describes what this deployment runs, `/browse` and `/projects` describe its disk, and `/settings` still serves provider `env` values as written. `/health` stays open because a liveness probe cannot hold a secret.
- Unrouted paths get the same 401, so the API is no way to ask which endpoints exist. A wrong token and no token are indistinguishable.
- Compared in constant time over SHA-256 digests, so neither the token's content nor its length leaks by timing.
- Read from `Authorization` only. Fastify writes the request URL into its own log — a query-string token showed up there during testing, the header never did — and a cookie would turn an auth question into a CSRF one.

**Off by default.** Strata is mostly run on the machine it analyses, so an unset variable keeps the open API — but startup says so every time, and says so again for a token short enough to guess:

```
[strata:auth] no STRATA_TOKEN set — the API is unauthenticated, so anyone who can reach
this port can analyse, register and remove projects, clear the cache and change the
settings. Fine on a workstation; set a token before the port is reachable from anywhere else.
```

**The two limits stay separate.** Holding the token makes a caller trusted, not unconfined: `$STRATA_ROOTS` still bounds every path they name.

## The web UI

Without this the feature would be curl-only — every screen would 401 with no way to supply a credential.

Every call carries the token when the browser holds one. A 401 locks the session and the root layout puts an unlock panel where the frame goes, so there is one prompt instead of a "401" in each of five panels. The panel checks a candidate against `/plugins` before the session adopts it, so a typo is answered where it was typed; a refused token is dropped from `localStorage` rather than failing the same way after the next reload. Unlocking reloads, because every store loads once and is holding a failed request by then.

## Notes for what comes next

- **#87 (serve the web UI from the server):** the static build must sit *outside* the token — a browser has to load the app before it can be asked for one. Added to that backlog entry and to the code comment listing the open paths.
- **CORS:** a bearer header makes calls preflighted, and browsers send `OPTIONS` without credentials. Nothing serves CORS today, so nothing is broken, but whoever adds it has to let `OPTIONS` past the hook.
- The token is a static secret with no expiry; rotating it is a restart. Enough for one self-hosted workbench — named, revocable keys are the shape to reach for if it ever serves more than one person. Both risks are written down in the server's architecture doc.

## Tests

20 server tests (`auth/hook.test.ts`, `auth/token.test.ts`) and 15 web ones (`session.test.ts`, `Unlock.test.ts`, plus the token cases in `request.test.ts`). Full suite green: 758 tests, plus build, typecheck and lint.

Also verified against a running server: `/health` 200 without a token, `/plugins` 401 without and 200 with, `DELETE /cache` and `PATCH /settings` 401, a query-string token 401, and both startup warnings.

## Docs

The "the API is unauthenticated" claims in three route files, both architecture docs, the README, `.env.example` and `compose.yml` were stale as of this change and are updated. Adds ADR-8 (one shared token, opt-in), `apps/web` decisions 37–38, and marks the backlog item done.
