### PR TITLE
feat(sdk): declare a plugin's stage in its manifest

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -80,7 +80,8 @@ Anything marked *(mockup)* exists as a design and needs an implementation.
       Broken into 17 tickets, sub-issues of the spec. The stage contract lands
       *beside* the existing plugin kinds and the old form is deleted only once
       nothing uses it, so every ticket keeps the local gate green on its own.
-      Ready to start: the one left with no blockers, *stage declarations*.
+      Ready to start: the one left with no blockers, *the scheduler runs its
+      first stage: hotspots*.
 
   - [x] Retire the AI provider plugin contract
   - [x] Fold cross-language derivation into the report
@@ -94,7 +95,16 @@ Anything marked *(mockup)* exists as a design and needs an implementation.
         setting that asked for it. The lenient convention path — a warning and
         an empty parse, which rendered as a history conforming to nothing — is
         gone.
-  - [ ] **P0** Stage declarations in the plugin manifest (SDK 0.2.0)
+  - [x] Stage declarations in the plugin manifest (SDK 0.2.0)
+        A manifest may declare its plugin's stage — what it consumes, what it
+        produces, the files it filters on and the group it is exclusive with —
+        and the registry validates all four from the JSON alone, before the
+        entry module is imported, so a run is planned without running
+        third-party code. A module that contradicts what its manifest declared
+        is refused at load, the way a mismatched kind is. The SDK is `0.2.0` and
+        carries the closed output-type set and the stage entry a report will
+        hold; `GET /plugins` reports every declaration. Nothing runs differently
+        yet.
   - [ ] **P0** The scheduler runs its first stage: hotspots
   - [ ] **P1** Migrate change coupling to a stage
   - [ ] **P1** Migrate the TypeScript language module to a stage

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -73,7 +73,7 @@ analysed repo.
 
 | Challenge | Decision |
 |-----------|----------|
-| Extensibility | Four small plugin contracts in `@strata/sdk`; a registry loads them by manifest — the built-ins, plus drop-in third-party plugins from `STRATA_PLUGINS_DIR`. |
+| Extensibility | Three small plugin contracts in `@strata/sdk`; a registry loads them by manifest — the built-ins, plus drop-in third-party plugins from `STRATA_PLUGINS_DIR`. |
 | One tool, many languages | Parsing standardised on **tree-sitter** grammars (WASM, so no native build step); analyzers return a common shape. |
 | Big-repo performance | Blob-sha-keyed incremental cache (SQLite) in the core. |
 | Portability | Web frontend + thin API, packaged as a Docker image now and Tauri desktop later. |
@@ -225,6 +225,14 @@ publish. The Linux desktop job is still a stub — it produces no bundle until
 
 - **Plugin model** — `define*` helpers stamp the `kind` discriminant; the
   registry refuses a plugin whose manifest `sdk` major mismatches.
