### PR TITLE
ci(vouch): vouch dependabot and let trusted authors bypass the gate

### DIFF
--- a/.github/vouched.json
+++ b/.github/vouched.json
@@ -1,5 +1,5 @@
 {
   "$comment": "Trusted reviewers. A PR from anyone other than an owner needs an approving review from one of these logins before it can merge. Grant with `/vouch @user`, revoke with `/unvouch @user` (owners only). Managed by .github/workflows/vouch-command.yml.",
   "owners": ["sschorer"],
-  "vouched": []
+  "vouched": ["dependabot[bot]"]
 }

--- a/.github/workflows/vouch-gate.yml
+++ b/.github/workflows/vouch-gate.yml
@@ -1,7 +1,7 @@
 name: Vouch gate
 
 # Produces the required "vouch-gate" status check. A PR passes when either:
-#   - the PR author is an owner (owner bypass), or
+#   - the PR author is an owner or a vouched reviewer (author bypass), or
 #   - at least one approving review comes from an owner or a vouched reviewer.
 # Mark this check as required in branch protection to enforce the vouch system.
 
@@ -31,8 +31,12 @@ jobs:
             const pr = context.payload.pull_request;
             const author = (pr.user.login || '').toLowerCase();
 
-            if (owners.map((s) => s.toLowerCase()).includes(author)) {
-              core.info(`Author @${author} is an owner — bypassing.`);
+            // Trust is symmetric: anyone whose approval unblocks other people's
+            // PRs doesn't need an approval on their own. This is also what lets
+            // dependabot[bot]'s weekly bumps through — a bot never reviews, so
+            // the approval path alone would leave them blocked forever.
+            if (trusted.has(author)) {
+              core.info(`Author @${author} is trusted — bypassing.`);
               return;
             }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -170,7 +170,9 @@ render.
 
 `/vouch @user` (issue comment) → `vouch-command` workflow validates the actor is
 an owner, edits `.github/vouched.json`, commits it. The `vouch-gate` check then
-lets that user's approvals unblock others' PRs.
+lets that user's approvals unblock others' PRs, and lets their own PRs through
+without one. `dependabot[bot]` is vouched for the second half alone: a bot never
+files a review, so the approval path would strand its weekly bumps.
 
 ## 7. Deployment View
 

--- a/docs/BRANCH_PROTECTION.md
+++ b/docs/BRANCH_PROTECTION.md
@@ -10,7 +10,7 @@ make them enforceable, but can't toggle the settings for you.
 
 ## Goal
 
-- **You (owner)** can merge without anyone's approval.
+- **You (owner)** and **vouched** reviewers can merge without anyone's approval.
 - **Everyone else** needs an approving review from a **vouched** reviewer
   before merging.
 
@@ -28,9 +28,12 @@ Enable:
 3. **Require status checks to pass**
    - Add **`build`** (CI) and **`gate`** (from the *Vouch gate* workflow)
    - Require branches to be up to date before merging
-4. **Bypass list → add your account.**
+4. **Bypass list → add your account**, and **Dependabot** if you want its
+   dependency PRs to merge unattended.
    This is what lets *you* merge without an approval while everyone else is held
-   to the rules above.
+   to the rules above. Dependabot is vouched in `.github/vouched.json`, which
+   clears the `gate` check — but *Required approvals: 1* is enforced by GitHub
+   itself, so its PRs still need the bypass entry here to merge on their own.
 
 ## How the two levers combine
 

--- a/docs/VOUCH.md
+++ b/docs/VOUCH.md
@@ -5,17 +5,21 @@ community-vouched contribution flows.
 
 ## The rule
 
-- **Owners** (listed in `.github/vouched.json` → `owners`) can merge their own
-  PRs without any approval.
+- **Owners** (listed in `.github/vouched.json` → `owners`) and **vouched
+  reviewers** (→ `vouched`) can merge their own PRs without any approval.
 - **Everyone else** needs an approving review from an **owner or a vouched
   reviewer** before their PR can merge.
+
+Trust is symmetric: vouching someone says their approval unblocks other
+people's PRs, so their own PRs don't need one either. Vouch accordingly.
 
 Two things enforce it together:
 
 1. **Branch protection** requires a passing `gate` check and (optionally) a
    Code Owner review — see [BRANCH_PROTECTION.md](./BRANCH_PROTECTION.md).
 2. The **Vouch gate** workflow (`.github/workflows/vouch-gate.yml`) fails until
-   an owner or vouched reviewer has approved (owners' own PRs pass immediately).
+   an owner or vouched reviewer has approved (trusted authors' own PRs pass
+   immediately).
 
 ## Granting trust
 
@@ -32,6 +36,18 @@ PRs. Revoke with:
 ```
 /unvouch @username
 ```
+
+## Bots
+
+`dependabot[bot]` is vouched. A bot never files an approving review, so without
+the author bypass its weekly dependency PRs would wait on a human forever.
+
+Note that the vouch gate is only **one** of the two levers. If your ruleset also
+sets *Require a pull request before merging → Required approvals: 1*, GitHub
+enforces that independently of this workflow, and Dependabot's PRs still stall.
+To let them merge unattended, add Dependabot to the ruleset's **bypass list**
+(Settings → Rules → Rulesets → *Bypass list* → Add → Dependabot) — see
+[BRANCH_PROTECTION.md](./BRANCH_PROTECTION.md).
 
 ## Why a file, not a GitHub team?
 


### PR DESCRIPTION
## Why

Dependabot's weekly dependency PRs were stranded by the vouch gate. The gate only cleared a PR on an **approving review** from a trusted login, and a bot never files a review — so every bump sat waiting on a human indefinitely.

## What changed

- **`.github/vouched.json`** — `dependabot[bot]` added to `vouched`.
- **`.github/workflows/vouch-gate.yml`** — the author bypass widened from `owners` to `owners + vouched`. Trust is now symmetric: a login whose approval unblocks other people's PRs doesn't need an approval on its own.
- **Docs** (`VOUCH.md`, `BRANCH_PROTECTION.md`, `ARCHITECTURE.md`) — updated to state the new rule, plus a new *Bots* section.

## Two things to be aware of

**1. This changes the rule for humans too.** Widening the bypass means anyone vouched from now on can also self-merge without review — Dependabot is just the first entry. `vouched` was empty before this PR, so there's no retroactive effect, but it's a real change to what `/vouch` grants. If you'd rather keep "vouched" meaning *reviewer only*, the alternative is a separate bot allowlist in the gate and reverting the `trusted.has(author)` change.

**2. The gate is only one of two levers.** If the `main` ruleset sets *Require a pull request before merging → Required approvals: 1*, GitHub enforces that independently of this workflow, and Dependabot's PRs will still stall on it. To let them merge unattended, add Dependabot to the ruleset's **bypass list** (Settings → Rules → Rulesets → Bypass list → Add → Dependabot). That's a repo setting, not a file, so it can't ship in this PR — documented in `BRANCH_PROTECTION.md`.

## Verification

- `.github/vouched.json` parses; `vouch-gate.yml` parses as YAML.
- Gate author check simulated against the committed list:

  | author | result |
  |---|---|
  | `dependabot[bot]` | bypass |
  | `Dependabot[bot]` (case) | bypass |
  | `sschorer` (owner) | bypass |
  | `some-contributor` | needs approval |

The gate's own run on this PR is the live check.