### PR TITLE
docs: add agent skills configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# Strata — Agent Guide
+
+A modular git & code-analysis workbench: a small core (`@strata/core`) plus
+plugins, contracts in `@strata/sdk`, an HTTP API in `@strata/server`, and a
+SvelteKit web app in `apps/web`. Start with `README.md` for what it does and
+`docs/ARCHITECTURE.md` for how it's put together; `CONTRIBUTING.md` covers
+commits, branches and review.
+
+## Agent skills
+
+### Issue tracker
+
+GitHub issues in `sschorer/strata` (via `gh`), mirrored line-for-line by `BACKLOG.md` — creating or closing an issue means editing both. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The five canonical roles, each label string equal to its name; orthogonal to the mandatory `area:*` and `priority:*` labels. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Multi-context — a root `CONTEXT-MAP.md` over one `CONTEXT.md` per workspace package (`packages/*`, `apps/*`, `plugins/*`). See `docs/agents/domain.md`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -307,8 +307,8 @@ publish. The Linux desktop job is still a stub — it produces no bundle until
 | ADR-5 | Docker image is the primary deliverable | Matches "self-host over the browser". |
 | ADR-6 | Vouch file over GitHub team | Works on a personal repo; auditable in git history. |
 | ADR-7 | Web UI is a SvelteKit **static SPA** (Tailwind v4) | The build is plain files: the server can serve it from the same image, and the Tauri shell can load it from disk. Analysis is a local API call, so nothing needs server rendering. |
-| ADR-9 | Heavy analyses on a `worker_threads` worker behind an in-process queue (not BullMQ/Redis) | Analysis is minutes of synchronous parsing, and on one thread that is minutes of an unanswered API. A Redis-backed queue would mean a second service for a workbench whose whole shape is one container, run offline, on the machine it analyses. The queue interface is independent of where work runs, so spreading runs over machines later means replacing the runner, not the API. |
 | ADR-8 | One shared bearer token (`$STRATA_TOKEN`), opt-in | A self-hosted workbench has one owner: a secret in the environment is the whole credential, with no user store, no session state and nothing for CI to log into. Off by default keeps `docker run` and localhost working; startup warns while it is. Named, revocable keys are the upgrade path if it ever serves more than one person. |
