### PR TITLE
docs: record the open analysis pipeline design and promote the ADRs

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -65,6 +65,40 @@ Anything marked *(mockup)* exists as a design and needs an implementation.
       the job, and waiting is still the default so CI and `curl` keep the
       endpoint they had. A dropped stream is not a failed run: the job outlives
       it and `GET /jobs/:id` still answers.
+- [ ] **P0** Open analysis pipeline: stages, repo-owned config, and a CLI (SDK 0.2.0)
+      — the pipeline becomes a dependency-ordered graph of **stages** declared in
+      plugin manifests, ordered by the core and depending on each other by
+      **output type** rather than by plugin id, so architecture fitness and the
+      commit fold stop being core features. Analysis config moves into a
+      checked-in `strata.config.json` and becomes authoritative, so CI and the
+      workbench cannot disagree about a repository; a new CLI is the CI entry
+      point. A failing stage fails its dependents, not the run, and the report
+      carries a status per stage. One breaking SDK wave to `0.2.0`, landing in
+      five steps, with the rule engine written against the public contract as
+      the acceptance test. Decided in `docs/adr/0010`–`0015`; spec in the issue.
+
+      Broken into 17 tickets, sub-issues of the spec. The stage contract lands
+      *beside* the existing plugin kinds and the old form is deleted only once
+      nothing uses it, so every ticket keeps the local gate green on its own.
+      Ready to start: the three with no blockers.
+
+  - [ ] **P0** Retire the AI provider plugin contract
+  - [ ] **P0** Fold cross-language derivation into the report
+  - [ ] **P0** A named-but-missing plugin fails the run
+  - [ ] **P0** Stage declarations in the plugin manifest (SDK 0.2.0)
+  - [ ] **P0** The scheduler runs its first stage: hotspots
+  - [ ] **P1** Migrate change coupling to a stage
+  - [ ] **P1** Migrate the TypeScript language module to a stage
+  - [ ] **P1** Migrate commit convention and the commit fold to stages
+  - [ ] **P1** A failing stage fails only its dependents
+  - [ ] **P1** Web reads stage entries
+  - [ ] **P1** Delete the legacy plugin kinds and report fields
+  - [ ] **P1** `strata.config.json` is authoritative
+  - [ ] **P1** Retire the project config store
+  - [ ] **P1** Gates move into the repository's file
+  - [ ] **P1** Project settings screens edit the repository's file
+  - [ ] **P1** A command-line entry point for CI
+  - [ ] **P1** Architecture fitness rule engine as a stage
 - [ ] **P1** Analyse a bare/remote repo (clone-on-demand) and a specific `rev` range
 - [ ] **P2** Snapshot & compare two revisions (trend deltas)
 - [ ] **P2** Plugin config schema + per-plugin settings surfaced to the UI
@@ -359,7 +393,13 @@ Sans/Mono.
 ## Docs & DX
 
 - [x] arc42 architecture + per-module docs + Makefile + `analyze`/`new-plugin` scripts