+- **Stage declarations** — a manifest may also declare its plugin's **stage**:
+  the output types it consumes, the one it produces, the files it filters on and
+  the exclusive group it belongs to. Static JSON, validated before the entry
+  module is imported, so a run is planned without running third-party code
+  ([ADR-10](./adr/0010-open-analysis-pipeline.md)); where the exported object
+  says the same thing, the registry holds the two to each other at load. Read
+  and reported (`GET /plugins`) but not yet scheduled from — the three kinds
+  above still drive a run.
 - **RepoContext** — the single immutable surface plugins are allowed to touch
   (`root`, `rev`, `files`, `git()`, `log`, `cache`).
 - **Incremental cache** — two levels in one SQLite file (`node:sqlite`, no

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -18,11 +18,48 @@ this repo — see [Installing a plugin](#installing-a-plugin).
   "name": "Python",
   "kind": "language",
   "version": "0.1.0",
-  "sdk": "0.1.0",
+  "sdk": "0.2.0",
   "main": "./dist/index.js",
   "description": "Dependency graph and dead code for Python."
 }
 ```
+
+### Declaring a stage
+
+A manifest may also declare the plugin's **stage** — what it consumes, what it
+produces, what files it wants, and what it is exclusive with:
+
+```json
+{
+  "consumes": ["graph"],
+  "produces": "findings",
+  "filter": { "extensions": ["py"], "globs": ["src/**/*.pyi"] },
+  "exclusive": "python-rules"
+}
+```
+
+- **`consumes`** — output types, never plugin ids. Every upstream output of each
+  type arrives keyed by the plugin that produced it, so a stage consuming
+  `graph` works with language modules that did not exist when it was written.
+- **`produces`** — the one output type the stage produces. The set is closed:
+  `graph`, `metrics`, `findings`, `commits`, `aggregate`. `aggregate` is
+  whatever a stage folded for itself, in a shape only it and a consumer that
+  means it understand.
+- **`filter`** — the files it wants, by extension (bare, no dot) and/or by
+  repo-relative glob. The **core** applies it, so the stage sees only what it
+  matched and its cache key covers only those files: an unrelated file changing
+  does not invalidate it.
+- **`exclusive`** — a group of which at most one member runs; configuration
+  names the active one. A repository has one commit convention, not several.
+
+All four are static JSON so the core can order the stages and reject a
+configuration it cannot satisfy **without importing any plugin code**
+([ADR-10](adr/0010-open-analysis-pipeline.md)). They are validated at load, and
+where the exported object still says the same thing — a language plugin's
+`extensions` against `filter.extensions` — the two must agree.
+
+They are optional today: a plugin that declares none of them runs the way it
+always did, by its `kind`. Declaring them is what lets the scheduler place it.
 
 ## The three kinds
 
@@ -170,11 +207,18 @@ What the loader enforces, because a drop-in plugin is not first-party code:
 - Every manifest field is validated, and the `kind` must be one of the three.
   A manifest naming a kind Strata has since dropped (`ai-provider`) is refused
   with what replaced it, rather than as an unknown word.
+- The stage declarations are validated **before the entry module is imported**
+  — an unknown output type, a filter that could match nothing, an extension
+  written `".py"` — because planning a run may not require running third-party
+  code.
 - `main` is resolved **inside the plugin's own directory** — it may not point
   anywhere else on the host.
 - The exported `kind` must match the manifest's, and the export must actually
   implement that kind (a `language` plugin without `analyze()` is refused at
-  load rather than throwing mid-analysis).
+  load rather than throwing mid-analysis). So must anything the manifest
+  declared twice: a `filter.extensions` the module's own `extensions` disagrees
+  with is refused, because the core plans from the manifest and the module does
+  the work.
 - Ids are unique and **first one wins**; built-ins load first, so a drop-in can
   never take over an id Strata ships with.
 - A plugin that trips any of these is skipped, not fatal. It shows up in
@@ -205,3 +249,6 @@ needed between runs. Discovery happens once at startup.
 
 `strata.plugin.json.sdk` must share a major with the running SDK. Breaking a
 published contract in `@strata/sdk` means a major bump and a migration note.
+The SDK is at `0.2.0`, which added the stage declarations above; `0.x` is
+deliberate, and the open pipeline gets used in anger before it is promised
+([ADR-11](adr/0011-sdk-0-2-0-single-break.md)).

--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -50,6 +50,8 @@ itself behaves.
 | `registry.ts` | `PluginRegistry` — load plugins, contain load failures, `byKind()` / `loadedByKind()`. |
 | `manifest.ts` | `readManifest()` / `resolveEntry()` — validate a `strata.plugin.json` and its entry path. |
 | `plugin-shape.ts` | `pluginShapeError()` — does the module implement the kind it claims? |
+| `stage-declarations.ts` | `stageDeclarationError()` — are a manifest's stage declarations ones the core could honour? Read from the JSON alone. |
+| `plugin-agreement.ts` | `pluginAgreementError()` — does the exported object still say what the manifest declared? |
 | `retired-kinds.ts` | `retiredKindError()` — a kind Strata dropped, and what took over its job. |
 | `summarise.ts` | `summarised()` — fill in a language result's graph summary when the plugin (or its cached run) predates the field. |
 | `progress/types.ts` | `AnalysisProgress`, `AnalysisStage`, `ProgressListener` — what a run says about itself while it runs. |

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -2,6 +2,7 @@ import { readFile } from 'node:fs/promises';
 import { dirname, isAbsolute, relative, resolve, sep } from 'node:path';
 import { PLUGIN_KINDS, SDK_VERSION, type PluginManifest } from '@strata/sdk';
 import { retiredKindError } from './retired-kinds.js';
+import { stageDeclarationError } from './stage-declarations.js';
 
 /** The file that marks a directory as a plugin. */
 export const MANIFEST_FILENAME = 'strata.plugin.json';
@@ -61,6 +62,12 @@ export async function readManifest(
       `Plugin "${manifest.id}" targets SDK ${manifest.sdk}, ` +
         `but this build ships SDK ${SDK_VERSION}.`,
     );
+  }
+  // Last, and still from the JSON alone: a plugin targeting another SDK
+  // declares its stage in that SDK's dialect, and has already been refused.
+  const declaration = stageDeclarationError(fields);
+  if (declaration) {
+    throw new Error(`Plugin "${manifest.id}" ${declaration}.`);
   }
   return manifest;
 }

--- a/packages/core/src/plugin-agreement.ts
+++ b/packages/core/src/plugin-agreement.ts
@@ -1,0 +1,43 @@
+import type { PluginManifest, StrataPlugin } from '@strata/sdk';
+
+/**
+ * Why a plugin's exported object contradicts what its manifest declared, or
+ * `null` when the two agree.
+ *
+ * The manifest is what the core plans from, and it plans without importing
+ * anything (`docs/adr/0010`) — so a declaration the module then disagrees with
+ * makes the plan a lie: the core would hand a stage files its analyzer ignores,
+ * or skip files it needed. Refused at load, exactly as a mismatched `kind` is,
+ * because the alternative is a run that silently analyses the wrong set.
+ *
+ * Only what the exported object still says about itself can be cross-checked,
+ * which today is a language plugin's extension list. As each declaration moves
+ * off the object and into the manifest, its check here goes with it.
+ */
+export function pluginAgreementError(
+  manifest: PluginManifest,
+  plugin: StrataPlugin,
+): string | null {
+  const declared = manifest.filter?.extensions;
+  if (!declared || plugin.kind !== 'language') return null;
+
+  const exported = plugin.extensions;
+  if (sorted(declared) !== sorted(exported)) {
+    return (
+      `declares filter extensions ${list(declared)} ` +
+      `but exports ${list(exported)}`
+    );
+  }
+  return null;
+}
+
+/** Order is not part of an extension list; membership is. */
+function sorted(extensions: readonly string[]): string {
+  return [...extensions].sort().join(',');
+}
+
+function list(extensions: readonly string[]): string {
+  return extensions.length === 0
+    ? 'none'
+    : extensions.map((extension) => `"${extension}"`).join(', ');
+}

--- a/packages/core/src/registry.test.ts
+++ b/packages/core/src/registry.test.ts
@@ -287,3 +287,137 @@ describe('loadFrom', () => {
     expect(loaded.source).toBe('builtin');
   });
 });
+
+/**
+ * A stage is declared in the manifest, as static JSON, so the core can plan a
+ * run without importing anything — which is only true if the declarations are
+ * validated there too.
+ */
+describe('stage declarations', () => {
+  it('keeps what a plugin declared on its manifest', async () => {
+    writePlugin('alpha', {
+      consumes: ['commits'],
+      produces: 'aggregate',
+      filter: { extensions: ['ts'], globs: ['src/**/*.ts'] },
+      exclusive: 'commit-fold',
+    });
+
+    const registry = new PluginRegistry(silent);
+    const [loaded] = await registry.loadDirectory(dir);
+
+    expect(loaded?.manifest).toMatchObject({
+      consumes: ['commits'],
+      produces: 'aggregate',
+      filter: { extensions: ['ts'], globs: ['src/**/*.ts'] },
+      exclusive: 'commit-fold',
+    });
+    expect(registry.failures()).toEqual([]);
+  });
+
+  it('loads a plugin that declares no stage at all', async () => {
+    writePlugin('alpha');
+
+    const registry = new PluginRegistry(silent);
+    const [loaded] = await registry.loadDirectory(dir);
+
+    expect(loaded?.manifest.produces).toBeUndefined();
+    expect(registry.failures()).toEqual([]);
+  });
+
+  it('refuses an output type that is not one of the closed set', async () => {
+    writePlugin('alpha', { consumes: ['graph', 'vibes'] });
+    writePlugin('beta', { produces: 'vibes' });
+
+    const registry = new PluginRegistry(silent);
+    await registry.loadDirectory(dir);
+
+    expect(registry.all()).toEqual([]);
+    expect(errors(registry)).toEqual([
+      expect.stringMatching(/unknown output type "vibes" in "consumes"/),
+      expect.stringMatching(/unknown output type "vibes" in "produces"/),
+    ]);
+  });
+
+  it('validates the declarations before it imports the entry module', async () => {
+    const pluginDir = writePlugin('alpha', { produces: 'vibes' });
+    writeFileSync(
+      join(pluginDir, 'index.js'),
+      'throw new Error("the entry module ran");',
+    );
+
+    const registry = new PluginRegistry(silent);
+    await registry.loadDirectory(dir);
+
+    expect(errors(registry)).toEqual([
+      expect.stringMatching(/unknown output type "vibes"/),
+    ]);
+  });
+
+  it('refuses a filter that would match nothing', async () => {
+    writePlugin('alpha', { filter: {} });
+    writePlugin('beta', { filter: { extensions: [] } });
+
+    const registry = new PluginRegistry(silent);
+    await registry.loadDirectory(dir);
+
+    expect(errors(registry)).toEqual([
+      expect.stringMatching(/naming neither extensions nor globs/),
+      expect.stringMatching(/naming neither extensions nor globs/),
+    ]);
+  });
+
+  it('refuses an extension written with its dot', async () => {
+    writePlugin('alpha', { filter: { extensions: ['.ts'] } });
+
+    const registry = new PluginRegistry(silent);
+    await registry.loadDirectory(dir);
+
+    expect(errors(registry)).toEqual([
+      expect.stringMatching(/extension "\.ts" with a leading dot/),
+    ]);
+  });
+
+  it('refuses declarations that are not the shape they must be', async () => {
+    writePlugin('alpha', { consumes: 'graph' });
+    writePlugin('beta', { filter: { globs: [''] } });
+    writePlugin('gamma', { exclusive: '  ' });
+
+    const registry = new PluginRegistry(silent);
+    await registry.loadDirectory(dir);
+
+    expect(errors(registry)).toEqual([
+      expect.stringMatching(/"consumes" that is not an array of output types/),
+      expect.stringMatching(/"filter.globs" that is not a list of globs/),
+      expect.stringMatching(/"exclusive" that is not a group name/),
+    ]);
+  });
+
+  it('rejects a module whose extensions contradict the filter it declared', async () => {
+    // The manifest is what the core plans from; the module ships the analyzer.
+    writePlugin('alpha', { filter: { extensions: ['py'] } });
+
+    const registry = new PluginRegistry(silent);
+    await registry.loadDirectory(dir);
+
+    expect(registry.all()).toEqual([]);
+    expect(errors(registry)).toEqual([
+      expect.stringMatching(
+        /declares filter extensions "py" but exports "ts"/,
+      ),
+    ]);
+  });
+
+  it('reads a filter and an exported list in the same order-free way', async () => {
+    const pluginDir = writePlugin('alpha', {
+      filter: { extensions: ['tsx', 'ts'] },
+    });
+    writeFileSync(
+      join(pluginDir, 'index.js'),
+      PLUGIN_SOURCE('language').replace("['ts']", "['ts', 'tsx']"),
+    );
+
+    const registry = new PluginRegistry(silent);
+
+    expect(await registry.loadDirectory(dir)).toHaveLength(1);
+  });
+});

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -4,6 +4,7 @@ import type { Logger, PluginManifest, StrataPlugin } from '@strata/sdk';
 import { discoverPlugins } from './discover.js';
 import { createConsoleLogger } from './logger.js';
 import { readManifest, resolveEntry } from './manifest.js';
+import { pluginAgreementError } from './plugin-agreement.js';
 import { pluginShapeError } from './plugin-shape.js';
 
 /** Where a plugin came from: shipped with Strata, or dropped in by the user. */
@@ -83,6 +84,10 @@ export class PluginRegistry {
     const shapeError = pluginShapeError(manifest.kind, plugin);
     if (shapeError) {
       throw new Error(`Plugin "${manifest.id}" (${entry}) ${shapeError}.`);
+    }
+    const disagreement = pluginAgreementError(manifest, plugin);
+    if (disagreement) {
+      throw new Error(`Plugin "${manifest.id}" ${disagreement}.`);
     }
 
     const loaded: LoadedPlugin = {

--- a/packages/core/src/stage-declarations.ts
+++ b/packages/core/src/stage-declarations.ts
@@ -1,0 +1,112 @@
+import { OUTPUT_TYPES } from '@strata/sdk';
+
+/**
+ * Why a manifest's stage declarations are not usable, or `null` when they are.
+ *
+ * Checked from the JSON alone, before the entry module is imported: the core
+ * plans a run — orders the stages, resolves what each one consumes, rejects a
+ * configuration nothing can satisfy — without running third-party code
+ * (`docs/adr/0010`). A declaration it cannot honour therefore has to fail as a
+ * validation error at the same moment `kind` does, not halfway through a load.
+ *
+ * Takes the parsed JSON rather than a `PluginManifest`, because a hand-written
+ * manifest has not earned that type yet: every field here may be any JSON at
+ * all, and saying so is the point of the checks.
+ */
+export function stageDeclarationError(
+  fields: Record<string, unknown>,
+): string | null {
+  const { consumes, produces, filter, exclusive } = fields;
+
+  if (consumes !== undefined) {
+    if (!Array.isArray(consumes)) {
+      return 'has a "consumes" that is not an array of output types';
+    }
+    for (const type of consumes) {
+      const unknown = unknownOutputType(type, 'consumes');
+      if (unknown) return unknown;
+    }
+  }
+
+  if (produces !== undefined) {
+    const unknown = unknownOutputType(produces, 'produces');
+    if (unknown) return unknown;
+  }
+
+  if (filter !== undefined) {
+    const error = filterError(filter);
+    if (error) return error;
+  }
+
+  if (
+    exclusive !== undefined &&
+    (typeof exclusive !== 'string' || exclusive.trim() === '')
+  ) {
+    return 'has an "exclusive" that is not a group name';
+  }
+
+  return null;
+}
+
+/**
+ * The set of output types is closed (`docs/adr/0010`), so a name that is not
+ * one is a plugin written against a Strata that has it, or a typo — either way
+ * a stage the core could never wire up. The message lists the set, which is
+ * short and is the answer.
+ */
+function unknownOutputType(value: unknown, field: string): string | null {
+  if (
+    typeof value === 'string' &&
+    (OUTPUT_TYPES as readonly string[]).includes(value)
+  ) {
+    return null;
+  }
+  return (
+    `declares unknown output type ${JSON.stringify(value)} in "${field}" ` +
+    `(expected one of ${OUTPUT_TYPES.join(', ')})`
+  );
+}
+
+/**
+ * A filter the core cannot apply is worse than none: it would hand the stage
+ * nothing and skip it every run, which reads on screen as a stage that found
+ * nothing. So an empty filter is refused rather than honoured.
+ */
+function filterError(filter: unknown): string | null {
+  if (typeof filter !== 'object' || filter === null || Array.isArray(filter)) {
+    return 'has a "filter" that is not an object';
+  }
+
+  const { extensions, globs } = filter as Record<string, unknown>;
+  for (const [field, value] of [
+    ['extensions', extensions],
+    ['globs', globs],
+  ] as const) {
+    if (value === undefined) continue;
+    if (!Array.isArray(value) || value.some((entry) => !isName(entry))) {
+      return `has a "filter.${field}" that is not a list of ${field}`;
+    }
+  }
+
+  const named = [...asStrings(extensions), ...asStrings(globs)];
+  if (named.length === 0) {
+    return 'has a "filter" naming neither extensions nor globs';
+  }
+
+  // The language contract has always spelled extensions bare, and the core
+  // matches them that way; ".ts" would quietly match nothing.
+  const dotted = asStrings(extensions).find((entry) => entry.startsWith('.'));
+  if (dotted !== undefined) {
+    return `declares the filter extension "${dotted}" with a leading dot (write it as "${dotted.slice(1)}")`;
+  }
+
+  return null;
+}
+
+function isName(value: unknown): value is string {
+  return typeof value === 'string' && value.trim() !== '';
+}
+
+function asStrings(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter(isName) : [];
+}

--- a/packages/sdk/ARCHITECTURE.md
+++ b/packages/sdk/ARCHITECTURE.md
@@ -5,9 +5,11 @@
 ## 1. Purpose & Goals
 
 The **public contract** every plugin implements and the core consumes. Defines
-the three plugin kinds, their data shapes, and the `define*` helpers. It is the
-one module whose stability matters most — a breaking change here ripples to all
-plugins.
+the three plugin kinds, their data shapes, and the `define*` helpers — and, from
+`0.2.0`, the vocabulary of the open pipeline: what a **stage** declares about
+itself in its manifest, the closed set of **output types** it may produce, and
+the **stage entry** a report carries per stage. It is the one module whose
+stability matters most — a breaking change here ripples to all plugins.
 
 Goals: a minimal, strongly-typed, SemVer-stable surface.
 
@@ -22,8 +24,9 @@ Goals: a minimal, strongly-typed, SemVer-stable surface.
 - **Consumed by:** `@strata/core` (registry validates `manifest.sdk` against
   `SDK_VERSION`) and every `plugins/*` package.
 - **Exports:** types (`RepoContext`, `LanguageAnalysis`, `ParsedCommit`,
-  `MetricSeries`, …) and helpers (`defineLanguagePlugin`,
-  `defineCommitConventionPlugin`, `defineGitMetricPlugin`).
+  `MetricSeries`, `OutputType`, `StageEntry`, …) and helpers
+  (`defineLanguagePlugin`, `defineCommitConventionPlugin`,
+  `defineGitMetricPlugin`).
 - **Not exported:** anything about AI. A provider is a configured instance in
   the app settings and the call surface for one lives inside `@strata/core`
   ([ADR-13](../../docs/adr/0013-providers-are-configured-instances.md)).
@@ -36,7 +39,7 @@ path (`@strata/sdk`).
 | File | Contents |
 |------|----------|
 | `version.ts` | `SDK_VERSION` |
-| `manifest.ts` | `PluginKind`, `PLUGIN_KINDS` (the same list as a value, for loaders), `PluginManifest` |
+| `manifest.ts` | `PluginKind`, `PLUGIN_KINDS` (the same list as a value, for loaders), `PluginManifest`, `StageFilter` — including a plugin's stage declarations (`consumes`, `produces`, `filter`, `exclusive`) |
 | `logger.ts` | `Logger` |
 | `repo.ts` | `RepoFile`, `RepoContext` |
 | `cache.ts` | `PluginCache` — the blob-keyed incremental cache contract |
@@ -46,6 +49,9 @@ path (`@strata/sdk`).
 | `language.ts` | `LanguagePlugin`, `LanguageAnalysis`, `DeadCodeFinding`, `CodeMetric` |
 | `commit.ts` | `CommitConventionPlugin`, `RawCommit`, `ParsedCommit` |
 | `metric.ts` | `GitMetricPlugin`, `MetricSeries`, `MetricPoint` |
+| `output.ts` | `OutputType`, `OUTPUT_TYPES`, `StageOutputs`, `Aggregate` — the closed set of what a stage may produce, and the shape behind each |
+| `finding.ts` | `Finding` — one thing a stage found, whichever stage found it |
+| `stage.ts` | `StageStatus`, `StageEntry` (+ `StageOk` / `StageFailed` / `StageSkipped`) — a report's per-stage slot |
 | `plugin.ts` | `StrataPlugin` — the discriminated union |
 
 ## 5. Runtime
@@ -53,6 +59,7 @@ path (`@strata/sdk`).
 Almost none, but not zero: the `define*` helpers merely stamp the `kind`
 discriminant so the core can route a plugin without reflection,
 `PLUGIN_KINDS` is the kind list as a value, for loaders validating a manifest,
+`OUTPUT_TYPES` is the same for the output types a manifest may name,
 and `summariseGraph` counts a dependency graph so that every language module
 reports the same numbers for the same graph.
 Both survive compilation, so a built plugin still imports `@strata/sdk` at
@@ -67,6 +74,18 @@ runtime — it must be resolvable from the plugin (see
   type-safely.
 - **`RepoContext.cache` is always present** — the core injects a pass-through
   when caching is off, so plugins never branch on cache availability.
+- **Stage declarations are manifest JSON, not exported members** — the core
+  plans a run without importing third-party code
+  ([ADR-10](../../docs/adr/0010-open-analysis-pipeline.md)). Where the exported
+  object still says the same thing, the registry cross-checks the two at load,
+  as it does `kind`.
+- **The output-type set is closed, the stage set is open** — a stage depends on
+  an output type, never on another stage's id, so a report stays renderable by a
+  consumer that does not know which stages ran. Adding an output type is a
+  change here; adding a stage is not.
+- **`0.2.0`, deliberately not `1.0.0`** — the contract is real but not yet
+  load-bearing for anyone outside this repo
+  ([ADR-11](../../docs/adr/0011-sdk-0-2-0-single-break.md)).
 
 ## 7. Quality & Risks
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@strata/sdk",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Plugin contracts for Strata: language, commit-convention and git-metric interfaces.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/sdk/src/finding.ts
+++ b/packages/sdk/src/finding.ts
@@ -1,0 +1,26 @@
+/**
+ * One thing a stage found and a reader can act on: a dead export, an import
+ * that crosses a layer it may not, a file nobody reaches.
+ *
+ * Deliberately not one kind of finding. The set of output types is closed
+ * (`docs/adr/0010`), so every stage whose result is a list of complaints
+ * reports it in this shape — and a screen, a CI gate and a second API client
+ * read all of them the same way, whichever stage produced them.
+ */
+export interface Finding {
+  /**
+   * What found it: a rule id, a check name. Stable enough for a repository to
+   * name in its configuration and for two runs to be compared by it.
+   */
+  rule: string;
+  /** Repo-relative file it is about; `null` when it is about the repository. */
+  path: string | null;
+  /** One line, in the stage's own words — what a list of findings prints. */
+  message: string;
+  /** Line within `path`, where the stage knows one. */
+  line?: number;
+  /** Symbol within `path`, where the finding is about one. */
+  symbol?: string;
+  /** How loudly to say it. A gate reads this, never the wording. */
+  severity: 'info' | 'warning' | 'error';
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -13,6 +13,12 @@
  * default-exports one of the `define*` helpers below. The core loads manifests,
  * imports the entry, and registers the returned object.
  *
+ * A manifest may also declare the plugin's **stage**: what it consumes, what it
+ * produces, what files it filters on and what it is exclusive with. Those are
+ * static JSON on purpose — the core plans a run from them without importing
+ * anything (`docs/adr/0010`) — and the shapes behind them are `OutputType` and
+ * `StageEntry`, a report's per-stage slot.
+ *
  * This file is a barrel: one concern per module, re-exported here as the public
  * surface. Import from `@strata/sdk`, never from a submodule path.
  */
@@ -26,6 +32,11 @@ export * from './repo.js';
 export * from './graph.js';
 export * from './cycle.js';
 export * from './summary.js';
+export * from './finding.js';
+
+// The pipeline: what a stage produces, and its slot in a report
+export * from './output.js';
+export * from './stage.js';
 
 // The three plugin kinds
 export * from './language.js';

--- a/packages/sdk/src/manifest.ts
+++ b/packages/sdk/src/manifest.ts
@@ -1,3 +1,5 @@
+import type { OutputType } from './output.js';
+
 /**
  * Every plugin kind, as a value — a loader validating a hand-written manifest
  * needs the list at runtime, not just the type.
@@ -9,6 +11,22 @@ export const PLUGIN_KINDS = [
 ] as const;
 
 export type PluginKind = (typeof PLUGIN_KINDS)[number];
+
+/**
+ * The files a stage wants, by extension and/or by glob.
+ *
+ * Declared rather than applied by the stage itself, because the *core* applies
+ * it: a stage only ever sees the files it matched, and so does its cache key —
+ * "the files this stage actually read" rather than every file in the
+ * repository, so a README edit does not invalidate a TypeScript graph
+ * (`docs/adr/0010`).
+ */
+export interface StageFilter {
+  /** Extensions, written without the dot: `["ts", "tsx"]`. */
+  extensions?: string[];
+  /** Repo-relative globs: `["proto/**\/*.proto"]`. */
+  globs?: string[];
+}
 
 /** Parsed from `strata.plugin.json`, sitting next to a plugin's package.json. */
 export interface PluginManifest {
@@ -24,4 +42,34 @@ export interface PluginManifest {
   main: string;
   description?: string;
   author?: string;
+
+  /*
+   * What this plugin's stage is, as static data.
+   *
+   * All four live here rather than on the exported object so the core can read
+   * them without importing the plugin: planning a run — ordering the stages and
+   * rejecting a configuration that cannot be satisfied — must never require
+   * running third-party code (`docs/adr/0010`).
+   *
+   * Optional for as long as `kind` still drives a run: a plugin that declares
+   * none of them is an ordinary language, git-metric or commit-convention
+   * plugin and runs the way it always did. The stage contract lands beside the
+   * kinds and replaces them once nothing needs them (`docs/adr/0011`).
+   */
+
+  /**
+   * Output types the stage reads. Every upstream output of each type arrives,
+   * keyed by the plugin that produced it, so a stage never needs to know which
+   * plugins are installed.
+   */
+  consumes?: OutputType[];
+  /** The single output type the stage produces. */
+  produces?: OutputType;
+  /** The files it wants; omitted means it reads no files of its own. */
+  filter?: StageFilter;
+  /**
+   * A named set of stages of which at most one may run — a repository has one
+   * commit convention, not several. Configuration names the active member.
+   */
+  exclusive?: string;
 }

--- a/packages/sdk/src/output.ts
+++ b/packages/sdk/src/output.ts
@@ -1,0 +1,64 @@
+import type { ParsedCommit } from './commit.js';
+import type { Finding } from './finding.js';
+import type { DependencyGraph } from './graph.js';
+import type { MetricSeries } from './metric.js';
+
+/**
+ * Every output type, as a value — a registry validating a hand-written manifest
+ * needs the list at runtime, not just the type.
+ */
+export const OUTPUT_TYPES = [
+  'graph',
+  'metrics',
+  'findings',
+  'commits',
+  'aggregate',
+] as const;
+
+/**
+ * What a stage produces, and what another stage asks for when it declares what
+ * it consumes.
+ *
+ * The set is **closed** and lives here, even though the set of stages is open:
+ * a stage depends on an output type, never on another stage's id, so adding a
+ * language module feeds every stage that consumes a graph with no configuration
+ * anywhere. Adding an output type is an SDK change; adding a stage is not
+ * (`docs/adr/0010`).
+ */
+export type OutputType = (typeof OUTPUT_TYPES)[number];
+
+/**
+ * Whatever a stage folded for itself: the commit fold's counts per type and
+ * scope, a rule engine's tally per rule.
+ *
+ * The escape hatch a closed set needs — a stage whose result is none of the
+ * other four stays a stage instead of becoming an SDK change. Its shape is the
+ * producer's own: the core carries it, serialises it and never reads inside it,
+ * and only a consumer that means one specific producer narrows it. It must
+ * therefore be JSON, because it crosses the wire like everything else in a
+ * report.
+ */
+export type Aggregate = unknown;
+
+/**
+ * The shape behind each output type: what a stage producing it hands over, and
+ * what a stage consuming it receives.
+ *
+ * One table rather than a convention, so "consumes a graph" means the same
+ * thing to the producer, the consumer, the cache and the screen.
+ */
+export interface StageOutputs {
+  /** A dependency graph over files, modules or packages. */
+  graph: DependencyGraph;
+  /** One measured series — hotspots, change coupling, code age. */
+  metrics: MetricSeries;
+  /** Everything one stage found, in one list. */
+  findings: Finding[];
+  /** The analysed history window as a convention parsed it, log order. */
+  commits: ParsedCommit[];
+  /** Numbers only the producing stage and a consumer that means it understand. */
+  aggregate: Aggregate;
+}
+
+/** The shape of one output type, spelled the short way. */
+export type StageOutput<T extends OutputType = OutputType> = StageOutputs[T];

--- a/packages/sdk/src/stage.ts
+++ b/packages/sdk/src/stage.ts
@@ -1,0 +1,49 @@
+import type { OutputType, StageOutputs } from './output.js';
+
+/**
+ * How a stage ended. `skipped` covers both "its filter matched nothing" and
+ * "something it consumes never arrived", which are the same thing to a reader:
+ * the stage did not run, and nothing it would have said is known.
+ */
+export type StageStatus = 'ok' | 'failed' | 'skipped';
+
+/** A stage that ran and produced what it declared. */
+export interface StageOk<T extends OutputType = OutputType> {
+  status: 'ok';
+  /** The output type it declared it produces. */
+  type: T;
+  output: StageOutputs[T];
+}
+
+/** A stage that ran and threw. Its output is not knowable, not empty. */
+export interface StageFailed<T extends OutputType = OutputType> {
+  status: 'failed';
+  type: T;
+  /** Why, in one line — what the screen that would have shown the output prints. */
+  reason: string;
+}
+
+/** A stage that never ran: nothing to work on, or an upstream that failed. */
+export interface StageSkipped<T extends OutputType = OutputType> {
+  status: 'skipped';
+  type: T;
+  reason: string;
+}
+
+/**
+ * One stage's slot in a report — a status, and the output only when it
+ * succeeded.
+ *
+ * An envelope rather than a bare output with the trouble recorded elsewhere: a
+ * consumer must not be able to read an output without seeing that it is absent,
+ * because *Dead code* rendering "0 findings" for a stage that crashed is the
+ * exact failure this shape exists to prevent (`docs/adr/0015`).
+ *
+ * `type` is carried whatever the status, so an entry says what it *would* have
+ * held. It is also the discriminant that narrows `output`: switching on it and
+ * on `status` renders a report without knowing which stages ran, which is what
+ * lets a new stage appear on screen without the UI being rebuilt for it.
+ */
+export type StageEntry<T extends OutputType = OutputType> = {
+  [K in T]: StageOk<K> | StageFailed<K> | StageSkipped<K>;
+}[T];

--- a/packages/sdk/src/version.ts
+++ b/packages/sdk/src/version.ts
@@ -1,2 +1,2 @@
 /** SemVer of the SDK contract a plugin was built against. */
-export const SDK_VERSION = '0.1.0' as const;
+export const SDK_VERSION = '0.2.0' as const;

--- a/packages/server/src/routes/plugins.test.ts
+++ b/packages/server/src/routes/plugins.test.ts
@@ -1,0 +1,66 @@
+import Fastify, { type FastifyInstance } from 'fastify';
+import type {
+  AnalysisQueue,
+  LoadedPlugin,
+  PluginRegistry,
+  ProjectStore,
+  SettingsStore,
+} from '@strata/core';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { pluginsRoute } from './plugins.js';
+
+/**
+ * What the workbench loaded, as the plugins screen reads it — and, since a
+ * plugin declares its stage in its manifest, the only way to see what the
+ * pipeline is without running it.
+ */
+
+const HOTSPOTS = {
+  manifest: {
+    id: 'strata-git-hotspots',
+    name: 'Hotspots',
+    kind: 'git-metric',
+    version: '0.1.0',
+    sdk: '0.2.0',
+    main: './dist/index.js',
+    consumes: ['commits'],
+    produces: 'metrics',
+    filter: { extensions: ['ts'] },
+    exclusive: 'hotspots',
+  },
+  source: 'builtin',
+  manifestPath: '/app/plugins/git-hotspots/strata.plugin.json',
+} as unknown as LoadedPlugin;
+
+let app: FastifyInstance;
+
+beforeEach(() => {
+  app = Fastify();
+  pluginsRoute(app, {
+    registry: {
+      all: () => [HOTSPOTS],
+      failures: () => [],
+    } as unknown as PluginRegistry,
+    settings: {} as SettingsStore,
+    projects: {} as ProjectStore,
+    analyses: {} as AnalysisQueue,
+    pluginsDir: '/app/.strata/plugins',
+  });
+});
+
+afterEach(async () => {
+  await app.close();
+});
+
+describe('GET /plugins', () => {
+  it('reports every declaration a plugin made about its stage', async () => {
+    const response = await app.inject({ url: '/plugins' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      directory: '/app/.strata/plugins',
+      plugins: [{ ...HOTSPOTS.manifest, source: 'builtin' }],
+      failures: [],
+    });
+  });
+});

--- a/plugins/commit-conventional/ARCHITECTURE.md
+++ b/plugins/commit-conventional/ARCHITECTURE.md
@@ -18,7 +18,7 @@ The default, dogfooded convention — Strata's own commits are conventional.
 
 - **Depends on:** `@strata/sdk`.
 - **Consumed by:** the core's commit-analytics step.
-- **Manifest:** `strata.plugin.json` (`kind: commit-convention`, `sdk: 0.1.0`).
+- **Manifest:** `strata.plugin.json` (`kind: commit-convention`, `sdk: 0.2.0`).
 
 ## 4. Building Blocks
 

--- a/plugins/commit-conventional/strata.plugin.json
+++ b/plugins/commit-conventional/strata.plugin.json
@@ -3,7 +3,7 @@
   "name": "Conventional Commits",
   "kind": "commit-convention",
   "version": "0.1.0",
-  "sdk": "0.1.0",
+  "sdk": "0.2.0",
   "main": "./dist/index.js",
   "description": "Parses commit messages following the Conventional Commits spec.",
   "author": "Strata"

--- a/plugins/git-coupling/strata.plugin.json
+++ b/plugins/git-coupling/strata.plugin.json
@@ -3,7 +3,7 @@
   "name": "Change coupling",
   "kind": "git-metric",
   "version": "0.1.0",
-  "sdk": "0.1.0",
+  "sdk": "0.2.0",
   "main": "./dist/index.js",
   "description": "Ranks pairs of files by how often they change in the same commit (temporal coupling).",
   "author": "Strata"

--- a/plugins/git-hotspots/strata.plugin.json
+++ b/plugins/git-hotspots/strata.plugin.json
@@ -3,7 +3,7 @@
   "name": "Hotspots",
   "kind": "git-metric",
   "version": "0.1.0",
-  "sdk": "0.1.0",
+  "sdk": "0.2.0",
   "main": "./dist/index.js",
   "description": "Ranks files by change frequency × complexity to surface maintenance hotspots.",
   "author": "Strata"

--- a/plugins/language-typescript/strata.plugin.json
+++ b/plugins/language-typescript/strata.plugin.json
@@ -3,7 +3,7 @@
   "name": "TypeScript / JavaScript",
   "kind": "language",
   "version": "0.6.0",
-  "sdk": "0.1.0",
+  "sdk": "0.2.0",
   "main": "./dist/index.js",
   "description": "Import dependency graph, cycle detection, and metrics for TS/JS. Angular and other analyzers build on this.",
   "author": "Strata"

--- a/scripts/lib/templates.mjs
+++ b/scripts/lib/templates.mjs
@@ -26,7 +26,7 @@ export function pluginManifest(name, kind) {
     name,
     kind,
     version: '0.1.0',
-    sdk: '0.1.0',
+    sdk: '0.2.0',
     main: './dist/index.js',
     description: 'TODO',
     author: 'Strata',


### PR DESCRIPTION
## What

A `strata.plugin.json` may declare its plugin's **stage**: the output types it
`consumes`, the one it `produces`, the `filter` of files it wants, and the
`exclusive` group it belongs to. The registry validates all four **from the
manifest alone, before the entry module is imported**, and refuses a module
whose exported object contradicts what the manifest declared — a language
plugin's `extensions` against its `filter.extensions` — the way a mismatched
`kind` is refused today.

The SDK also gains the two shapes the rest of the wave needs:

- `OutputType` / `OUTPUT_TYPES` — the closed set a stage may produce (`graph`,
  `metrics`, `findings`, `commits`, `aggregate`), with `StageOutputs` giving the
  shape behind each and a new `Finding` for the list ones.
- `StageEntry` — a report's per-stage slot: `ok` / `failed` / `skipped`,
  carrying the output only when `ok`, and typed so `entry.type === 'graph'`
  narrows `entry.output`.

Version goes to `0.2.0`, deliberately not `1.0.0`.

Nothing runs differently: the declarations are read, validated and reported on
`GET /plugins`, the three plugin kinds still drive an analysis, and every
existing plugin loads untouched. This is the expand half of the migration.

## Why

Closes #117 — the first step of #113 (open analysis pipeline). Design decided in
`docs/adr/0010` (declarations are static JSON so a run is planned without running
third-party code), `docs/adr/0011` (one SDK wave, `0.2.0`) and `docs/adr/0015`
(the stage entry is an envelope, so an absent output can never read as an empty
one).

## Type of change

- [x] feat / fix / perf / refactor
- [x] docs / test / build / ci / chore

## Checklist

- [x] `pnpm build && pnpm test && pnpm lint` pass locally (`make check`: 845 tests)
- [x] Added/updated tests where it made sense — registry suite covers each
      declaration rule, that validation precedes the import, and the
      manifest/module disagreement; a new `GET /plugins` suite pins that the
      declarations reach the wire
- [x] Docs updated — `docs/PLUGINS.md` (declaring a stage, what the loader
      enforces, versioning), `docs/ARCHITECTURE.md`, and the SDK/core module docs