+| ADR-9 | Heavy analyses on a `worker_threads` worker behind an in-process queue (not BullMQ/Redis) | Analysis is minutes of synchronous parsing, and on one thread that is minutes of an unanswered API. A Redis-backed queue would mean a second service for a workbench whose whole shape is one container, run offline, on the machine it analyses. The queue interface is independent of where work runs, so spreading runs over machines later means replacing the runner, not the API. |
 
 (Promote these into `docs/adr/NNNN-*.md` as they harden.)
 

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,72 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic. (A single root `CONTEXT.md` is the single-context alternative; this repo is multi-context.)
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. Also check `<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+This is a pnpm workspace, so a "context" is a workspace package rather than a
+folder under `src/`. Contexts are `packages/*`, `apps/*` and `plugins/*`:
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/
+│   ├── ARCHITECTURE.md                 ← system-wide arc42
+│   └── adr/                            ← system-wide decisions
+├── packages/
+│   ├── core/
+│   │   ├── ARCHITECTURE.md
+│   │   ├── CONTEXT.md
+│   │   └── docs/adr/                   ← context-specific decisions
+│   ├── sdk/…
+│   └── server/…
+├── apps/
+│   └── web/…
+└── plugins/
+    ├── language-typescript/…
+    └── …
+```
+
+## What exists today
+
+Every context already has an `ARCHITECTURE.md` (arc42, trimmed) beside its
+`src/`, and `docs/ARCHITECTURE.md` covers the system. There is **no**
+`CONTEXT-MAP.md`, no `CONTEXT.md` and no `docs/adr/` yet.
+
+`ARCHITECTURE.md` and `CONTEXT.md` are not the same document and neither
+replaces the other. Architecture docs describe structure — building blocks,
+runtime views, deployment. A `CONTEXT.md` is a glossary: the terms this context
+uses, what each one means, and the synonyms it deliberately avoids. Read the
+architecture doc for a context you're about to change, whether or not a
+`CONTEXT.md` is there yet.
+
+## ADRs live in a table for now
+
+System-wide decisions ADR-1…9 are rows in a table at the bottom of
+`docs/ARCHITECTURE.md`, not files. Read them there. Promoting them into
+standalone records under `docs/adr/` is a tracked backlog item
+(*Docs & DX → ADR folder*), so expect this to change; once `docs/adr/` exists,
+it is authoritative and the table becomes an index.
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+Until the glossaries exist, `README.md` and `docs/ARCHITECTURE.md` carry the
+project's vocabulary — plugin kinds (language / commit-convention / git-metric /
+ai-provider), *hotspot*, *coupling*, *context*, *job*, *project*, *run*.
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,121 @@
+# Issue tracker: GitHub
+
+Issues and specs for this repo live as GitHub issues in
+[`sschorer/strata`](https://github.com/sschorer/strata). Use the `gh` CLI for
+all operations — it infers the repo from `git remote -v` when run inside a
+clone.
+
+`BACKLOG.md` at the repo root is the same work, grouped and prioritised for a
+human reader. Every issue has a backlog line and every backlog line has an
+issue; see [Keeping `BACKLOG.md` in sync](#keeping-backlogmd-in-sync) below,
+which is a duty, not a nicety.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+### Every issue carries an area and a priority
+
+Two label axes are mandatory on every issue — one `area:*` and one
+`priority:*`. They are the axes `BACKLOG.md` is organised along, so an issue
+missing either can't be placed in the backlog.
+
+| `area:` label                     | `BACKLOG.md` section          |
+| --------------------------------- | ----------------------------- |
+| `area:core-platform`              | Core & platform               |
+| `area:configuration-persistence`  | Configuration & persistence   |
+| `area:git-history-intelligence`   | Git / history intelligence    |
+| `area:language-modules`           | Language modules              |
+| `area:architecture-fitness`       | Architecture fitness          |
+| `area:ai`                         | AI                            |
+| `area:web-ui`                     | Web UI (`apps/web`)           |
+| `area:ci-delivery`                | CI / delivery                 |
+| `area:docs-dx`                    | Docs & DX                     |
+
+`priority:P0` = next, `priority:P1` = soon, `priority:P2` = later — the same
+three levels the backlog prints in bold.
+
+The `area:web-ui` section is subdivided in the backlog (*Shell*, *Analysis
+screens*, *Project settings*, *Application settings*). There is no label for
+the subsection; pick it from the issue's subject when writing the backlog line.
+
+### Issue body shape
+
+Existing issues open with a sentence or two of intent and close with a
+provenance line naming the backlog section:
+
+```
+So the Docker image is a single deployable workbench.
+
+From `BACKLOG.md` → *CI / delivery*.
+```
+
+Follow that shape for new issues.
+
+## Keeping `BACKLOG.md` in sync
+
+`BACKLOG.md` mirrors the issue list. Editing one without the other is what
+this section exists to prevent.
+
+- **Creating an issue** → add its backlog line, in the section its `area:`
+  label maps to, in priority order within that section. Shape:
+  `- [ ] **P1** <title>`, optionally followed by indented prose. Closed/`[x]`
+  items sit above open ones in each section, roughly in the order they shipped.
+- **Closing an issue** → flip its line to `[x]` and drop the `**P1**` marker
+  (shipped items carry no priority), moving it up to the done run of its
+  section. Where the shipped thing differs from what was asked, rewrite the
+  line to describe what actually landed — the done entries are a record, not a
+  wish list.
+- **Starting work** → `[~]` marks in progress.
+- **Re-prioritising or re-scoping an issue** → update the `priority:*` label
+  and the `**P<n>**` marker together.
+
+The legend at the top of `BACKLOG.md` is authoritative for the checkbox
+vocabulary: `[ ]` todo · `[~]` in progress · `[x]` done.
+
+When a skill's output would leave the two out of step and it can't make both
+edits (for example, it only has permission to comment), say so explicitly
+rather than letting the mirror drift silently.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+Dependabot PRs carry the `dependencies` label and are not triage input.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue, label it with an `area:` and a `priority:`, and add the
+matching `BACKLOG.md` line.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`. Read the issue's backlog section too —
+neighbouring lines carry the prose context the issue body compresses.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.
+
+Wayfinder maps and their children are session scaffolding, not roadmap items —
+they get no `area:`/`priority:` labels and no `BACKLOG.md` line.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,30 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.
+
+## Status in this repo
+
+`wontfix` exists already (a GitHub default). The other four are not created
+yet — `gh label create <name>` on first use.
+
+## These are orthogonal to `area:` and `priority:`
+
+Triage labels say what an issue *needs next*. The `area:*` and `priority:*`
+labels say where it *belongs* and *when* — every issue carries one of each, and
+`BACKLOG.md` is organised along them. See `docs/agents/issue-tracker.md`.
+
+A triage pass that reaches `ready-for-agent` or `ready-for-human` on an issue
+missing an `area:` or `priority:` should add the missing one, because a
+backlog line can't be placed without both.


### PR DESCRIPTION
## What

Adds `AGENTS.md` at the repo root and three files under `docs/agents/` that the
[mattpocock engineering skills](https://github.com/mattpocock/skills) read for
per-repo configuration:

- **`issue-tracker.md`** — GitHub issues via `gh`, the mandatory `area:*` +
  `priority:*` label pair with all nine areas mapped to their `BACKLOG.md`
  sections, the `From \`BACKLOG.md\` → *Section*` body shape existing issues
  use, and the sync duty: creating an issue adds its backlog line, closing one
  flips `[ ]` → `[x]` and drops the priority marker. PRs are not a request
  surface (flag is in the file); Dependabot PRs are excluded from triage.
- **`triage-labels.md`** — the five canonical triage roles mapped to
  themselves, noting only `wontfix` exists today and that these are orthogonal
  to `area:`/`priority:`.
- **`domain.md`** — multi-context layout, with the file tree written against
  the actual workspace (`packages/*`, `apps/*`, `plugins/*`), and a note that
  a module's `ARCHITECTURE.md` is not a substitute for a `CONTEXT.md`.

Also reorders the ADR table in `docs/ARCHITECTURE.md` so ADR-8 precedes ADR-9
(second commit, pure row swap — no text changed).

## Why

The skills assume this configuration exists; without it they guess at where
issues live and can silently let `BACKLOG.md` drift out of step with the issue
list. Writing the mirroring convention down is the point.

No `CONTEXT-MAP.md`, `CONTEXT.md` or `docs/adr/` is created here — the skills
create those lazily when terms and decisions actually get resolved, and
promoting ADR-1…9 into `docs/adr/` is already tracked under *Docs & DX*.

## Type of change

- [ ] feat / fix / perf / refactor
- [x] docs / test / build / ci / chore

## Checklist

- [ ] `pnpm build && pnpm test && pnpm lint` pass locally — not run; markdown-only, no source or config touched
- [x] Added/updated tests where it made sense — n/a
- [x] Docs updated (README / docs/) if behaviour changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)