-- [ ] **P1** ADR folder (`docs/adr/`) — promote ADR-1…6 into standalone records
-- [ ] **P1** ADR for the CLI-agent provider model (subprocess + shadow home +
-      secret storage), since it supersedes the HTTP-provider assumption
+- [x] ADR folder (`docs/adr/`) — ADR-1…9 promoted into standalone records, each
+      carrying the rejected alternatives and consequences the table had no room
+      for; `docs/ARCHITECTURE.md` §9 is now the index over them. ADR-10…15 were
+      written straight there. A `CONTEXT-MAP.md` over per-package `CONTEXT.md`
+      files (sdk, core, server, web) landed alongside them.
+- [x] ADR for the CLI-agent provider model — `docs/adr/0013`. It goes further
+      than the line asked for: providers stop being a plugin kind altogether and
+      become configured instances, and nothing in the pipeline may call a model,
+      which is what keeps a run offline and reproducible.
 - [ ] **P2** Example gallery / screenshots once the UI exists

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -1,0 +1,30 @@
+# Context Map
+
+Strata is a pnpm workspace, so a context is a workspace package. Each one that
+has resolved vocabulary carries a `CONTEXT.md` beside its `ARCHITECTURE.md`;
+the rest get one when their terms are first pinned down.
+
+## Contexts
+
+- [SDK](./packages/sdk/CONTEXT.md) — the contracts a plugin implements
+- [Core](./packages/core/CONTEXT.md) — what a run is, what it reads, what it produces
+- [Server](./packages/server/CONTEXT.md) — who may call and what they may reach
+- [Web](./apps/web/CONTEXT.md) — how the workbench presents a run
+
+`plugins/*` are contexts too; none has a glossary yet. The terms for what a
+run *finds* — hotspot, churn, change coupling, dead code, cycle — are defined
+in the [system glossary](./docs/ARCHITECTURE.md#12-glossary) until the plugin
+that owns each one needs its own.
+
+## Relationships
+
+- **SDK → everything.** The SDK defines *stage*, *output type* and *plugin
+  manifest*; Core, the plugins and Web all use those words as the SDK means them.
+- **Core → SDK.** Core schedules stages and owns everything about a *run* that
+  is not a stage's business: revision resolution, scope, caching, ordering.
+- **Server → Core.** The server adds only its own two limits — who may call
+  (*API token*) and what any caller may reach (*allow-list root*) — and turns a
+  run into a *job*.
+- **Web → Core, over the server.** Web adds presentation vocabulary (*screen*,
+  *settings scope*) and holds the *selected revision* as view state; it invents
+  no analysis terms of its own.

--- a/apps/web/CONTEXT.md
+++ b/apps/web/CONTEXT.md
@@ -1,0 +1,27 @@
+# Web
+
+The workbench in a browser. It presents runs; it invents no analysis
+vocabulary of its own — those words come from [Core](../../packages/core/CONTEXT.md)
+and the [SDK](../../packages/sdk/CONTEXT.md).
+
+## Language
+
+**Screen**:
+One addressable view in the workbench — Overview, Hotspots, Dependencies,
+Commit analytics, Dead code — reached from the rail.
+_Avoid_: page, tab, view
+
+**Settings scope**:
+Which of the two settings areas a screen belongs to: *Project settings*, which
+edits the repository's analysis config, or *Settings*, which edits this
+workbench's app settings. The rail swaps to the scope's own nav inside either.
+_Avoid_: settings level, section (a section is one screen within a scope)
+
+**Selected revision**:
+The revision the workbench is currently looking at. View state held by the
+browser, not stored configuration — picking a different one is a different run,
+not a changed project.
+
+**Recent runs**:
+This browser's own log of runs it started, seeded with the one summary the
+registry keeps per project. Not a server-side history.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -298,19 +298,33 @@ publish. The Linux desktop job is still a stub — it produces no bundle until
 
 ## 9. Architecture Decisions
 
-| ID | Decision | Rationale |
-|----|----------|-----------|
-| ADR-1 | TypeScript core (not Rust) | One language end-to-end; easy plugin authoring. Revisit if profiling demands. |
-| ADR-2 | tree-sitter for parsing | One framework, many grammars, uniform AST. Grammars are loaded as **WebAssembly** (`web-tree-sitter` + pre-built `.wasm`), so a language plugin installs without a compiler. |
-| ADR-3 | Shell out to `git` | Fastest and most complete; avoids reimplementing git. |
-| ADR-4 | SQLite blob-keyed cache (`node:sqlite`) | Cheap incremental analysis for large repos, with no runtime dependency. |
-| ADR-5 | Docker image is the primary deliverable | Matches "self-host over the browser". |
-| ADR-6 | Vouch file over GitHub team | Works on a personal repo; auditable in git history. |
-| ADR-7 | Web UI is a SvelteKit **static SPA** (Tailwind v4) | The build is plain files: the server can serve it from the same image, and the Tauri shell can load it from disk. Analysis is a local API call, so nothing needs server rendering. |
-| ADR-8 | One shared bearer token (`$STRATA_TOKEN`), opt-in | A self-hosted workbench has one owner: a secret in the environment is the whole credential, with no user store, no session state and nothing for CI to log into. Off by default keeps `docker run` and localhost working; startup warns while it is. Named, revocable keys are the upgrade path if it ever serves more than one person. |
-| ADR-9 | Heavy analyses on a `worker_threads` worker behind an in-process queue (not BullMQ/Redis) | Analysis is minutes of synchronous parsing, and on one thread that is minutes of an unanswered API. A Redis-backed queue would mean a second service for a workbench whose whole shape is one container, run offline, on the machine it analyses. The queue interface is independent of where work runs, so spreading runs over machines later means replacing the runner, not the API. |
+Each decision is a record in [`docs/adr/`](./adr/). This table is the index;
+the record holds the trade-off and what it costs us.
 
-(Promote these into `docs/adr/NNNN-*.md` as they harden.)
+| ID | Decision |
+|----|----------|
+| [ADR-1](./adr/0001-typescript-core.md) | TypeScript core, not Rust |
+| [ADR-2](./adr/0002-tree-sitter-parsing.md) | tree-sitter for parsing, loaded as WebAssembly |
+| [ADR-3](./adr/0003-shell-out-to-git.md) | Shell out to `git` rather than link a git library |
+| [ADR-4](./adr/0004-sqlite-blob-keyed-cache.md) | Incremental cache in SQLite, keyed on the git blob sha |
+| [ADR-5](./adr/0005-docker-image-primary-deliverable.md) | The Docker image is the primary deliverable |
+| [ADR-6](./adr/0006-vouch-file-over-github-team.md) | Merge trust lives in a vouched file, not a GitHub team |
+| [ADR-7](./adr/0007-web-ui-static-spa.md) | The web UI is a SvelteKit static SPA |
+| [ADR-8](./adr/0008-shared-bearer-token.md) | One shared bearer token for the API, opt-in |
+| [ADR-9](./adr/0009-worker-thread-analysis-queue.md) | Heavy analyses on a worker thread behind an in-process queue |
+| [ADR-10](./adr/0010-open-analysis-pipeline.md) | The analysis pipeline is an open, dependency-ordered graph of stages |
+| [ADR-11](./adr/0011-sdk-0-2-0-single-break.md) | One breaking SDK wave to 0.2.0, and deliberately not 1.0.0 |
+| [ADR-12](./adr/0012-repo-owned-config-file.md) | The analysed repository owns its analysis config |
+| [ADR-13](./adr/0013-providers-are-configured-instances.md) | AI providers are configured instances, not plugins |
+| [ADR-14](./adr/0014-cli-and-its-trust-model.md) | A first-class CLI beside the server, with no path allow-list |
+| [ADR-15](./adr/0015-partial-runs-and-per-stage-status.md) | A stage failure fails its dependents, not the run |
+
+ADR-10 through ADR-15 are **accepted but not yet implemented** — sections 5, 6
+and 8 above still describe the shipped three-phase pipeline. ADR-11 holds the
+landing order.
+
+New decisions are written straight into `docs/adr/` and listed here. The
+project's vocabulary is [`CONTEXT-MAP.md`](../CONTEXT-MAP.md).
 
 ## 10. Quality Requirements
 

--- a/docs/adr/0001-typescript-core.md
+++ b/docs/adr/0001-typescript-core.md
@@ -1,0 +1,7 @@
+# TypeScript core, not Rust
+
+Strata parses and walks large repositories, which is the kind of work a systems language is usually reached for. We chose TypeScript for the whole stack anyway — core, server, plugins and web UI — because the product's value is in its *plugin surface*, and a contributor adding a language module should not have to cross a language boundary or ship a compiled artifact to do it.
+
+## Consequences
+
+Parsing throughput is bounded by Node rather than by the algorithm, which is why heavy runs sit behind a worker thread ([ADR-9](0009-worker-thread-analysis-queue.md)) and an incremental cache ([ADR-4](0004-sqlite-blob-keyed-cache.md)) rather than behind raw speed. Revisit if profiling says the parser, not the I/O, is the wall.

--- a/docs/adr/0002-tree-sitter-parsing.md
+++ b/docs/adr/0002-tree-sitter-parsing.md
@@ -1,0 +1,11 @@
+# tree-sitter for parsing, loaded as WebAssembly
+
+Every language module needs a syntax tree, and one framework with many grammars beats one bespoke parser per language. We use tree-sitter, and load grammars as pre-built `.wasm` through `web-tree-sitter` rather than as native bindings.
+
+## Considered Options
+
+Native tree-sitter bindings are faster, but they need a compiler on the installing machine — which would mean a language plugin could not be a drop-in directory in `STRATA_PLUGINS_DIR`, and the Docker image would carry a build toolchain. Per-language official tooling (the TypeScript compiler API, `nikic/php-parser`) is more accurate per language but gives every module a different shape and a different runtime.
+
+## Consequences
+
+Resolution is ours, not the language toolchain's: tree-sitter reads the syntax, but a TypeScript import still has to be resolved through `tsconfig.json` `paths`/`baseUrl` by hand, and schemes we have not implemented draw no edge.

--- a/docs/adr/0003-shell-out-to-git.md
+++ b/docs/adr/0003-shell-out-to-git.md
@@ -1,0 +1,7 @@
+# Shell out to `git` rather than link a git library
+
+History, blob shas and tracked-file lists all come from executing the `git` binary and reading its output, not from a JS git implementation such as isomorphic-git.
+
+## Consequences
+
+`git` must be on `PATH` (and in the image) — that is an explicit deployment constraint. In exchange, every repository shape git supports (worktrees, submodules, alternates, partial clones) works on day one, and we never reimplement revision resolution.

--- a/docs/adr/0004-sqlite-blob-keyed-cache.md
+++ b/docs/adr/0004-sqlite-blob-keyed-cache.md
@@ -1,0 +1,9 @@
+# Incremental cache in SQLite, keyed on the git blob sha
+
+Re-analysing an unchanged file is the dominant cost on a large repo, so results are cached in a SQLite file (`node:sqlite`, so no runtime dependency) at two levels: per-file results keyed on `(pluginId, pluginVersion, blob)`, and whole-plugin-run results keyed on a digest of every input.
+
+Keying on the blob sha — a content hash — rather than on a path or an mtime means an entry survives across revisions, branches and even repositories: checking out a branch that reverts a file re-uses the entry from before. Including the plugin version means a new plugin build invalidates its own entries without a migration.
+
+## Consequences
+
+The cache is only as pure as its plugins: a `cache.file()` value that depends on anything beyond that file's contents will go stale, and the contract cannot enforce it. `DELETE /cache` is the escape hatch. A cache that cannot be opened, read or written degrades to a pass-through with one warning — it never fails an analysis.

--- a/docs/adr/0005-docker-image-primary-deliverable.md
+++ b/docs/adr/0005-docker-image-primary-deliverable.md
@@ -1,0 +1,7 @@
+# The Docker image is the primary deliverable
+
+Strata ships first as a multi-arch image (`ghcr.io/sschorer/strata`) that mounts repositories read-only, rather than as an npm package, a CLI binary or a desktop app. That matches the stated shape of the product — self-hosted, run over the browser, offline — and it is the one artifact that carries the `git` binary and the WASM grammars the analysis needs without asking the host for them.
+
+## Consequences
+
+Every other target is defined relative to it: CI runs the same image, and the Tauri desktop shell ([ADR-7](0007-web-ui-static-spa.md)) loads the same built web UI from disk. Anything that would require a second service to be deployed alongside it is measured against this — see [ADR-9](0009-worker-thread-analysis-queue.md).

--- a/docs/adr/0006-vouch-file-over-github-team.md
+++ b/docs/adr/0006-vouch-file-over-github-team.md
@@ -1,0 +1,9 @@
+# Merge trust lives in a vouched file, not a GitHub team
+
+Contributors are granted the power to unblock merges by being listed in `.github/vouched.json`, edited by a `/vouch @user` issue command, rather than by being added to a GitHub team or given repository write access.
+
+Teams need an organisation; this is a personal repository. The file also makes every grant a commit — who vouched for whom, and when, is in the history and reviewable like anything else.
+
+## Consequences
+
+The vouch bot needs push access to `main`, which collides with branch protection; a bypass entry or a PR-mode fallback is the documented mitigation. `dependabot[bot]` is vouched only for the self-merge half — a bot never files a review, so the approval path would strand its weekly bumps.

--- a/docs/adr/0007-web-ui-static-spa.md
+++ b/docs/adr/0007-web-ui-static-spa.md
@@ -1,0 +1,7 @@
+# The web UI is a SvelteKit static SPA
+
+`apps/web` builds to plain static files (SvelteKit's static adapter, Tailwind v4) with no server-rendering runtime. Analysis is a local API call against `@strata/server`, so there is nothing for a server-rendered page to do that the browser cannot do itself after load.
+
+## Consequences
+
+The same build serves both deployment targets: the server can serve the files out of the same image ([ADR-5](0005-docker-image-primary-deliverable.md)), and the Tauri desktop shell can load them from disk with no Node process behind them. The static files sit outside the API token ([ADR-8](0008-shared-bearer-token.md)) — a browser has to load the app before it can be asked for a token.

--- a/docs/adr/0008-shared-bearer-token.md
+++ b/docs/adr/0008-shared-bearer-token.md
@@ -1,0 +1,9 @@
+# One shared bearer token for the API, opt-in
+
+The HTTP API is authenticated by a single shared secret in `$STRATA_TOKEN`, presented as `Authorization: Bearer <token>` and checked in `onRequest` — before a request is routed, parsed or a path resolved. Everything but `/health` answers 401 without it, unrouted paths included, so the API is no way to enumerate which endpoints exist. Leaving the variable unset keeps the API open, and startup warns every time it is.
+
+A self-hosted workbench has one owner. A secret in the environment is the whole credential: no user store, no session state, and nothing for CI to log into.
+
+## Consequences
+
+The token says *who may call*; the path allow-list (`$STRATA_ROOTS`) says *what any caller may reach*. Neither replaces the other, and holding the token makes a caller trusted, not unconfined. The token is read from the header alone — one in a query string lands in the request log and browser history, and one in a cookie would need a CSRF story. Named, revocable keys are the upgrade path if the workbench ever serves more than one person. The CLI has neither limit, deliberately — see [ADR-14](0014-cli-and-its-trust-model.md).

--- a/docs/adr/0009-worker-thread-analysis-queue.md
+++ b/docs/adr/0009-worker-thread-analysis-queue.md
@@ -1,0 +1,11 @@
+# Heavy analyses on a worker thread behind an in-process queue
+
+An analysis is minutes of synchronous parsing, and on the HTTP thread that is minutes of an unanswered API. `POST /analyze` therefore puts the request on an in-process queue that runs one job at a time on a `worker_threads` worker owning the plugins and the incremental cache; the HTTP thread never parses anything. Runs are serialised deliberately — they share one cache and one CPU — and an identical request already in flight is joined rather than queued twice.
+
+## Considered Options
+
+A Redis-backed queue (BullMQ) is the conventional answer and was rejected: it means a second service alongside a workbench whose whole shape is one offline container run on the machine it analyses ([ADR-5](0005-docker-image-primary-deliverable.md)). The queue *interface* is independent of where work runs, so spreading runs over machines later means replacing the runner, not the API.
+
+## Consequences
+
+A job outlives the request that asked for it, so `wait: false` plus `GET /jobs/:id` and `GET /jobs/:id/events` let the UI show progress instead of a blocked button, while waiting stays the default so CI and `curl` keep the endpoint they had. Plugins load on both threads — twice the startup cost and memory — which is the price of the two threads sharing no state.

--- a/docs/adr/0010-open-analysis-pipeline.md
+++ b/docs/adr/0010-open-analysis-pipeline.md
@@ -1,0 +1,27 @@
+# The analysis pipeline is an open, dependency-ordered graph of stages
+
+> Status: accepted, not yet implemented. See [ADR-11](0011-sdk-0-2-0-single-break.md) for sequencing.
+
+`Strata.analyze` runs a fixed three-phase pipeline — languages, then history metrics, then commit parsing — with the report's shape and the order both hard-coded. Anything that is not one of those three (architecture fitness, the commit fold) has to be written into the core, which contradicts the claim that the tool grows without the core changing.
+
+Instead: a **stage** is any unit of work in the pipeline. Each declares, in its manifest, what it *consumes* and what it *produces*, and the core topologically orders the stages from those declarations. `Strata.analyze` becomes a scheduler with nothing domain-specific left in it; the built-in language, metric and convention plugins become ordinary stages, as does the commit fold.
+
+## Dependencies are on output types, not plugin ids
+
+A stage declares `consumes: ['graph']`, not `consumes: ['strata-language-typescript']`, and receives every `graph` produced upstream, keyed by producer. A stage therefore never needs to know the installed set: adding a PHP module feeds the rule engine with no configuration anywhere. Ids are used only when a stage genuinely means one specific producer.
+
+The set of **output types** is closed and lives in the SDK, even though the set of stages is open — that is what keeps [ADR-12](0012-repo-owned-config-file.md)'s consumers able to render a report without knowing which stages ran. Adding an output type is an SDK change; adding a stage is not.
+
+## One declaration, three jobs
+
+`consumes` is simultaneously the dependency edge, the cache-key input ([ADR-4](0004-sqlite-blob-keyed-cache.md)) and the type of what arrives. A stage that consumes files also declares a **filter** (extensions or globs) which the *core* applies — not the stage — so the cache key stays "the files this stage actually matched" rather than every file in the repository. A stage filtering itself would force the key to digest the whole tree, and a README edit would invalidate the TypeScript graph on a 50k-file repo.
+
+All of it lives in `strata.plugin.json` rather than on the exported object, so the core can plan a run, order it, and reject an unsatisfiable configuration **without importing any third-party code**. The `define*` helpers cross-check the object against the manifest at load, as `kind` is checked today.
+
+## Exclusive groups
+
+A repository has one commit convention, and "96% conforming" only means something relative to one. A stage may declare `exclusive: '<group>'`; configuration names the active member and the core runs only that one, so the graph sees exactly one producer. This generalises to the second rule engine or the second duplication detector.
+
+## Consequences
+
+The core can no longer know a stage's semantics, so everything it used to know intimately is now declared: inputs, filters, exclusivity. Progress reporting stops hard-coding a step count and becomes the length of the topological order. The built-ins get no privileges beyond the existing id-clash rule — writing the architecture-fitness rule engine against the public contract is the acceptance test for this decision, not a follow-up to it.

--- a/docs/adr/0011-sdk-0-2-0-single-break.md
+++ b/docs/adr/0011-sdk-0-2-0-single-break.md
@@ -1,0 +1,21 @@
+# One breaking SDK wave to 0.2.0, and deliberately not 1.0.0
+
+> Status: accepted, not yet implemented.
+
+The open pipeline ([ADR-10](0010-open-analysis-pipeline.md)), keying language results by manifest id instead of by a joined extension list, the per-stage status envelope ([ADR-15](0015-partial-runs-and-per-stage-status.md)) and removing the AI provider contract ([ADR-13](0013-providers-are-configured-instances.md)) are each a break of the contract the registry enforces (`SDK_VERSION`, major-checked at load). They ship as **one** bump to `0.2.0` rather than staged across several majors with adapters.
+
+The window is exactly now: the only plugins in existence are the five in this repository, so the blast radius is entirely internal. Staging the changes would mean writing adapters for kinds that are deleted two weeks later.
+
+## Explicitly not 1.0.0
+
+An open pipeline is the kind of design that should be used in anger before it is promised. `0.2.0` says the contract is real but not yet load-bearing for other people. Recording that here so a future reader reads the missing `1.0.0` as restraint rather than neglect.
+
+## Landing order
+
+Each step is independently mergeable and keeps `make check` green:
+
+1. SDK `0.2.0` — manifest fields (`consumes`, `produces`, `filter`, `exclusive`), the output-type union, the stage envelope; `AIProvider` deleted.
+2. The core becomes a scheduler; the five built-ins migrate to stages. The report shape changes here.
+3. Server and web move to the new report shape.
+4. `strata.config.json`, the CLI, and the gates migration out of `settings.db` ([ADR-12](0012-repo-owned-config-file.md), [ADR-14](0014-cli-and-its-trust-model.md)).
+5. The architecture-fitness rule engine, written against nothing but the public contract — the acceptance test for ADR-10.

--- a/docs/adr/0012-repo-owned-config-file.md
+++ b/docs/adr/0012-repo-owned-config-file.md
@@ -1,0 +1,31 @@
+# The analysed repository owns its analysis config
+
+> Status: accepted, not yet implemented.
+
+What an analysis *does* — scope and ignore globs, which stages run, the commit convention, architecture rules and CI gate thresholds — is declared in a `strata.config.json` checked into the analysed repository. It is authoritative: where a stored setting and the file disagree, the file wins.
+
+The line this draws: **the repository owns its analysis; the workbench owns its own behaviour.** Nothing about one repository belongs in the workbench's databases, and nothing about the workbench belongs in a repository.
+
+The forcing case is CI. A fresh container has no `settings.db`, so gate thresholds edited in a settings screen were unreachable exactly where gates are evaluated — which is why gates move out of `AppSettings` into the file, and why *CI gates* becomes a project screen rather than an app one. A layered merge (file < db < request) was rejected for the same reason: under it a green local run and a red CI run have no single explanation.
+
+## What this leaves in the databases
+
+`projects.db` keeps identity — id, display name, root — and the last-run summary. The project config store disappears entirely: `historyLimit` moves into the file (it describes a repository's history), and `rev` stops being stored configuration at all. A revision is a **run parameter** — the workbench keeps the selected revision as client-side view state, CI passes its checkout, the default is `HEAD`. `settings.db` keeps only what describes this workbench: appearance, plugins directory, third-party loading, the incremental cache, and provider instances.
+
+## Format, and who writes it
+
+JSON with a published `$schema`, not TypeScript. A settings screen has to *round-trip* the file, and an arbitrary TypeScript module cannot be re-serialised; a `.ts` config would also need a transpiling loader in both the CLI and the server, for a tool whose pitch is offline and self-contained. The `$schema` line buys the editor completion that was TS config's real attraction.
+
+The settings screens do edit it — a workbench whose settings screens are all disabled labels is a worse product, and a change that lands in `git diff` is more auditable than one that lands in a database. But repositories are mounted read-only in the shipped image ([ADR-5](0005-docker-image-primary-deliverable.md)), so the server **probes writability per project and degrades**: where the repo is writable the screens edit, where it is not they render read-only with the would-be file content available to copy. The deployment decides, not a second setting. The server writes only the file and never commits.
+
+## Naming stages
+
+Stages are named as a map (`{ enabled?, options? }` per stage id) rather than an allow-list, so unnamed means enabled and there is somewhere for per-stage options to live. This flips today's allow-list semantics: a repository can no longer say "only ever run exactly these," so a newly installed stage can start reporting findings on an untouched repository. That is a report changing, not a build breaking — a failing stage is not fatal ([ADR-15](0015-partial-runs-and-per-stage-status.md)) and gates are opt-in per rule. The alternative was worse: under an allow-list, installing a language module does nothing until every repository's file is edited, and the user concludes the plugin is broken.
+
+## No lock file
+
+Stage versions are not pinned. Cache keys already include a plugin's version, so an upgrade invalidates its own entries rather than mixing results, and a lock file cannot police an audience that installs plugins by dropping a directory into `STRATA_PLUGINS_DIR`. Instead the **report records provenance** — every stage that ran, with its version — which is what makes a comparison between two revisions, or a gate that flipped, explainable.
+
+## A named stage that is missing is a hard failure
+
+Everywhere, in the workbench as well as in CI. The lenient precedent — a project naming an unloaded commit convention gets a warning and an empty parse — is a correctness bug waiting for the *Commit analytics* screen, where "96% valid" and "0% valid because nothing parsed" render through the same path and mean opposite things. Once gates read those numbers, a missing plugin becomes a green build that checked nothing.

--- a/docs/adr/0013-providers-are-configured-instances.md
+++ b/docs/adr/0013-providers-are-configured-instances.md
@@ -1,0 +1,17 @@
+# AI providers are configured instances, not plugins, and never run in the pipeline
+
+> Status: accepted, not yet implemented.
+
+`ai-provider` is removed as a plugin kind. `AIProvider`, `defineAIProvider` and the `ai-provider-template` package are deleted; the call surface moves into `@strata/core` as the internal interface the subprocess runtime implements.
+
+The indirection stopped earning anything the moment providers became **local coding-agent CLIs** that Strata spawns rather than HTTP endpoints it calls. `AIProviderInstance` in the app settings is already fully generic over that — binary, launch args, environment, agent home, shadow home, models — so "add a custom provider" needs *configuration*, not code. A plugin kind the orchestrator never looked up was a contract with no implementors but ours.
+
+## AI is never a stage
+
+Nothing in the pipeline may call a model. AI features — explaining a hotspot, natural-language query over a repository — are separate endpoints that read a *finished* report and talk to a spawned agent.
+
+This is a property of stages, not an accident of what is built so far. It preserves three things at once: the constraint that analysis runs without network, the goal that results are reproducible for a given revision (a stage that calls a model is not), and the incremental cache, which digests a stage's declared inputs ([ADR-10](0010-open-analysis-pipeline.md)) and would otherwise serve a stale model answer forever.
+
+## Consequences
+
+Adding a fundamentally new *kind* of provider — something that is not "spawn a binary and talk to it" — is now a core change rather than a plugin. That is the trade, and it is acceptable while every provider on the roadmap is a coding-agent subprocess. The template package's replacement is documentation of the settings shape, not a package.

--- a/docs/adr/0014-cli-and-its-trust-model.md
+++ b/docs/adr/0014-cli-and-its-trust-model.md
@@ -1,0 +1,21 @@
+# A first-class CLI beside the server, with no path allow-list
+
+> Status: accepted, not yet implemented.
+
+Headless CI mode is a CLI whether or not it is called one: it should read a config file, analyse the repository CI has already checked out, and exit with a code. Asking CI to `docker run` a container for that is ceremony. So `@strata/core` gets two supported entry points — the CLI and the server — and `scripts/analyze.mjs` is retired into one of them.
+
+This only pays for itself if both entry points share **one** config resolver, which is why it depends on [ADR-12](0012-repo-owned-config-file.md): the repository's file is the single description of what a run does, so the CLI and the workbench cannot disagree about a repository's health.
+
+## Exit codes
+
+`0` clean · `1` a gate was violated · `2` Strata could not tell you — a named stage was missing, a stage threw, the config was invalid.
+
+The distinction between `1` and `2` is the difference between "your code got worse" and "the tool broke," which CI treats differently. Collapsing them is how a broken plugin becomes a permanently red build nobody investigates.
+
+## No path allow-list, deliberately
+
+`$STRATA_ROOTS` answers "what may a *remote caller* reach on this machine" ([ADR-8](0008-shared-bearer-token.md)). That question does not exist for a process the user launched from their own shell, in their own repository, with their own privileges. Re-applying it in the CLI would be theatre that mostly produces confusing 403s in CI. `$STRATA_TOKEN` likewise has nothing to authenticate: there is no request.
+
+Recorded because the *absence* is the surprising part — a future reader will find the allow-list in one entry point and not the other and assume it is an oversight.
+
+What does transfer is the plugin trust decision: third-party stages run in-process with the caller's privileges, the same as any linter or test runner, and the CLI's documentation says so plainly.

--- a/docs/adr/0015-partial-runs-and-per-stage-status.md
+++ b/docs/adr/0015-partial-runs-and-per-stage-status.md
@@ -1,0 +1,17 @@
+# A stage failure fails its dependents, not the run
+
+> Status: accepted, not yet implemented.
+
+Today any plugin that throws propagates out of `Strata.analyze`, and the worker marks the whole job failed. Once anyone can add a stage ([ADR-10](0010-open-analysis-pipeline.md)), that means a third-party stage dividing by zero discards twenty minutes of successful language analysis.
+
+A failing stage instead fails **itself and everything downstream of it**; unrelated branches still produce output. The dependency graph makes "downstream" precisely computable, which is a second dividend of declaring dependencies by output type.
+
+This is a deliberate inconsistency with [ADR-12](0012-repo-owned-config-file.md)'s rule that a *missing* stage is a hard failure. A missing stage is a configuration error knowable before any work happens; a throwing stage is discovered after most of the work is done.
+
+## The report carries status, not bare outputs
+
+Each stage's entry is an envelope — `ok`, `failed` or `skipped`, with the output present only when `ok`, and `skipped` covering both "the filter matched nothing" and "an upstream failed". A sibling `diagnostics` array was rejected: a consumer must not be able to read an output without seeing that it is absent, and *Dead code* rendering "0 findings" when the stage crashed is the exact failure mode this design exists to prevent.
+
+## Consequences
+
+Every consumer must handle a partial report — the honest shape once anyone can add a stage. A partial run still counts as a run and still refreshes the project's last-run summary, marked partial. **Gates fail on any stage that is not `ok`**, which is what makes non-fatal failures safe. Caching stays per-stage: successful stages persist their results, failed ones cache nothing, so a retry re-runs only what failed.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -37,8 +37,10 @@ folder under `src/`. Contexts are `packages/*`, `apps/*` and `plugins/*`:
 ## What exists today
 
 Every context already has an `ARCHITECTURE.md` (arc42, trimmed) beside its
-`src/`, and `docs/ARCHITECTURE.md` covers the system. There is **no**
-`CONTEXT-MAP.md`, no `CONTEXT.md` and no `docs/adr/` yet.
+`src/`, and `docs/ARCHITECTURE.md` covers the system. `CONTEXT-MAP.md` exists
+at the root, with a `CONTEXT.md` in `packages/sdk`, `packages/core`,
+`packages/server` and `apps/web`; the `plugins/*` contexts have none yet.
+`docs/adr/` exists and is authoritative.
 
 `ARCHITECTURE.md` and `CONTEXT.md` are not the same document and neither
 replaces the other. Architecture docs describe structure — building blocks,
@@ -49,11 +51,10 @@ architecture doc for a context you're about to change, whether or not a
 
 ## ADRs live in a table for now
 
-System-wide decisions ADR-1…9 are rows in a table at the bottom of
-`docs/ARCHITECTURE.md`, not files. Read them there. Promoting them into
-standalone records under `docs/adr/` is a tracked backlog item
-(*Docs & DX → ADR folder*), so expect this to change; once `docs/adr/` exists,
-it is authoritative and the table becomes an index.
+System-wide decisions live as records in `docs/adr/`. The table at the bottom
+of `docs/ARCHITECTURE.md` is the index over them, not the storage. ADR-10
+onwards are **accepted but not yet implemented** — read them alongside the
+architecture doc, which still describes what ships today.
 
 ## Use the glossary's vocabulary
 

--- a/packages/core/CONTEXT.md
+++ b/packages/core/CONTEXT.md
@@ -1,0 +1,77 @@
+# Core
+
+The orchestrator: what a run is, what it reads, and what it hands back. Core
+owns everything about an analysis that is not a single stage's business.
+
+## Language
+
+**Workbench**:
+One installation of Strata — the server, its databases, and the plugins it
+loaded. It has one owner and knows about several projects.
+_Avoid_: instance, tenant, server (the server is a process, not the thing)
+
+**Project**:
+A repository this workbench knows about: an id, a display name, a root, and the
+summary of its last run. One repository is one project.
+_Avoid_: repo entry, workspace
+
+**Run**:
+One analysis of one project at one revision. A run is what produces a report.
+_Avoid_: analysis (ambiguous between the act and the result), scan
+
+**Revision**:
+The commit a run analyses. A run parameter, not stored configuration.
+_Avoid_: rev target, branch (a branch names a revision; it is not one)
+
+**Report**:
+Everything one run produced: the revision, the run's own facts, and one entry
+per stage.
+
+**Stage entry**:
+A stage's slot in the report — `ok`, `failed` or `skipped`, carrying the output
+only when `ok`. A consumer cannot read an output without seeing that it is
+absent.
+_Avoid_: stage result, diagnostics
+
+**Partial run**:
+A run in which at least one stage failed or was skipped. Still a run, still
+recorded, and never a passing gate.
+
+**Provenance**:
+The record, in the report, of which stages ran and at which versions — what
+makes a comparison between two runs, or a gate that flipped, explainable.
+
+**Job**:
+A run on the queue — queued, running, then succeeded or failed. A job outlives
+the request that asked for it.
+
+**Analysis config**:
+What an analysis of a repository does: scope, stages, convention, architecture
+rules, gates. Lives in a file checked into the analysed repository and is
+authoritative over anything stored by the workbench.
+_Avoid_: project config, project settings (a screen is named that; the concept
+belongs to the repository)
+
+**App settings**:
+How this workbench behaves — appearance, plugins directory, third-party
+loading, the incremental cache, provider instances. Never about one repository.
+_Avoid_: global config, preferences
+
+**Gate**:
+A threshold that fails a build: a new cycle, a hotspot regression, a violated
+enforced rule. A gate belongs to the repository, not to the workbench.
+
+**Architecture rule**:
+A declaration that one part of a repository may not depend on another. An
+*enforced* rule fails a gate; the rest only report.
+
+**Provider instance**:
+A configured local coding-agent CLI the workbench can launch — binary, launch
+args, environment, agent home, shadow home, models. Configuration, not a
+plugin, and never part of a run.
+_Avoid_: AI provider plugin, model backend, endpoint
+
+**Shadow home**:
+An account-specific home directory for a provider instance, keeping its
+credentials separate while the rest of the agent's state is shared. How one
+machine runs two accounts of the same agent.

--- a/packages/sdk/CONTEXT.md
+++ b/packages/sdk/CONTEXT.md
@@ -1,0 +1,39 @@
+# SDK
+
+The contracts a plugin implements and the vocabulary every other context
+borrows to talk about analysis. Nothing here executes; it is the shape of the
+agreement.
+
+## Language
+
+**Stage**:
+A unit of work in the analysis pipeline, contributed by a plugin. It declares
+what it consumes and what it produces, and the core orders the stages from
+those declarations.
+_Avoid_: plugin kind, analyzer, pass, phase
+
+**Output type**:
+The shape a stage produces — a dependency graph, a metric series, a findings
+list, an aggregate. The set is closed and defined here, even though the set of
+stages is open. A stage depends on an output type, never on another stage's id.
+_Avoid_: result type, payload
+
+**Stage filter**:
+The extensions or globs a stage declares it wants files for. The core applies
+it, so a stage only ever sees the files it matched — and so do its cache keys.
+_Avoid_: claimed files, extensions
+
+**Exclusive group**:
+A named set of stages of which at most one may run. A repository has one commit
+convention, not several.
+_Avoid_: mutex, singleton stage
+
+**Plugin**:
+A directory with a manifest that contributes one stage. Built-in and drop-in
+plugins are the same thing and get the same privileges.
+_Avoid_: extension, module (a module is a unit of the analysed code)
+
+**Plugin manifest**:
+The JSON file that declares a plugin to the registry — its id, version, target
+SDK, entry module, and everything the core needs to plan a run *without*
+importing it: what it consumes, produces, filters on, and is exclusive with.

--- a/packages/server/CONTEXT.md
+++ b/packages/server/CONTEXT.md
@@ -1,0 +1,24 @@
+# Server
+
+The HTTP API over the core. It adds two limits of its own and turns a run into
+something a browser can follow; everything else it borrows from
+[Core](../core/CONTEXT.md).
+
+## Language
+
+**API token**:
+The single shared secret that says *who may call this workbench at all*.
+Presented as a bearer credential and checked before a request is routed,
+parsed, or resolved.
+_Avoid_: API key, password, session
+
+**Allow-list root**:
+One of the directories this server may reach on disk. Says *what any caller may
+reach*, which is a different question from who may call — holding the token
+makes a caller trusted, not unconfined.
+_Avoid_: sandbox, browse root, jail
+
+**Browse**:
+Listing the subdirectories of one directory on the server's machine, marking
+which are git working trees, so a repository can be picked rather than typed.
+Directory names only — never files, never contents.


### PR DESCRIPTION
## What

Documentation only — no code changes, no behaviour changes.

- **`docs/adr/` now exists and is authoritative.** ADR-1…9 are promoted out of the table at the bottom of the architecture doc into standalone records, each carrying the rejected alternatives and consequences the table had no room for.
- **ADR-10…15 record a new design**, from a grilling session: the open analysis pipeline, one breaking SDK wave to `0.2.0`, repo-owned analysis config, AI providers as configured instances rather than plugins, the CLI's trust model, and partial runs with per-stage status.
- **A `CONTEXT-MAP.md` over per-package `CONTEXT.md` files** (sdk, core, server, web), in the multi-context layout `AGENTS.md` specifies. Only the four contexts whose vocabulary actually got settled have one.
- **`BACKLOG.md` mirrors** the spec and its seventeen tickets, and marks the two ADR items done.

Section 9 of `docs/ARCHITECTURE.md` becomes the index over `docs/adr/` rather than the storage.

## Why

The claim that "everything is a plugin" was not true: the pipeline is three hard-coded phases and the report is a closed struct, so architecture fitness and the commit fold had to be built into the core. Three more problems shared that shape — analysis config living in the workbench's databases meant CI could not read the gates its own settings screen edits; any plugin that throws fails the whole run; and `ai-provider` was a plugin kind the orchestrator never looked up.

ADR-10…15 settle what to do about all four. This PR is the record of those decisions, not their implementation.

**Nothing here is implemented.** ADR-10 onwards are marked *accepted, not yet implemented*, and the architecture doc says plainly that sections 5, 6 and 8 still describe what ships today. The work is specced in #113 and broken into seventeen tickets, #114–#130, with native blocking edges — #114, #115 and #116 have no blockers.

Closes #38. Closes #88.

## Type of change

- [x] docs / test / build / ci / chore

## Checklist

- [x] `pnpm build && pnpm test && pnpm lint` pass locally — unaffected; no source file is touched
- [ ] Added/updated tests where it made sense — n/a, documentation only
- [x] Docs updated (README / docs/) if behaviour changed — this PR *is* the docs update; no behaviour changed

## Review notes

The two backfilled ADRs worth a second look are [0004 (blob-keyed cache)](docs/adr/0004-sqlite-blob-keyed-cache.md) and [0009 (worker queue)](docs/adr/0009-worker-thread-analysis-queue.md) — I reconstructed their rejected alternatives from the architecture doc and the code, so check I attributed the reasoning correctly rather than inventing it.

Of the new ones, [0012 (repo-owned config)](docs/adr/0012-repo-owned-config-file.md) has the widest blast radius: it deletes the project config store, moves gates out of app settings, and makes settings screens write into the analysed repository — which cuts against the read-only mount the shipped image uses, so it resolves that with a per-project writability probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
